### PR TITLE
Remove invalid conda environment activation

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -31,9 +31,6 @@ gpuci_conda_retry install -y -c rapidsai-nightly \
     rapids-doc-env \
     cucim
 
-conda activate cucim
-
-
 gpuci_logger "Check versions"
 python --version
 $CC --version


### PR DESCRIPTION
This line has been breaking doc builds ([link](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/doc-builds/job/docs-build/3044/console)) since there is no `cucim` conda environment when the job runs.