### PR TITLE
Pin gcc/g++ to 9.3

### DIFF
--- a/conda/recipes/cucim/conda_build_config.yaml
+++ b/conda/recipes/cucim/conda_build_config.yaml
@@ -1,4 +1,4 @@
 c_compiler_version:
-  - 9
+  - 9.3
 cxx_compiler_version:
-  - 9
+  - 9.3

--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -1,4 +1,4 @@
 c_compiler_version:
-  - 9
+  - 9.3
 cxx_compiler_version:
-  - 9
+  - 9.3


### PR DESCRIPTION
Just pin the compilers to 9.3 to match the rest of RAPIDS