### PR TITLE
Do not use cudatoolkit from conda for building libcucim

### DIFF
--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - sysroot_linux-64 2.17
     - yasm # [x86_64]
   host:
-    - cudatoolkit {{ cuda_version }}.*
     - openslide
     - zlib
     - jpeg


### PR DESCRIPTION
When `find_package(CUDAToolkit REQUIRED)` is called, CUDA library path is determined by the location of `libcudart.so`.

- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.22.1/Modules/FindCUDAToolkit.cmake#L922
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.22.1/Modules/FindCUDAToolkit.cmake#L848
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.22.1/Modules/FindCUDAToolkit.cmake#L834
- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.22.1/Modules/FindCUDAToolkit.cmake#L793

For https://github.com/rapidsai/cucim/pull/191 to be built, it needs `CUDA::culibos` (libculibos.a) which is a static library that will be needed to link a custom nvjpeg static library(libnvjpeg.a).

If `cudatoolkit` is set to `host` of `libcucim`'s conda recipe, it cannot find `CUDA::culibos` component because conda's `cudatoolkit` (runtime libraries) takes precedence.

This patch removes `cudatoolkit` dependency for libcucim recipe so it can build the library without error.




Signed-off-by: Gigon Bae <gbae@nvidia.com>

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
