### PR TITLE
Update `conda` recipes for Enhanced Compatibility effort

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -5,6 +5,7 @@
 {% set py_version=environ.get('CONDA_PY', 37) %}
 {% set python_version=environ.get('PYTHON_VER', '3.7') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '11.0').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 package:
   name: cucim
@@ -15,7 +16,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda_{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda_{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -37,7 +38,7 @@ requirements:
     - scipy
     - scikit-image 0.18.1
   run:
-    - cudatoolkit {{ cuda_version }}.*
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -4,6 +4,7 @@
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set python_version=environ.get('PYTHON_VER', '3.7') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '11.0').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 package:
   name: libcucim
@@ -14,7 +15,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -37,7 +38,7 @@ requirements:
     - zstd
     - libwebp-base  # [linux or osx]
   run:
-    - cudatoolkit {{ cuda_version }}.*
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     # - openslide # skipping here but benchmark binary would needs openslide library
     - zlib
     - jpeg


### PR DESCRIPTION
Similar to https://github.com/rapidsai/cudf/pull/9456.


This PR updates the `conda` recipe build strings and `cudatoolkit` version specifications as part of the Enhanced Compatibility efforts.

The build strings have been updated to only include the major CUDA version (i.e. `librmm-21.12.00a-cuda11_gc781527_12.tar.bz2`) and the `cudatoolkit` version specifications will now be formatted like `cudatoolkit >=x,<y.0a0` (i.e. `cudatoolkit >=11,<12.0a0`).

Moving forward, we'll build the packages with a single CUDA version (i.e. `11.5`) and test them in environments with different CUDA versions (i.e. `11.0`, `11.2`, `11.4`, `11.5` etc.).
