### PR TITLE
Allow installation with CuPy 10

### DIFF
--- a/conda/environments/env.yml
+++ b/conda/environments/env.yml
@@ -2,7 +2,7 @@ name: cucim
 channels:
   - conda-forge
 dependencies:
-  - cupy>=9,<11.0.0a0
+  - cupy>=9
   - scikit-image=0.18.1
   - openslide
   - zlib

--- a/conda/environments/env.yml
+++ b/conda/environments/env.yml
@@ -2,7 +2,7 @@ name: cucim
 channels:
   - conda-forge
 dependencies:
-  - cupy=9
+  - cupy>=9,<11.0.0a0
   - scikit-image=0.18.1
   - openslide
   - zlib

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy >=9,<11
+    - cupy >=9,<11.0.0a0
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-image 0.18.1

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy 9.*
+    - cupy >=9,<11
     - numpy 1.17
     - scipy
     - scikit-image 0.18.1
@@ -42,7 +42,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy 9.*
+    - cupy >=9,<11
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-image 0.18.1


### PR DESCRIPTION
Now that CuPy 10.0 is out, we should also allow cuCIM to be installed with CuPy 10.x in the next release.

I checked the integration repo and [it has the same constraint proposed here](https://github.com/rapidsai/integration/blob/a76cfc32e684f53cf0a9b4cb113cf0fd9fad51e7/conda/recipes/versions.yaml#L47-L48)
