### PR TITLE
Port upstream fixes to skimage.transform estimate methods

### DIFF
--- a/python/cucim/src/cucim/skimage/transform/tests/test_geometric.py
+++ b/python/cucim/src/cucim/skimage/transform/tests/test_geometric.py
@@ -609,6 +609,7 @@ def test_degenerate(xp=cp):
     for affine in tform.inverse_affines:
         assert not xp.all(xp.isnan(affine.params))
 
+
 @pytest.mark.parametrize('xp', [np, cp])
 def test_normalize_degenerate_points(xp):
     """Return nan matrix *of appropriate size* when point is repeated."""

--- a/python/cucim/src/cucim/skimage/transform/tests/test_geometric.py
+++ b/python/cucim/src/cucim/skimage/transform/tests/test_geometric.py
@@ -70,7 +70,7 @@ def test_euclidean_estimation():
 
     # via estimate method
     tform3 = EuclideanTransform()
-    tform3.estimate(SRC, DST)
+    assert tform3.estimate(SRC, DST)
     assert_array_almost_equal(tform3.params, tform2.params)
 
 
@@ -117,7 +117,7 @@ def test_similarity_estimation():
 
     # via estimate method
     tform3 = SimilarityTransform()
-    tform3.estimate(SRC, DST)
+    assert tform3.estimate(SRC, DST)
     assert_array_almost_equal(tform3.params, tform2.params)
 
 
@@ -183,7 +183,7 @@ def test_affine_estimation():
 
     # via estimate method
     tform3 = AffineTransform()
-    tform3.estimate(SRC, DST)
+    assert tform3.estimate(SRC, DST)
     assert_array_almost_equal(tform3.params, tform2.params)
 
 
@@ -214,7 +214,7 @@ def test_affine_init():
 
 def test_piecewise_affine():
     tform = PiecewiseAffineTransform()
-    tform.estimate(SRC, DST)
+    assert tform.estimate(SRC, DST)
     # make sure each single affine transform is exactly estimated
     assert_array_almost_equal(tform(SRC), DST)
     assert_array_almost_equal(tform.inverse(DST), SRC)
@@ -357,7 +357,7 @@ def test_projective_estimation():
 
     # via estimate method
     tform3 = ProjectiveTransform()
-    tform3.estimate(SRC, DST)
+    assert tform3.estimate(SRC, DST)
     assert_array_almost_equal(tform3.params, tform2.params)
 
 
@@ -401,7 +401,7 @@ def test_polynomial_estimation():
 
     # via estimate method
     tform2 = PolynomialTransform()
-    tform2.estimate(SRC, DST, order=10)
+    assert tform2.estimate(SRC, DST, order=10)
     assert_array_almost_equal(tform2.params, tform.params)
 
 
@@ -557,15 +557,15 @@ def test_degenerate(xp=cp):
     src = dst = xp.zeros((10, 2))
 
     tform = SimilarityTransform()
-    tform.estimate(src, dst)
+    assert not tform.estimate(src, dst)
     assert xp.all(xp.isnan(tform.params))
 
     tform = AffineTransform()
-    tform.estimate(src, dst)
+    assert not tform.estimate(src, dst)
     assert xp.all(xp.isnan(tform.params))
 
     tform = ProjectiveTransform()
-    tform.estimate(src, dst)
+    assert not tform.estimate(src, dst)
     assert xp.all(xp.isnan(tform.params))
 
     # See gh-3926 for discussion details
@@ -581,6 +581,33 @@ def test_degenerate(xp=cp):
         # a transform could be returned with nan values.
         assert not tform.estimate(src, dst) or xp.isfinite(tform.params).all()
 
+    src = xp.array([[0, 2, 0], [0, 2, 0], [0, 4, 0]])
+    dst = xp.array([[0, 1, 0], [0, 1, 0], [0, 3, 0]])
+    tform = AffineTransform()
+    assert not tform.estimate(src, dst)
+    # Prior to gh-6207, the above would set the parameters as the identity.
+    assert xp.all(xp.isnan(tform.params))
+
+    # The tesselation on the following points produces one degenerate affine
+    # warp within PiecewiseAffineTransform.
+    src = xp.asarray([
+        [0, 192, 256], [0, 256, 256], [5, 0, 192], [5, 64, 0], [5, 64, 64],
+        [5, 64, 256], [5, 192, 192], [5, 256, 256], [0, 192, 256],
+    ])
+
+    dst = xp.asarray([
+        [0, 142, 206], [0, 206, 206], [5, -50, 142], [5, 14, 0], [5, 14, 64],
+        [5, 14, 206], [5, 142, 142], [5, 206, 206], [0, 142, 206],
+    ])
+    tform = PiecewiseAffineTransform()
+    assert not tform.estimate(src, dst)
+    xp = np  # PiecewiseAffine implemented in CPU
+    assert np.all(xp.isnan(tform.affines[4].params))  # degenerate affine
+    for idx, affine in enumerate(tform.affines):
+        if idx != 4:
+            assert not xp.all(xp.isnan(affine.params))
+    for affine in tform.inverse_affines:
+        assert not xp.all(xp.isnan(affine.params))
 
 @pytest.mark.parametrize('xp', [np, cp])
 def test_normalize_degenerate_points(xp):
@@ -659,7 +686,7 @@ def test_estimate_affine_3d(xp):
     dst = tf(src)
     dst_noisy = dst + xp.asarray(np.random.random((25, ndim)))
     tf2 = AffineTransform(dimensionality=ndim)
-    tf2.estimate(src, dst_noisy)
+    assert tf2.estimate(src, dst_noisy)
     # we check rot/scale/etc more tightly than translation because translation
     # estimation is on the 1 pixel scale
     assert_array_almost_equal(tf2.params[:, :-1], matrix[:, :-1], decimal=2)


### PR DESCRIPTION
Porting the following changes:
- ProjectiveTransform has a consistent failure state when `estimate` is ill-conditioned
- SimilarityTransform.estimate returns False if ill-conditioned (currently always returns True)
- PiecewiseSimilarityTransform.estimate returns False if any piece is illconditioned (currently always returns True)

Upstream refs:
https://github.com/scikit-image/scikit-image/pull/6207
https://github.com/scikit-image/scikit-image/pull/6211

Closes #199 

