### PR TITLE
Remove int-type bug on Windows in skimage.measure.label

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_label_kernels.py
+++ b/python/cucim/src/cucim/skimage/measure/_label_kernels.py
@@ -21,22 +21,10 @@ def _label(x, structure, y, greyscale_mode=False):
     y_shape = cupy.array(y.shape, dtype=numpy.int32)
     count = cupy.zeros(2, dtype=numpy.int32)
     _kernel_init()(x, y)
-    try:
-        int_t = int_types[y.dtype.char]
-    except KeyError:
-        raise ValueError("y must have int32, uint16, uint32 or uint64 dtype")
-    if int_t != "int":
-        raise NotImplementedError(
-            "Currently only 32-bit integer case is implemented"
-        )
     if greyscale_mode:
-        _kernel_connect(True, int_t)(
-            x, y_shape, dirs, ndirs, x.ndim, y, size=y.size
-        )
+        _kernel_connect(True)(x, y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     else:
-        _kernel_connect(False, int_t)(
-            y_shape, dirs, ndirs, x.ndim, y, size=y.size
-        )
+        _kernel_connect(False)(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     _kernel_count()(y, count, size=y.size)
     maxlabel = int(count[0])  # synchronize
     labels = cupy.empty(maxlabel, dtype=numpy.int32)
@@ -184,11 +172,3 @@ def _kernel_finalize():
         """,
         "cucim_nd_label_finalize",
     )
-
-
-int_types = {
-    "i": "int",
-    "H": "unsigned short",
-    "I": "unsigned int",
-    "L": "unsigned long long",
-}


### PR DESCRIPTION
A windows user reported an issue with `skimage.measure.label` in the older `cupyimg` repository: https://github.com/mritools/cupyimg/issues/21.

It seems the same issue is present here, but should be resolved by this PR. I don't think we can easily add a test case on our current linux-based CI as the issue has to do with the NumPy dtype character used to represent the `numpy.int32` dtype. We may want to wait on merging until the fix is confirmed in https://github.com/mritools/cupyimg/issues/21

I think I originally introduced this `int_types` dict with the intention of also supporting >32-bit integers, but it was incomplete and still used `int32` in the actual implementation. This PR just removes this dict altogether and we can revisit the function if we get a request for int64 support.

<!--

Thank you for contributing to ___PROJECT___ :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
