### PR TITLE
Do not compile code with nvcc if no CUDA kernel exists

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -122,9 +122,6 @@ set_target_properties(${CUCIM_PACKAGE_NAME}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         VERSION ${PROJECT_VERSION}
 )
-# At least one file needs to be compiled with nvcc.
-# Otherwise, it will cause `/usr/bin/ld: cannot find -lcudart` error message.
-set_source_files_properties(src/cucim.cpp src/filesystem/cufile_driver.cpp PROPERTIES LANGUAGE CUDA)
 
 # Note: Looks like the following line causes error on CMake 3.18.4 (it is working on 3.18.2). Keeping it for now.
 set(CUCIM_REQUIRED_FEATURES cxx_std_17 cuda_std_17)
@@ -161,6 +158,7 @@ target_link_libraries(${CUCIM_PACKAGE_NAME}
             # $<INSTALL_INTERFACE:cucim::rmm>
 ##            $<INSTALL_INTERFACE:cucim::gds>
         PRIVATE
+            CUDA::cudart
             deps::abseil
             deps::gds
             deps::libcuckoo

--- a/cpp/plugins/cucim.kit.cumed/CMakeLists.txt
+++ b/cpp/plugins/cucim.kit.cumed/CMakeLists.txt
@@ -163,10 +163,6 @@ add_library(${CUCIM_PLUGIN_NAME}
     src/cumed/cumed.h
     )
 
-# At least one file needs to be compiled with nvcc.
-# Otherwise, it will cause `/usr/bin/ld: cannot find -lcudart` error message.
-set_source_files_properties(src/cumed/cumed.cpp PROPERTIES LANGUAGE CUDA)
-
 # Compile options
 set_target_properties(${CUCIM_PLUGIN_NAME}
     PROPERTIES
@@ -188,6 +184,7 @@ target_compile_options(${CUCIM_PLUGIN_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-W
 # Link libraries
 target_link_libraries(${CUCIM_PLUGIN_NAME}
         PRIVATE
+            CUDA::cudart
             deps::fmt
             cucim::cucim
         )

--- a/cpp/plugins/cucim.kit.cumed/src/cumed/cumed.cpp
+++ b/cpp/plugins/cucim.kit.cumed/src/cumed/cumed.cpp
@@ -103,6 +103,7 @@ static CuCIMFileHandle CUCIM_ABI parser_open(const char* file_path_)
 
 static bool CUCIM_ABI parser_parse(CuCIMFileHandle* handle, cucim::io::format::ImageMetadataDesc* out_metadata_desc)
 {
+    (void)handle;
     if (!out_metadata_desc || !out_metadata_desc->handle)
     {
         throw std::runtime_error("out_metadata_desc shouldn't be nullptr!");
@@ -162,8 +163,6 @@ static bool CUCIM_ABI parser_parse(CuCIMFileHandle* handle, cucim::io::format::I
     }
 
     std::pmr::vector<float> level_downsamples(&resource);
-    float orig_width = static_cast<float>(shape[1]);
-    float orig_height = static_cast<float>(shape[0]);
     for (size_t i = 0; i < level_count; ++i)
     {
         level_downsamples.emplace_back(1.0);
@@ -234,6 +233,7 @@ static bool CUCIM_ABI reader_read(const CuCIMFileHandle* handle,
                                   cucim::io::format::ImageDataDesc* out_image_data,
                                   cucim::io::format::ImageMetadataDesc* out_metadata_desc = nullptr)
 {
+    (void)handle;
     (void)metadata;
 
     std::string device_name(request->device);

--- a/cpp/plugins/cucim.kit.cuslide/CMakeLists.txt
+++ b/cpp/plugins/cucim.kit.cuslide/CMakeLists.txt
@@ -191,11 +191,6 @@ add_library(${CUCIM_PLUGIN_NAME}
     src/cuslide/tiff/tiff.h
     src/cuslide/tiff/types.h)
 
-# At least one file needs to be compiled with nvcc.
-# Otherwise, it will cause `/usr/bin/ld: cannot find -lcudart` error message.
-# Note: Since cuslide.cpp is using nlohmann/json.hpp which nvcc cannot parse properly, set other files for cudart.
-set_source_files_properties(src/cuslide/jpeg/libjpeg_turbo.cpp PROPERTIES LANGUAGE CUDA)
-
 # compile color.c for libopenjpeg with c++
 set_source_files_properties(${deps-libopenjpeg_SOURCE_DIR}/src/bin/common/color.c
     PROPERTIES
@@ -203,6 +198,12 @@ set_source_files_properties(${deps-libopenjpeg_SOURCE_DIR}/src/bin/common/color.
         CMAKE_CXX_VISIBILITY_PRESET default
         CMAKE_C_VISIBILITY_PRESET default
         CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
+
+# Ignore warnings in existing source code from libjpeg-turbo
+set_source_files_properties(src/cuslide/jpeg/libjpeg_turbo.cpp
+    PROPERTIES
+        COMPILE_OPTIONS "-Wno-error" # or, "-Wno-write-strings;-Wno-clobbered"
+    )
 
 # Compile options
 set_target_properties(${CUCIM_PLUGIN_NAME}
@@ -225,6 +226,7 @@ target_compile_options(${CUCIM_PLUGIN_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-W
 # Link libraries
 target_link_libraries(${CUCIM_PLUGIN_NAME}
         PRIVATE
+            CUDA::cudart
             deps::fmt
             #cucim::rmm
             cucim::cucim

--- a/cpp/src/filesystem/cufile_driver.cpp
+++ b/cpp/src/filesystem/cufile_driver.cpp
@@ -526,7 +526,6 @@ ssize_t CuFileDriver::pread(void* buf, size_t count, off_t file_offset, off_t bu
         {
             ssize_t read_cnt;
             size_t block_read_size = ALIGN_DOWN(count, PAGE_SIZE);
-            auto start = std::chrono::high_resolution_clock::now();
             if (block_read_size > 0)
             {
                 if (memory_type == cudaMemoryTypeUnregistered)


### PR DESCRIPTION
Currently, cuCIM code links CUDA runtime by creating PTX code explicitly (changing LANGUAGE to CUDA) even though cuCIM code (in C++) currently doesn't have any CUDA kernels.

```cmake
# At least one file needs to be compiled with nvcc.
# Otherwise, it will cause `/usr/bin/ld: cannot find -lcudart` error message.
set_source_files_properties(src/cucim.cpp src/filesystem/cufile_driver.cpp PROPERTIES LANGUAGE CUDA)
```

That causes the issue with CuPy, causing the following error message (#170)
```python
>>> import cupy as cp
>>> import cucim.clara
>>> a = cp.zeros((3,3))
...
cupy/cuda/memory.pyx in cupy.cuda.memory.Memory.__init__()

cupy_backends/cuda/api/runtime.pyx in cupy_backends.cuda.api.runtime.malloc()

cupy_backends/cuda/api/runtime.pyx in cupy_backends.cuda.api.runtime.check_status()

CUDARuntimeError: cudaErrorUnsupportedPtxVersion: the provided PTX was compiled with an unsupported toolchain.
```

The error is related to the nvcc version (from cuda 11.5) used in RAPIDS GPUCI.

https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gg3f51e3575c21[…]e003844fd2df23a72a9ee7364d30150ae7e9e

>cudaErrorUnsupportedPtxVersion = 222
>This indicates that the provided PTX was compiled with an unsupported toolchain. The most common reason for this, is the PTX was generated by a compiler newer than what is supported by the CUDA driver and PTX JIT compiler.

With CUDA toolkit (nvcc) v11.4, it doesn't cause the error.

Fix the error by linking libcudart.so explicitly.
Also fixes warnings.

Close #170

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
