### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/conda/environments/env.yml
+++ b/conda/environments/env.yml
@@ -2,7 +2,7 @@ name: cucim
 channels:
   - conda-forge
 dependencies:
-  - cupy=9
+  - cupy>=9
   - scikit-image=0.18.1
   - openslide
   - zlib


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.