### PR TITLE
Upgrade Numpy to 1.18 for Python 3.9 support

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libcucim {{ version }}.*
     - click
     - cupy >=9,<11.0.0a0
-    - numpy 1.17
+    - numpy 1.18
     - scipy
     - scikit-image 0.18.1
   run:


### PR DESCRIPTION
To support Python 3.9, we need to have `numpy >= 1.18`