### PR TITLE
Upgrade Numpy to 1.19 for Python 3.9 support

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libcucim {{ version }}.*
     - click
     - cupy >=9,<11.0.0a0
-    - numpy 1.18
+    - numpy 1.19
     - scipy
     - scikit-image 0.18.1
   run:


### PR DESCRIPTION
Following https://github.com/rapidsai/cucim/pull/196, it seems like Numpy 1.18 is not enough for Python 3.9 and we need to upgrade to Numpy 1.19