### PR TITLE
Do not force install linux-64 version of openslide-python

### DIFF
--- a/run
+++ b/run
@@ -692,11 +692,8 @@ test() {
 
 install_python_test_deps_() {
     if [ -n "${CONDA_PREFIX}" ]; then
-        # Override openslide-python due to the following issue:
-        #   https://github.com/conda-forge/openslide-python-feedstock/issues/4
         run_command conda install -c conda-forge -y \
-            --file ${TOP}/python/cucim/requirements-test.txt \
-            conda-forge/linux-64::openslide-python
+            --file ${TOP}/python/cucim/requirements-test.txt
     else
         if [ -n "${VIRTUAL_ENV}" ]; then
             run_command pip3 install -r ${TOP}/python/cucim/requirements-test.txt


### PR DESCRIPTION
We do not need anymore to force install `linux-64` version of `openslide-python` as `noarch` packages are not available anymore. This will help to add `arm64` support

cc @gigony @jakirkham 