### PR TITLE
Fix thread contention in Cache

### DIFF
--- a/cpp/include/cucim/cache/image_cache_config.h
+++ b/cpp/include/cucim/cache/image_cache_config.h
@@ -28,7 +28,26 @@ constexpr uint64_t kOneMiB = 1024UL * 1024;
 constexpr std::string_view kDefaultCacheTypeStr = "nocache";
 constexpr CacheType kDefaultCacheType = cucim::cache::CacheType::kNoCache;
 constexpr uint64_t kDefaultCacheMemoryCapacity = 1024UL;
-constexpr uint32_t kDefaultCacheMutexPoolCapacity = 11117;
+/**
+ * @brief Mutex Pool size
+ *
+ * >>> from functools import reduce
+ * >>> def calc(pool_size, thread_size):
+ * >>>     a = reduce(lambda x,y: x*y, range(pool_size, pool_size - thread_size, -1))
+ * >>>     print(1 - (a / (pool_size**thread_size)))
+ *
+ * >>> calc(100003, 128)
+ * 0.07809410393222294
+ * >>> calc(100003, 256)
+ * 0.2786772006302005
+ *
+ * See https://godbolt.org/z/Tvx8179xK
+ * Creating a pool of 100000 mutexes takes only about 4 MB which is not big.
+ * I believe that making the mutex size biggger enough helps to the reduce the thread contention.
+ * For systems with more than 256 threads, the pool size should be larger.
+ * Choose a prime number for the pool size (https://primes.utm.edu/lists/small/100000.txt).
+ */
+constexpr uint32_t kDefaultCacheMutexPoolCapacity = 100003;
 constexpr uint32_t kDefaultCacheListPadding = 10000;
 constexpr uint32_t kDefaultCacheExtraSharedMemorySize = 100;
 constexpr bool kDefaultCacheRecordStat = false;


### PR DESCRIPTION
Needs to rebase once #141 is merged.

When multiple threads are used, it can cause thread contentions so
performance can be degraded.

![image](https://user-images.githubusercontent.com/1928522/141038018-a55ed61f-8a3b-43c2-bb0a-1215ddc5ceaf.png)

It is found that the performance degradation is due to `lock()` method in cuCIM's cache implementation.

![image](https://user-images.githubusercontent.com/1928522/141059618-f84634c5-6e5c-4626-bffa-88808654ed38.png)

This patch fixes the issue by using a hash value for the index of the mutex pool.
Also, the default mutex pool size is increased from 11117 to 100003.

![image](https://user-images.githubusercontent.com/1928522/141059799-922ce8c6-279e-4e2f-ad36-55d458a30848.png)


### After Fix

Note:: experiment on JPEG-compressed SVS had an incorrect configuration (start location and patch size was specified as (128,256) instead of (120, 240)) so updated it in both documents and [Google Spreadsheet](https://docs.google.com/spreadsheets/d/15D1EqNI_E9x_S8i3kJLwBxMcEmwk8SafW0WryMrAm6A/edit?usp=sharing).
![image](https://user-images.githubusercontent.com/1928522/141350490-06fdd8cb-5be2-42e4-9774-c7b76fab6f9a.png)

![image](https://user-images.githubusercontent.com/1928522/141093324-574b532e-ad42-4d61-8473-4c3e07e3feae.png)

![image](https://user-images.githubusercontent.com/1928522/141093381-8ab0161d-1b17-4e80-a680-86abfbf2fa65.png)


Close #146

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
