### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libcucim {{ version }}.*
     - click
     - cupy >=9,<11.0.0a0
-    - numpy 1.17
+    - numpy 1.18
     - scipy
     - scikit-image 0.18.1
   run:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.