### PR TITLE
MAINT: avoid use of deprecated cp.float, cp.int, cp.bool

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/tests/test_ccomp.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_ccomp.py
@@ -55,7 +55,7 @@ class TestConnectedComponents:
         assert_array_equal(label(self.x, background=9), self.labels_bg_9)
 
     def test_random(self):
-        x = (cp.random.rand(20, 30) * 5).astype(cp.int)
+        x = (cp.random.rand(20, 30) * 5).astype(int)
         labels = label(x)
 
         n = int(labels.max())
@@ -180,7 +180,7 @@ class TestConnectedComponents3d:
         assert self.x[0, 0, 2] == 2, "Data was modified!"
 
     def test_random(self):
-        x = (cp.random.rand(20, 30) * 5).astype(cp.int)
+        x = (cp.random.rand(20, 30) * 5).astype(int)
         labels = label(x)
 
         n = int(labels.max())

--- a/python/cucim/src/cucim/skimage/measure/tests/test_profile.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_profile.py
@@ -4,7 +4,7 @@ from cupy.testing import assert_array_almost_equal, assert_array_equal
 
 from cucim.skimage.measure import profile_line
 
-image = cp.arange(100).reshape((10, 10)).astype(cp.float)
+image = cp.arange(100).reshape((10, 10)).astype(float)
 
 
 def test_horizontal_rightward():

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -65,10 +65,10 @@ def test_all_props_3d():
 
 
 def test_dtype():
-    regionprops(cp.zeros((10, 10), dtype=cp.int))
+    regionprops(cp.zeros((10, 10), dtype=int))
     regionprops(cp.zeros((10, 10), dtype=cp.uint))
     with pytest.raises(TypeError):
-        regionprops(cp.zeros((10, 10), dtype=cp.float))
+        regionprops(cp.zeros((10, 10), dtype=float))
     with pytest.raises(TypeError):
         regionprops(cp.zeros((10, 10), dtype=cp.double))
     with pytest.raises(TypeError):
@@ -76,13 +76,13 @@ def test_dtype():
 
 
 def test_ndim():
-    regionprops(cp.zeros((10, 10), dtype=cp.int))
-    regionprops(cp.zeros((10, 10, 1), dtype=cp.int))
-    regionprops(cp.zeros((10, 10, 10), dtype=cp.int))
-    regionprops(cp.zeros((1, 1), dtype=cp.int))
-    regionprops(cp.zeros((1, 1, 1), dtype=cp.int))
+    regionprops(cp.zeros((10, 10), dtype=int))
+    regionprops(cp.zeros((10, 10, 1), dtype=int))
+    regionprops(cp.zeros((10, 10, 10), dtype=int))
+    regionprops(cp.zeros((1, 1), dtype=int))
+    regionprops(cp.zeros((1, 1, 1), dtype=int))
     with pytest.raises(TypeError):
-        regionprops(cp.zeros((10, 10, 10, 2), dtype=cp.int))
+        regionprops(cp.zeros((10, 10, 10, 2), dtype=int))
 
 
 @pytest.mark.skip('feret_diameter_max not implmented on the GPU')
@@ -210,7 +210,7 @@ def test_eccentricity():
     eps = regionprops(SAMPLE)[0].eccentricity
     assert_almost_equal(eps, 0.814629313427)
 
-    img = cp.zeros((5, 5), dtype=cp.int)
+    img = cp.zeros((5, 5), dtype=int)
     img[2, 2] = 1
     eps = regionprops(img)[0].eccentricity
     assert_almost_equal(eps, 0)
@@ -473,7 +473,7 @@ def test_weighted_moments_normalized():
 
 
 def test_label_sequence():
-    a = cp.empty((2, 2), dtype=cp.int)
+    a = cp.empty((2, 2), dtype=int)
     a[:, :] = 2
     ps = regionprops(a)
     assert len(ps) == 1
@@ -481,7 +481,7 @@ def test_label_sequence():
 
 
 def test_pure_background():
-    a = cp.zeros((2, 2), dtype=cp.int)
+    a = cp.zeros((2, 2), dtype=int)
     ps = regionprops(a)
     assert len(ps) == 0
 
@@ -503,7 +503,7 @@ def test_invalid_size():
 
 
 def test_equals():
