### PR TITLE
fix isort on CI

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -18,7 +18,7 @@ conda activate rapids
 cd python/cucim
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only python`
+ISORT=`isort --recursive --check-only src`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -18,7 +18,7 @@ conda activate rapids
 cd python/cucim
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only src`
+ISORT=`isort --check-only src`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code

--- a/python/cucim/setup.cfg
+++ b/python/cucim/setup.cfg
@@ -52,7 +52,7 @@ testpaths =
     tests
 
 [tool:isort]
-force_single_line = True
+force_single_line = False
 line_length = 80
 known_first_party = cucim
 default_section = THIRDPARTY

--- a/python/cucim/setup.cfg
+++ b/python/cucim/setup.cfg
@@ -59,4 +59,4 @@ default_section = THIRDPARTY
 forced_separate = test_cucim
 skip = .tox,.eggs,ci/templates,build,dist,versioneer.py
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-multi_line_output = 0
+multi_line_output = GRID

--- a/python/cucim/src/cucim/__init__.py
+++ b/python/cucim/src/cucim/__init__.py
@@ -31,6 +31,4 @@ skimage
 
 """
 
-from .clara import CuImage
-from .clara import __version__
-from .clara import cli
+from .clara import CuImage, __version__, cli

--- a/python/cucim/src/cucim/clara/__init__.py
+++ b/python/cucim/src/cucim/clara/__init__.py
@@ -15,13 +15,9 @@
 
 import os
 
-from . import cli
-from . import converter
+from . import cli, converter
 # import hidden methods
-from ._cucim import CuImage
-from ._cucim import __version__
-from ._cucim import filesystem
-from ._cucim import io
+from ._cucim import CuImage, __version__, filesystem, io
 
 __all__ = ['cli', 'CuImage', 'filesystem', 'io', 'converter', '__version__']
 

--- a/python/cucim/src/cucim/skimage/_vendored/_internal.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_internal.py
@@ -1,20 +1,15 @@
 import cupy
 import numpy
 
-
 try:
     # try importing Cython-based private axis handling functions from CuPy
     if hasattr(cupy, '_core'):
         # CuPy 10 renames core->_core
-        from cupy._core.internal import (
-            _normalize_axis_index,
-            _normalize_axis_indices,
-        )  # NOQA
+        from cupy._core.internal import (_normalize_axis_index,  # NOQA
+                                         _normalize_axis_indices)
     else:
-        from cupy.core.internal import (
-            _normalize_axis_index,
-            _normalize_axis_indices,
-        )  # NOQA
+        from cupy.core.internal import (_normalize_axis_index,  # NOQA
+                                        _normalize_axis_indices)
 
 except ImportError:
     # Fallback to local Python implementations

--- a/python/cucim/src/cucim/skimage/_vendored/_internal.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_internal.py
@@ -5,11 +5,11 @@ try:
     # try importing Cython-based private axis handling functions from CuPy
     if hasattr(cupy, '_core'):
         # CuPy 10 renames core->_core
-        from cupy._core.internal import (_normalize_axis_index,  # NOQA
-                                         _normalize_axis_indices)
+        from cupy._core.internal import _normalize_axis_index  # NOQA
+        from cupy._core.internal import _normalize_axis_indices  # NOQA
     else:
-        from cupy.core.internal import (_normalize_axis_index,  # NOQA
-                                        _normalize_axis_indices)
+        from cupy.core.internal import _normalize_axis_index  # NOQA
+        from cupy.core.internal import _normalize_axis_indices  # NOQA
 
 except ImportError:
     # Fallback to local Python implementations

--- a/python/cucim/src/cucim/skimage/color/tests/test_colorconv.py
+++ b/python/cucim/src/cucim/skimage/color/tests/test_colorconv.py
@@ -22,12 +22,12 @@ from cucim.skimage._shared.testing import TestCase, fetch
 from cucim.skimage.color import (combine_stains, convert_colorspace, gray2rgb,
                                  gray2rgba, hed2rgb, hsv2rgb, lab2lch, lab2rgb,
                                  lab2xyz, lch2lab, luv2rgb, luv2xyz, rgb2gray,
-                                 rgb2hed, rgb2hsv, rgb2lab, rgb2luv,
-                                 rgb2rgbcie, rgb2xyz, rgb2ycbcr, rgb2ydbdr,
-                                 rgb2yiq, rgb2ypbpr, rgb2yuv, rgba2rgb,
-                                 rgbcie2rgb, separate_stains, xyz2lab, xyz2luv,
-                                 xyz2rgb, ycbcr2rgb, ydbdr2rgb, yiq2rgb,
-                                 ypbpr2rgb, yuv2rgb)
+                                 rgb2hed, rgb2hsv, rgb2lab, rgb2luv, rgb2rgbcie,
+                                 rgb2xyz, rgb2ycbcr, rgb2ydbdr, rgb2yiq,
+                                 rgb2ypbpr, rgb2yuv, rgba2rgb, rgbcie2rgb,
+                                 separate_stains, xyz2lab, xyz2luv, xyz2rgb,
+                                 ycbcr2rgb, ydbdr2rgb, yiq2rgb, ypbpr2rgb,
+                                 yuv2rgb)
 from cucim.skimage.util import img_as_float, img_as_float32, img_as_ubyte
 
 

--- a/python/cucim/src/cucim/skimage/color/tests/test_delta_e.py
+++ b/python/cucim/src/cucim/skimage/color/tests/test_delta_e.py
@@ -6,7 +6,7 @@ import pytest
 from cupy.testing import (assert_allclose, assert_array_almost_equal,
                           assert_array_equal)
 
-from cucim.skimage._shared.testing import fetch, expected_warnings
+from cucim.skimage._shared.testing import expected_warnings, fetch
 from cucim.skimage.color.delta_e import (deltaE_cie76, deltaE_ciede94,
                                          deltaE_ciede2000, deltaE_cmc)
 

--- a/python/cucim/src/cucim/skimage/filters/__init__.py
+++ b/python/cucim/src/cucim/skimage/filters/__init__.py
@@ -16,9 +16,8 @@ from .ridges import frangi, hessian, meijering, sato
 from .thresholding import (apply_hysteresis_threshold, threshold_isodata,
                            threshold_li, threshold_local, threshold_mean,
                            threshold_minimum, threshold_multiotsu,
-                           threshold_niblack, threshold_otsu,
-                           threshold_sauvola, threshold_triangle,
-                           threshold_yen, try_all_threshold)
+                           threshold_niblack, threshold_otsu, threshold_sauvola,
+                           threshold_triangle, threshold_yen, try_all_threshold)
 
 __all__ = [
     "inverse",

--- a/python/cucim/src/cucim/skimage/filters/tests/test_edges.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_edges.py
@@ -4,7 +4,6 @@ import pytest
 from cupy.testing import assert_allclose, assert_array_almost_equal
 from numpy.testing import assert_
 
-
 from cucim.skimage import filters
 from cucim.skimage.data import binary_blobs
 from cucim.skimage.filters.edges import _mask_filter_result

--- a/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
@@ -14,9 +14,8 @@ from cucim.skimage._shared._warnings import expected_warnings
 from cucim.skimage.color import rgb2gray
 from cucim.skimage.exposure import histogram
 from cucim.skimage.filters.thresholding import _cross_entropy  # _mean_std,
-from cucim.skimage.filters.thresholding import (threshold_isodata,
-                                                threshold_li, threshold_local,
-                                                threshold_mean,
+from cucim.skimage.filters.thresholding import (threshold_isodata, threshold_li,
+                                                threshold_local, threshold_mean,
                                                 threshold_minimum,
                                                 threshold_multiotsu,
                                                 threshold_niblack,

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_reconstruction.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_reconstruction.py
@@ -12,9 +12,9 @@ import cupy as cp
 import numpy as np
 import pytest
 from cupy.testing import assert_array_almost_equal
+from skimage.morphology import reconstruction as reconstruction_cpu
 
 from cucim.skimage.morphology import reconstruction
-from skimage.morphology import reconstruction as reconstruction_cpu
 
 
 def test_zeros():

--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -5,8 +5,8 @@ from cupyx.scipy.ndimage import fourier_shift
 from skimage.data import camera
 
 from cucim.skimage import img_as_float
-from cucim.skimage.data import binary_blobs
 from cucim.skimage._shared.fft import fftmodule as fft
+from cucim.skimage.data import binary_blobs
 from cucim.skimage.registration._phase_cross_correlation import (
     _upsampled_dft, phase_cross_correlation)
 

--- a/python/cucim/src/cucim/skimage/transform/__init__.py
+++ b/python/cucim/src/cucim/skimage/transform/__init__.py
@@ -3,8 +3,8 @@ from ._geometric import (AffineTransform, EssentialMatrixTransform,
                          PiecewiseAffineTransform, PolynomialTransform,
                          ProjectiveTransform, SimilarityTransform,
                          estimate_transform, matrix_transform)
-from ._warps import (downscale_local_mean, rescale, resize, rotate, swirl,
-                     warp, warp_coords, warp_polar)
+from ._warps import (downscale_local_mean, rescale, resize, rotate, swirl, warp,
+                     warp_coords, warp_polar)
 from .integral import integral_image, integrate
 from .pyramids import (pyramid_expand, pyramid_gaussian, pyramid_laplacian,
                        pyramid_reduce)

--- a/python/cucim/src/cucim/time.py
+++ b/python/cucim/src/cucim/time.py
@@ -1,4 +1,3 @@
 from .skimage._vendored.time import repeat
 
-
 __all__ = ['repeat']


### PR DESCRIPTION
I looks like `isort` checks have not been running on CI due to an incorrect path in a CI script. The following shows up in CI logs:
```
/opt/conda/envs/rapids/lib/python3.7/site-packages/isort/main.py:104: UserWarning: Unable to parse file python due to [Errno 2] No such file or directory: '/workspace/python/cucim/python'

  warn(f"Unable to parse file {file_name} due to {error}")
```

The first commit here fixes that. I then changed `force_single_line` to False to minimize the amount of changes when rerunning `isort` on the existing code base (see #24). Let me know if we need to switch to `force_single_line = True` instead.

