### PR TITLE
Update docs build script [skip ci]

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -14,7 +14,6 @@ export DOCS_WORKSPACE=$WORKSPACE/docs
 export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
 export HOME=$WORKSPACE
 export PROJECT_WORKSPACE=/rapids/cucim
-export NIGHTLY_VERSION=$(echo $BRANCH_VERSION | awk -F. '{print $2}')
 export PROJECTS=(cucim)
 
 gpuci_logger "Check environment"


### PR DESCRIPTION
This PR removes a variable that is no longer necessary for docs builds after the calver transition.