-    arr = cp.zeros((100, 100), dtype=cp.int)
+    arr = cp.zeros((100, 100), dtype=int)
     arr[0:25, 0:25] = 1
     arr[50:99, 50:99] = 2
 

--- a/python/cucim/src/cucim/skimage/morphology/binary.py
+++ b/python/cucim/src/cucim/skimage/morphology/binary.py
@@ -39,7 +39,7 @@ def binary_erosion(image, selem=None, out=None):
 
     """
     if out is None:
-        out = cp.empty(image.shape, dtype=cp.bool)
+        out = cp.empty(image.shape, dtype=bool)
     ndi.binary_erosion(image, structure=selem, output=out, border_value=True)
     return out
 
@@ -74,7 +74,7 @@ def binary_dilation(image, selem=None, out=None):
         ``[False, True]``.
     """
     if out is None:
-        out = cp.empty(image.shape, dtype=cp.bool)
+        out = cp.empty(image.shape, dtype=bool)
     ndi.binary_dilation(image, structure=selem, output=out)
     return out
 

--- a/python/cucim/src/cucim/skimage/restoration/_denoise.py
+++ b/python/cucim/src/cucim/skimage/restoration/_denoise.py
@@ -153,7 +153,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.0e-4, n_iter_max=200,
 
     >>> x, y, z = np.ogrid[0:20, 0:20, 0:20]
     >>> mask = (x - 22)**2 + (y - 20)**2 + (z - 17)**2 < 8**2
-    >>> mask = mask.astype(np.float)
+    >>> mask = mask.astype(float)
     >>> mask += 0.2*np.random.randn(*mask.shape)
     >>> res = denoise_tv_chambolle(mask, weight=100)
 

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
@@ -102,7 +102,7 @@ def test_image_shape():
 
     This addresses issue #1172.
     """
-    point = cp.zeros((5, 5), np.float)
+    point = cp.zeros((5, 5), float)
     point[2, 2] = 1.0
     psf = ndi.gaussian_filter(point, sigma=1.0)
     # image shape: (45, 45), as reported in #1172

--- a/python/cucim/src/cucim/skimage/segmentation/boundaries.py
+++ b/python/cucim/src/cucim/skimage/segmentation/boundaries.py
@@ -147,7 +147,7 @@ def find_boundaries(label_img, connectivity=1, mode="thick", background=0):
     ...                        [False, False,  True,  True,  True],
     ...                        [False, False,  True,  True,  True],
     ...                        [False, False,  True,  True,  True]],
-    ...                       dtype=cp.bool)
+    ...                       dtype=bool)
     >>> find_boundaries(bool_image)
     array([[False, False, False, False, False],
            [False, False,  True,  True,  True],

--- a/python/cucim/src/cucim/skimage/segmentation/tests/test_join.py
+++ b/python/cucim/src/cucim/skimage/segmentation/tests/test_join.py
@@ -140,7 +140,7 @@ def test_relabel_sequential_int_dtype_overflow():
     _check_maps(ar, ar_relab, fw, inv)
     assert all(a.dtype == cp.uint16 for a in (ar_relab, fw))
     assert inv.dtype == ar.dtype
-    ar_relab_ref = cp.where(ar > 0, ar.astype(cp.int) + offset - 1, 0)
+    ar_relab_ref = cp.where(ar > 0, ar.astype(int) + offset - 1, 0)
     assert_array_equal(ar_relab, ar_relab_ref)
 
 

--- a/python/cucim/src/cucim/skimage/transform/integral.py
+++ b/python/cucim/src/cucim/skimage/transform/integral.py
@@ -58,7 +58,7 @@ def integrate(ii, start, end):
 
     Examples
     --------
-    >>> arr = np.ones((5, 6), dtype=np.float)
+    >>> arr = np.ones((5, 6), dtype=float)
     >>> ii = integral_image(arr)
     >>> integrate(ii, (1, 0), (1, 2))  # sum from (1, 0) to (1, 2)
     array([3.])


### PR DESCRIPTION
This PR silences a number of warnings when running the tests with the current CuPy development branch. As in NumPy, these types are deprecated and `float`, `int` or `bool` should be used instead.
