### PR TITLE
add cucim.skimage.__api_version__

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,6 +17,10 @@ CuImage
 skimage Submodules
 ==================
 
+The `cucim.skimage` subpackage is designed to match the API of upstream scikit-image. The version of the upstream API that has been implemented can be determined by checking `cucim.skimage.__api_version__`. This attribute will be
+a "major.minor" version string corresponding to a released scikit-image
+version.
+
 color
 -----
 

--- a/python/cucim/src/cucim/skimage/__init__.py
+++ b/python/cucim/src/cucim/skimage/__init__.py
@@ -58,6 +58,10 @@ dtype_limits
 
 """
 
+# This __api_version__ attribute indicates which major.minor version of the
+# scikit-image API we are currently targeting.
+__api_version__ = '0.18'
+
 # All skimage root imports go here
 from .util.dtype import (dtype_limits, img_as_bool, img_as_float,
                          img_as_float32, img_as_float64, img_as_int,


### PR DESCRIPTION
This attribute will indicate which version of the scikit-image API has been implemented (currently 0.18). Since we use an independent versioning scheme from scikit-image, this is otherwise not obvious to end users.
