### PR TITLE
add egg_info section to setup.py for editable installs

### DIFF
--- a/python/cucim/setup.cfg
+++ b/python/cucim/setup.cfg
@@ -9,6 +9,9 @@ parentdir_prefix = cucim-
 [bdist_wheel]
 universal = 0
 
+[egg_info]
+egg_base = src
+
 [flake8]
 max-line-length = 80
 ignore =


### PR DESCRIPTION
See #24

This PR adds an `egg_info` section to our `setup.cfg` so that editable installs via `pip install -e . ` work. 
