### PR TITLE
Fix a segmentation fault due to unloaded libcufile

### DIFF
--- a/cpp/src/filesystem/cufile_driver.cpp
+++ b/cpp/src/filesystem/cufile_driver.cpp
@@ -41,6 +41,7 @@ namespace cucim::filesystem
 {
 static constexpr unsigned int PAGE_SIZE = 4096;
 static constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 128 << 20; // 128MiB
+static CuFileStub s_cufile_stub;
 static CuFileDriverInitializer s_cufile_initializer;
 thread_local static CuFileDriverCache s_cufile_cache;
 Mutex CuFileDriver::driver_mutex_;
@@ -300,7 +301,7 @@ bool discard_page_cache(const char* file_path)
 CuFileDriverInitializer::CuFileDriverInitializer()
 {
     // Initialize libcufile library
-    open_cufile_stub();
+    s_cufile_stub.load();
 
     CUfileError_t status = cuFileDriverOpen();
     if (status.err == CU_FILE_SUCCESS)
@@ -347,7 +348,7 @@ CuFileDriverInitializer::~CuFileDriverInitializer()
     }
 
     // Close cufile stub
-    close_cufile_stub();
+    s_cufile_stub.unload();
 }
 
 CuFileDriverCache::CuFileDriverCache()

--- a/gds/include/cufile_stub.h
+++ b/gds/include/cufile_stub.h
@@ -18,7 +18,17 @@
 
 #include "cufile.h"
 
-extern "C" void open_cufile_stub();
-extern "C" void close_cufile_stub();
+#include "cucim/dynlib/helper.h"
+
+class CuFileStub
+{
+public:
+    void load();
+    void unload();
+    ~CuFileStub();
+
+private:
+    cucim::dynlib::LibraryHandle handle_ = nullptr;
+};
 
 #endif // CUCIM_CUFILE_STUB_H

--- a/gds/src/cufile_stub.cpp
+++ b/gds/src/cufile_stub.cpp
@@ -50,11 +50,8 @@ static t_cuFileDriverSetMaxCacheSize impl_cuFileDriverSetMaxCacheSize = nullptr;
 static t_cuFileDriverSetMaxPinnedMemSize impl_cuFileDriverSetMaxPinnedMemSize = nullptr;
 
 
-class CuFileStub
+void CuFileStub::load()
 {
-public:
-    void load()
-    {
 #if !CUCIM_SUPPORT_GDS
         return;
 #endif
@@ -83,9 +80,9 @@ public:
             IMPORT_FUNCTION(handle_, cuFileDriverSetMaxPinnedMemSize);
         }
 #endif
-    }
-    void unload()
-    {
+}
+void CuFileStub::unload()
+{
 #if !CUCIM_SUPPORT_GDS
         return;
 #endif
@@ -117,33 +114,19 @@ public:
             impl_cuFileDriverSetMaxPinnedMemSize = nullptr;
         }
 #endif
-    }
-    ~CuFileStub()
-    {
-        // Note: unload() would be called explicitly by CuFileDriverInitializer to unload the shared library after calling
-        // cuFileDriverClose() in CuFileDriverInitializer::~CuFileDriverInitializer()
-//        unload();
-    }
+}
 
-private:
-    cucim::dynlib::LibraryHandle handle_ = nullptr;
-};
-
-static CuFileStub g_cufile_stub;
+CuFileStub::~CuFileStub()
+{
+    // Note: unload() would be called explicitly by CuFileDriverInitializer to unload the shared library after
+    // calling cuFileDriverClose() in CuFileDriverInitializer::~CuFileDriverInitializer()
+    //        unload();
+}
 
 #if __cplusplus
 extern "C"
 {
 #endif
-
-    void open_cufile_stub()
-    {
-        g_cufile_stub.load();
-    }
-    void close_cufile_stub()
-    {
-        g_cufile_stub.unload();
-    }
 
 #if !CUCIM_STATIC_GDS
     CUfileError_t cuFileHandleRegister(CUfileHandle_t* fh, CUfileDescr_t* descr)

--- a/gds/src/cufile_stub.cpp
+++ b/gds/src/cufile_stub.cpp
@@ -93,7 +93,12 @@ public:
 #if !CUCIM_STATIC_GDS
         if (handle_)
         {
-            cucim::dynlib::unload_library(handle_);
+            // Do not unload the cufile (GDS) library as libcufile registers a cleanup function with atexit() and
+            // unloading the library will cause a segfault (calling the cleanup function that doesn't exist anymore).
+            // Just leave the library loaded.
+            // See https://github.com/rapidsai/cucim/pull/153
+
+            // cucim::dynlib::unload_library(handle_);
             handle_ = nullptr;
 
             impl_cuFileDriverOpen = nullptr;


### PR DESCRIPTION
Do not unload the `cufile (GDS)` library because `libcufile` registers a cleanup function with `atexit()` and unloading the library will cause a segfault (calling the cleanup function that doesn't exist anymore).

It turns out that CUDA 11.5 bundled GDS library (libcufile) and it is available in GPUCI's build/test container image (such as `gpuci/rapidsai:21.12-cuda11.5-devel-ubuntu18.04-py3.7`).
cuCIM would dynamically load `libcufile.so` shared library and unload it when a global static variable in cuCIM is destroyed.
Since libcufile's cleanup function(through `atexit()`) is called after the libcufile is unloaded, it causes a segmentation fault at exit.
(See https://github.com/rapidsai/cucim/pull/153)

You can see discussions with `atexit in dynamically loaded shared library` keywords
- https://news.ycombinator.com/item?id=20228082
- https://forums.raspberrypi.com/viewtopic.php?t=237006

Maybe using [destructor attribute](https://www.geeksforgeeks.org/__attribute__constructor-__attribute__destructor-syntaxes-c/) could fix the issue from GDS(cufile) side.

This patch leaves the libcufile library loaded, without calling `::dlclose(library_handle)` method to unload `libcufile.so`.

Update: I couldn't find `atexit()` used in libcufile (though I can see `atexit()` call for a executable file[fio]) but it seems that a method is registered and called at the exit time so we cannot help but leave the dynamically loaded library without unloading.

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
