### PR TITLE
Document editable install of the Python source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,3 +143,9 @@ cp -P python/install/lib/* python/cucim/src/cucim/clara/
 cd python/cucim/
 python -m pip install .
 ```
+
+For contributors interested in working on the Python code from an in-place
+(editable) installation, replace the last line above with
+```bash
+python -m pip install --editable .
+```


### PR DESCRIPTION
closes #24

This is basically just the standard procedure now that the `setup.cfg` change in #26 was merged, but possibly still worth documenting?
