### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - libcucim {{ version }}.*
     - click
     - cupy 9.*
-    - numpy >=1.17.0
+    - numpy 1.17
     - scipy
     - scikit-image 0.18.1
   run:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.