### PR TITLE
Add skimage.morphology.thin

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -31,9 +31,6 @@ gpuci_conda_retry install -y -c rapidsai-nightly \
     rapids-doc-env \
     cucim
 
-conda activate cucim
-
-
 gpuci_logger "Check versions"
 python --version
 $CC --version

--- a/cpp/include/cucim/core/framework.h
+++ b/cpp/include/cucim/core/framework.h
@@ -18,6 +18,9 @@
 #define CUCIM_FRAMEWORK_H
 
 #include "cucim/core/plugin.h"
+
+#include <cstdlib>
+
 #include "cucim/memory/memory_manager.h"
 
 #define CUCIM_FRAMEWORK_GLOBALS(client_name)                                                                           \
@@ -27,8 +30,13 @@
 
 namespace cucim
 {
-
-const struct Version kFrameworkVersion = { CUCIM_VERSION_MAJOR, CUCIM_VERSION_MINOR, CUCIM_VERSION_PATCH };
+#define TEMP_STR(x) #x
+#define TEMP_XSTR(x) TEMP_STR(x)
+const struct Version kFrameworkVersion = { static_cast<uint32_t>(std::atoi(TEMP_XSTR(CUCIM_VERSION_MAJOR))),
+                                           static_cast<uint32_t>(std::atoi(TEMP_XSTR(CUCIM_VERSION_MINOR))),
+                                           static_cast<uint32_t>(std::atoi(TEMP_XSTR(CUCIM_VERSION_PATCH))) };
+#undef TEMP_STR
+#undef TEMP_XSTR
 
 struct PluginRegistrationDesc
 {

--- a/cpp/src/cuimage.cpp
+++ b/cpp/src/cuimage.cpp
@@ -868,11 +868,12 @@ void CuImage::ensure_init()
         auto plugin_root = framework_->get_plugin_root();
         // TODO: Here 'LINUX' path separator is used. Need to make it generalize once filesystem library is
         // available.
-        std::string plugin_file_path = (plugin_root && *plugin_root != 0) ?
-                                           fmt::format("{}/cucim.kit.cuslide@{}.{}.{}.so", plugin_root,
-                                                       CUCIM_VERSION_MAJOR, CUCIM_VERSION_MINOR, CUCIM_VERSION_PATCH) :
-                                           fmt::format("cucim.kit.cuslide@{}.{}.{}.so", CUCIM_VERSION_MAJOR,
-                                                       CUCIM_VERSION_MINOR, CUCIM_VERSION_PATCH);
+        std::string plugin_file_path =
+            (plugin_root && *plugin_root != 0) ?
+                fmt::format("{}/cucim.kit.cuslide@{}.{}.{}.so", plugin_root, XSTR(CUCIM_VERSION_MAJOR),
+                            XSTR(CUCIM_VERSION_MINOR), XSTR(CUCIM_VERSION_PATCH)) :
+                fmt::format("cucim.kit.cuslide@{}.{}.{}.so", XSTR(CUCIM_VERSION_MAJOR), XSTR(CUCIM_VERSION_MINOR),
+                            XSTR(CUCIM_VERSION_PATCH));
         if (!cucim::util::file_exists(plugin_file_path.c_str()))
         {
             plugin_file_path = fmt::format("cucim.kit.cuslide@" XSTR(CUCIM_VERSION) ".so");

--- a/python/cucim/src/cucim/skimage/morphology/__init__.py
+++ b/python/cucim/src/cucim/skimage/morphology/__init__.py
@@ -1,3 +1,4 @@
+from ._skeletonize import thin
 from .binary import (binary_closing, binary_dilation, binary_erosion,
                      binary_opening)
 from .grey import (black_tophat, closing, dilation, erosion, opening,
@@ -30,4 +31,5 @@ __all__ = [
     "reconstruction",
     "remove_small_objects",
     "remove_small_holes",
+    "thin",
 ]

--- a/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
@@ -2,7 +2,7 @@ import cupy as cp
 import cupyx.scipy.ndimage as ndi
 import numpy as np
 
-from .._shared.utils import check_nD, warn
+from .._shared.utils import check_nD
 
 # --------- Skeletonization and thinning based on Guo and Hall 1989 ---------
 
@@ -112,8 +112,8 @@ def thin(image, max_iter=None):
     skel = cp.asarray(image, dtype=bool).astype(cp.uint8)
 
     # neighborhood mask
-    mask = cp.asarray([[ 8,  4,   2],
-                       [16,  0,   1],
+    mask = cp.asarray([[ 8,  4,   2],  # noqa
+                       [16,  0,   1],  # noqa
                        [32, 64, 128]], dtype=cp.uint8)
 
     G123_LUT = cp.asarray(_G123_LUT)

--- a/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
@@ -1,0 +1,187 @@
+import cupy as cp
+import cupyx.scipy.ndimage as ndi
+import numpy as np
+
+from .._shared.utils import check_nD, warn
+
+# --------- Skeletonization and thinning based on Guo and Hall 1989 ---------
+
+def _generate_thin_luts():
+    """generate LUTs for thinning algorithm (for reference)"""
+
+    def nabe(n):
+        return np.array([n >> i & 1 for i in range(0, 9)]).astype(bool)
+
+    def G1(n):
+        s = 0
+        bits = nabe(n)
+        for i in (0, 2, 4, 6):
+            if not(bits[i]) and (bits[i + 1] or bits[(i + 2) % 8]):
+                s += 1
+        return s == 1
+
+    g1_lut = np.array([G1(n) for n in range(256)])
+
+    def G2(n):
+        n1, n2 = 0, 0
+        bits = nabe(n)
+        for k in (1, 3, 5, 7):
+            if bits[k] or bits[k - 1]:
+                n1 += 1
+            if bits[k] or bits[(k + 1) % 8]:
+                n2 += 1
+        return min(n1, n2) in [2, 3]
+
+    g2_lut = np.array([G2(n) for n in range(256)])
+
+    g12_lut = g1_lut & g2_lut
+
+    def G3(n):
+        bits = nabe(n)
+        return not((bits[1] or bits[2] or not(bits[7])) and bits[0])
+
+    def G3p(n):
+        bits = nabe(n)
+        return not((bits[5] or bits[6] or not(bits[3])) and bits[4])
+
+    g3_lut = np.array([G3(n) for n in range(256)])
+    g3p_lut = np.array([G3p(n) for n in range(256)])
+
+    g123_lut = g12_lut & g3_lut
+    g123p_lut = g12_lut & g3p_lut
+
+    return g123_lut, g123p_lut
+
+
+_G123_LUT = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+                      0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1,
+                      0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                      0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                      1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0,
+                      0, 1, 1, 0, 0, 1, 0, 0, 0], dtype=bool)
+
+
+_G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0,
+                       0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                       1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1,
+                       0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
+
+
+def thin(image, max_iter=None):
+    """
+    Perform morphological thinning of a binary image.
+
+    Parameters
+    ----------
+    image : binary (M, N) ndarray
+        The image to be thinned.
+    max_iter : int, number of iterations, optional
+        Regardless of the value of this parameter, the thinned image
+        is returned immediately if an iteration produces no change.
+        If this parameter is specified it thus sets an upper bound on
+        the number of iterations performed.
+
+    Returns
+    -------
+    out : ndarray of bool
+        Thinned image.
+
+    See Also
+    --------
+    skeletonize, medial_axis
+
+    Notes
+    -----
+    This algorithm [1]_ works by making multiple passes over the image,
+    removing pixels matching a set of criteria designed to thin
+    connected regions while preserving eight-connected components and
+    2 x 2 squares [2]_. In each of the two sub-iterations the algorithm
+    correlates the intermediate skeleton image with a neighborhood mask,
+    then looks up each neighborhood in a lookup table indicating whether
+    the central pixel should be deleted in that sub-iteration.
+
+    References
+    ----------
+    .. [1] Z. Guo and R. W. Hall, "Parallel thinning with
+           two-subiteration algorithms," Comm. ACM, vol. 32, no. 3,
+           pp. 359-373, 1989. :DOI:`10.1145/62065.62074`
+    .. [2] Lam, L., Seong-Whan Lee, and Ching Y. Suen, "Thinning
+           Methodologies-A Comprehensive Survey," IEEE Transactions on
+           Pattern Analysis and Machine Intelligence, Vol 14, No. 9,
+           p. 879, 1992. :DOI:`10.1109/34.161346`
+
+    Examples
+    --------
+    >>> square = np.zeros((7, 7), dtype=np.uint8)
+    >>> square[1:-1, 2:-2] = 1
+    >>> square[0, 1] =  1
+    >>> square
+    array([[0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    >>> skel = thin(square)
+    >>> skel.astype(np.uint8)
+    array([[0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    """
+    # check that image is 2d
+    check_nD(image, 2)
+
+    # convert image to uint8 with values in {0, 1}
+    skel = cp.asarray(image, dtype=bool).astype(np.uint8)
+
+    # neighborhood mask
+    mask = cp.asarray([[ 8,  4,   2],
+                       [16,  0,   1],
+                       [32, 64, 128]], dtype=np.uint8)
+
+    G123_LUT = cp.asarray(_G123_LUT)
+    G123P_LUT = cp.asarray(_G123P_LUT)
+
+    # iterate until convergence, up to the iteration limit
+    max_iter = max_iter or np.inf
+    n_iter = 0
+    n_pts_old, n_pts_new = np.inf, cp.sum(skel)
+    while n_pts_old != n_pts_new and n_iter < max_iter:
+        n_pts_old = n_pts_new
+
+        # perform the two "subiterations" described in the paper
+        for lut in [G123_LUT, G123P_LUT]:
+            # correlate image with neighborhood mask
+            N = ndi.correlate(skel, mask, mode='constant')
+            # take deletion decision from this subiteration's LUT
+            D = cp.take(lut, N)
+            # perform deletion
+            skel[D] = 0
+
+        n_pts_new = cp.sum(skel)  # count points after thinning
+        n_iter += 1
+
+    return skel.astype(bool)

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -6,8 +6,7 @@ from skimage import data
 from skimage.morphology import thin as thin_cpu
 
 from cucim.skimage.morphology import thin
-from cucim.skimage.morphology._skeletonize import (_G123_LUT, _G123P_LUT,
-                                                   _generate_thin_luts)
+from cucim.skimage.morphology._skeletonize import _G123_LUT, _G123P_LUT
 
 
 class TestThin():
@@ -52,12 +51,6 @@ class TestThin():
         for ii in [cp.zeros((3)), cp.zeros((3, 3, 3))]:
             with pytest.raises(ValueError):
                 thin(ii)
-
-    def test_lut_generation(self):
-        g123, g123p = _generate_thin_luts()
-
-        assert_array_equal(cp.asarray(g123), _G123_LUT)
-        assert_array_equal(cp.asarray(g123p), _G123P_LUT)
 
     @pytest.mark.parametrize('invert', [False, True])
     def test_compare_skimage(self, invert):

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -2,6 +2,8 @@ import cupy as cp
 import numpy as np
 import pytest
 from cupy.testing import assert_array_equal
+from skimage import data
+from skimage.morphology import thin as thin_cpu
 
 from cucim.skimage.morphology import thin
 from cucim.skimage.morphology._skeletonize import (_G123_LUT, _G123P_LUT,
@@ -56,3 +58,12 @@ class TestThin():
 
         assert_array_equal(cp.asarray(g123), _G123_LUT)
         assert_array_equal(cp.asarray(g123p), _G123P_LUT)
+
+    @pytest.mark.parametrize('invert', [False, True])
+    def test_compare_skimage(self, invert):
+        h = data.horse()
+        if invert:
+            h = ~h
+        result = thin(cp.asarray(h))
+        expected = thin_cpu(h)
+        assert_array_equal(result, expected)

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -1,0 +1,58 @@
+import cupy as cp
+import numpy as np
+import pytest
+from cupy.testing import assert_array_equal
+
+from cucim.skimage.morphology import thin
+from cucim.skimage.morphology._skeletonize import (_G123_LUT, _G123P_LUT,
+                                                   _generate_thin_luts)
+
+
+class TestThin():
+    @property
+    def input_image(self):
+        """image to test thinning with"""
+        ii = cp.array([[0, 0, 0, 0, 0, 0, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 0, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 0, 0, 0, 0, 0, 0]], dtype=cp.uint8)
+        return ii
+
+    def test_zeros(self):
+        assert cp.all(thin(cp.zeros((10, 10))) == False)
+
+    def test_iter_1(self):
+        result = thin(self.input_image, 1).astype(cp.uint8)
+        expected = cp.array([[0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 1, 1, 0, 0],
+                             [0, 0, 1, 1, 1, 0, 0],
+                             [0, 0, 1, 1, 1, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0]], dtype=cp.uint8)
+        assert_array_equal(result, expected)
+
+    def test_noiter(self):
+        result = thin(self.input_image).astype(cp.uint8)
+        expected = cp.array([[0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 1, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0]], dtype=cp.uint8)
+        assert_array_equal(result, expected)
+
+    def test_baddim(self):
+        for ii in [cp.zeros((3)), cp.zeros((3, 3, 3))]:
+            with pytest.raises(ValueError):
+                thin(ii)
+
+    def test_lut_generation(self):
+        g123, g123p = _generate_thin_luts()
+
+        assert_array_equal(cp.asarray(g123), _G123_LUT)
+        assert_array_equal(cp.asarray(g123p), _G123P_LUT)

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -1,12 +1,10 @@
 import cupy as cp
-import numpy as np
 import pytest
 from cupy.testing import assert_array_equal
 from skimage import data
 from skimage.morphology import thin as thin_cpu
 
 from cucim.skimage.morphology import thin
-from cucim.skimage.morphology._skeletonize import _G123_LUT, _G123P_LUT
 
 
 class TestThin():
@@ -23,7 +21,7 @@ class TestThin():
         return ii
 
     def test_zeros(self):
-        assert cp.all(thin(cp.zeros((10, 10))) == False)
+        assert cp.all(thin(cp.zeros((10, 10))) == 0)
 
     def test_iter_1(self):
         result = thin(self.input_image, 1).astype(cp.uint8)


### PR DESCRIPTION
This PR adds one additional function for thinning binary images [as shown here](https://scikit-image.org/docs/stable/auto_examples/edges/plot_skeleton.html#sphx-glr-auto-examples-edges-plot-skeleton-py). This particular algorithm is 2D only. There is a second skeletonization algorithm in scikit-image with 3D support, but that one is currently Cython based and take more work to adapt.
