### PR TITLE
Fix missing array interface for associated_image()

### DIFF
--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -148,7 +148,7 @@ PYBIND11_MODULE(_cucim, m)
              py::arg("shm_name") = "") //
         .def_property("associated_images", &CuImage::associated_images, nullptr, doc::CuImage::doc_associated_images,
                       py::call_guard<py::gil_scoped_release>()) //
-        .def("associated_image", &CuImage::associated_image, doc::CuImage::doc_associated_image,
+        .def("associated_image", &py_associated_image, doc::CuImage::doc_associated_image,
              py::call_guard<py::gil_scoped_release>(), //
              py::arg("name") = "", //
              py::arg("device") = io::Device()) //
@@ -392,6 +392,22 @@ py::object py_read_region(const CuImage& cuimg,
         _set_array_interface(region);
 
         return region;
+    }
+}
+
+py::object py_associated_image(const CuImage& cuimg, const std::string& name, const io::Device& device)
+{
+    auto image_ptr = std::make_shared<cucim::CuImage>(cuimg.associated_image(name, device));
+
+    {
+        py::gil_scoped_acquire scope_guard;
+
+        py::object image = py::cast(image_ptr);
+
+        // Add `__array_interace__` or `__cuda_array_interface__` in runtime.
+        _set_array_interface(image);
+
+        return image;
     }
 }
 

--- a/python/pybind11/cucim_py.h
+++ b/python/pybind11/cucim_py.h
@@ -68,6 +68,8 @@ py::object py_read_region(const CuImage& cuimg,
                           const py::object& buf,
                           const std::string& shm_name,
                           const py::kwargs& kwargs);
+py::object py_associated_image(const CuImage& cuimg, const std::string& name, const io::Device& device);
+
 void _set_array_interface(const py::object& cuimg_obj);
 } // namespace cucim
 


### PR DESCRIPTION
`__array_interface__` for the object returned by `CuImage.associated_image()` was missing so cannot be converted numpy.

This bug was introduced during the implementation of Cache and support for `__cuda_array_interface__`: https://github.com/rapidsai/cucim/pull/48 .

`associated_image()` API is not frequently used by users so it's fine.

We will need to add a test case for this once the artificial test image with the associated image (such as Philips TIFF) is available.


<!--

Thank you for contributing to ___PROJECT___ :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
