### PR TITLE
Update environment variable used to determine `cuda_version`

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -4,7 +4,7 @@
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[2] %}
 {% set py_version=environ.get('CONDA_PY', 37) %}
 {% set python_version=environ.get('PYTHON_VER', '3.7') %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '11.0').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '11.0').split('.')[:2]) %}
 
 package:
   name: cucim

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -3,7 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set python_version=environ.get('PYTHON_VER', '3.7') %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '11.0').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '11.0').split('.')[:2]) %}
 
 package:
   name: libcucim


### PR DESCRIPTION
This PR updates the environment variable thats used to determine the `cuda_version` varaible in our conda recipes.

The `CUDA` environment variable is explicitly set by the Ops team in our Jenkins jobs, whereas `CUDA_VERSION` comes from the `nvidia/cuda` Docker images that we base our images from.
