### PR TITLE
Allow CuPy 10

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy 9.*
+    - cupy >=9,<11.0.0a0
     - numpy 1.17
     - scipy
     - scikit-image 0.18.1
@@ -42,7 +42,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy 9.*
+    - cupy >=9,<11.0.0a0
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-image 0.18.1


### PR DESCRIPTION
Relaxes version constraints to allow CuPy 10.

xref: https://github.com/rapidsai/integration/pull/413