### PR TITLE
Expose data type of CuImage object for interoperability with NumPy

### DIFF
--- a/cpp/include/cucim/cuimage.h
+++ b/cpp/include/cucim/cuimage.h
@@ -37,6 +37,14 @@
 #include <string>
 #include <vector>
 
+
+// Forward declarations for DLDataType's equality operator.
+template <>
+struct std::hash<DLDataType>;
+
+EXPORT_VISIBLE bool operator==(const DLDataType& lhs, const DLDataType& rhs);
+EXPORT_VISIBLE bool operator!=(const DLDataType& lhs, const DLDataType& rhs);
+
 namespace cucim
 {
 

--- a/cpp/include/cucim/cuimage.h
+++ b/cpp/include/cucim/cuimage.h
@@ -148,6 +148,8 @@ public:
 
     DLDataType dtype() const;
 
+    std::string typestr() const;
+
     std::vector<std::string> channel_names() const;
 
     std::vector<float> spacing(std::string dim_order = std::string{}) const;

--- a/cpp/include/cucim/cuimage.h
+++ b/cpp/include/cucim/cuimage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cucim/memory/dlpack.h
+++ b/cpp/include/cucim/memory/dlpack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,60 @@
 namespace cucim::memory
 {
 
+/**
+* @brief Return a string providing the basic type of the homogenous array in NumPy.
+*
+* Note: This method assumes little-endian for now.
+*
+* @return A const character pointer that represents a string from a given `DLDataType` data.
+*/
+inline const char* to_numpy_dtype(const DLDataType& dtype) {
+    // TODO: consider bfloat16: https://github.com/dmlc/dlpack/issues/45
+    // TODO: consider other byte-order
+    uint8_t code = dtype.code;
+    uint8_t bits = dtype.bits;
+    switch(code) {
+
+    case kDLInt:
+        switch(bits) {
+        case 8:
+            return "|i1";
+        case 16:
+            return "<i2";
+        case 32:
+            return "<i4";
+        case 64:
+            return "<i8";
+        }
+        throw std::logic_error(fmt::format("DLDataType(code: kDLInt, bits: {}) is not supported!", bits));
+    case kDLUInt:
+        switch(bits) {
+        case 8:
+            return "|u1";
+        case 16:
+            return "<u2";
+        case 32:
+            return "<u4";
+        case 64:
+            return "<u8";
+        }
+        throw std::logic_error(fmt::format("DLDataType(code: kDLUInt, bits: {}) is not supported!", bits));
+    case kDLFloat:
+        switch(bits) {
+        case 16:
+            return "<f2";
+        case 32:
+            return "<f4";
+        case 64:
+            return "<f8";
+        }
+        break;
+    case kDLBfloat:
+        throw std::logic_error(fmt::format("DLDataType(code: kDLBfloat, bits: {}) is not supported!", bits));
+    }
+    throw std::logic_error(fmt::format("DLDataType(code: {}, bits: {}) is not supported!", code, bits));
+}
+
 class DLTContainer
 {
 public:
@@ -36,7 +90,7 @@ public:
      *
      * @return size_t Required size for the tensor.
      */
-    size_t size()
+    size_t size() const
     {
         size_t size = 1;
         for (int i = 0; i < tensor_->ndim; ++i)
@@ -47,6 +101,12 @@ public:
         return size;
     }
 
+    DLDataType dtype() const {
+        if (!tensor_) {
+            return DLDataType({ DLDataTypeCode::kDLUInt, 8, 1 });
+        }
+        return tensor_->dtype;
+    }
     /**
      * @brief Return a string providing the basic type of the homogenous array in NumPy.
      *
@@ -54,56 +114,18 @@ public:
      *
      * @return A const character pointer that represents a string
      */
-    const char* numpy_dtype() {
+    const char* numpy_dtype() const {
         // TODO: consider bfloat16: https://github.com/dmlc/dlpack/issues/45
         // TODO: consider other byte-order
         if (!tensor_) {
             return "";
         }
+        return to_numpy_dtype(tensor_->dtype);
+    }
 
-        const DLDataType& dtype = tensor_->dtype;
-        uint8_t code = dtype.code;
-        uint8_t bits = dtype.bits;
-        switch(code) {
-
-        case kDLInt:
-            switch(bits) {
-            case 8:
-                return "|i1";
-            case 16:
-                return "<i2";
-            case 32:
-                return "<i4";
-            case 64:
-                return "<i8";
-            }
-            throw std::logic_error(fmt::format("DLDataType(code: kDLInt, bits: {}) is not supported!", bits));
-        case kDLUInt:
-            switch(bits) {
-            case 8:
-                return "|u1";
-            case 16:
-                return "<u2";
-            case 32:
-                return "<u4";
-            case 64:
-                return "<u8";
-            }
-            throw std::logic_error(fmt::format("DLDataType(code: kDLUInt, bits: {}) is not supported!", bits));
-        case kDLFloat:
-            switch(bits) {
-            case 16:
-                return "<f2";
-            case 32:
-                return "<f4";
-            case 64:
-                return "<f8";
-            }
-            break;
-        case kDLBfloat:
-            throw std::logic_error(fmt::format("DLDataType(code: kDLBfloat, bits: {}) is not supported!", bits));
-        }
-        throw std::logic_error(fmt::format("DLDataType(code: {}, bits: {}) is not supported!", code, bits));
+    operator bool() const
+    {
+        return static_cast<bool>(tensor_);
     }
 
     operator DLTensor() const

--- a/cpp/src/cuimage.cpp
+++ b/cpp/src/cuimage.cpp
@@ -446,6 +446,11 @@ DLDataType CuImage::dtype() const
     // TODO: support string conversion like Device class
     return DLDataType({ DLDataTypeCode::kDLUInt, 8, 1 });
 }
+std::string CuImage::typestr() const
+{
+    const char* type_str = container().numpy_dtype();
+    return std::string(type_str);
+}
 std::vector<std::string> CuImage::channel_names() const
 {
     std::vector<std::string> channel_names;

--- a/cpp/src/cuimage.cpp
+++ b/cpp/src/cuimage.cpp
@@ -34,6 +34,27 @@
 #define XSTR(x) STR(x)
 #define STR(x) #x
 
+
+// DLDataType's equality operator implementation
+template <>
+struct std::hash<DLDataType>
+{
+    size_t operator()(const DLDataType& dtype) const
+    {
+        return (dtype.code * 1117) ^ (dtype.bits * 31) ^ (dtype.lanes);
+    }
+};
+
+bool operator==(const DLDataType& lhs, const DLDataType& rhs)
+{
+    return (lhs.code == rhs.code) && (lhs.bits == rhs.bits) && (lhs.lanes == rhs.lanes);
+}
+
+bool operator!=(const DLDataType& lhs, const DLDataType& rhs)
+{
+    return (lhs.code != rhs.code) || (lhs.bits != rhs.bits) || (lhs.lanes != rhs.lanes);
+}
+
 namespace cucim
 {
 

--- a/cpp/src/cuimage.cpp
+++ b/cpp/src/cuimage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -464,13 +464,37 @@ std::vector<int64_t> CuImage::size(std::string dim_order) const
 }
 DLDataType CuImage::dtype() const
 {
-    // TODO: support string conversion like Device class
+    const memory::DLTContainer img_data = container();
+    if (img_data)
+    {
+        const DLDataType dtype = img_data.dtype();
+        return dtype;
+    }
+    else
+    {
+        if (image_metadata_)
+        {
+            return image_metadata_->dtype;
+        }
+    }
     return DLDataType({ DLDataTypeCode::kDLUInt, 8, 1 });
 }
 std::string CuImage::typestr() const
 {
-    const char* type_str = container().numpy_dtype();
-    return std::string(type_str);
+    const memory::DLTContainer img_data = container();
+    if (img_data)
+    {
+        const char* type_str = img_data.numpy_dtype();
+        return std::string(type_str);
+    }
+    else
+    {
+        if (image_metadata_)
+        {
+            return std::string(memory::to_numpy_dtype(image_metadata_->dtype));
+        }
+    }
+    return "|u1";
 }
 std::vector<std::string> CuImage::channel_names() const
 {

--- a/cpp/tests/test_metadata.cpp
+++ b/cpp/tests/test_metadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,25 +74,30 @@ TEST_CASE("Verify metadata", "[test_metadata.cpp]")
 {
     cucim::Framework* framework = cucim::acquire_framework("sample.app");
     REQUIRE(framework != nullptr);
-
+    std::string plugin_path = g_config.get_plugin_path();
     cucim::io::format::IImageFormat* image_format =
-        framework->acquire_interface_from_library<cucim::io::format::IImageFormat>(g_config.get_plugin_path().c_str());
+        framework->acquire_interface_from_library<cucim::io::format::IImageFormat>(plugin_path.c_str());
     // fmt::print("{}\n", image_format->formats[0].get_format_name());
     REQUIRE(image_format != nullptr);
 
-    auto handle =
-        image_format->formats[0].image_parser.open(g_config.get_input_path("private/philips_tiff_000.tif").c_str());
+    std::string input_path = g_config.get_input_path();
+    std::shared_ptr<CuCIMFileHandle>* file_handle_shared = reinterpret_cast<std::shared_ptr<CuCIMFileHandle>*>(
+        image_format->formats[0].image_parser.open(input_path.c_str()));
+
+    std::shared_ptr<CuCIMFileHandle> file_handle = *file_handle_shared;
+    delete file_handle_shared;
+
+    // Set deleter to close the file handle
+    file_handle->set_deleter(image_format->formats[0].image_parser.close);
 
     cucim::io::format::ImageMetadata metadata{};
-    image_format->formats[0].image_parser.parse(&handle, &metadata.desc());
+    image_format->formats[0].image_parser.parse(file_handle.get(), &metadata.desc());
 
     // Using fmt::print() has a problem with TestMate VSCode plugin (output is not caught by the plugin)
     std::cout << fmt::format("metadata: {}\n", metadata.desc().raw_data);
     const uint8_t* buf = metadata.get_buffer();
     const uint8_t* buf2 = static_cast<uint8_t*>(metadata.allocate(1));
     std::cout << fmt::format("test: {}\n", buf2 - buf);
-
-    image_format->formats[0].image_parser.close(&handle);
 
     // cucim::CuImage img{ g_config.get_input_path("private/philips_tiff_000.tif") };
     // const auto& img_metadata = img.metadata();

--- a/cpp/tests/test_metadata.cpp
+++ b/cpp/tests/test_metadata.cpp
@@ -136,8 +136,13 @@ TEST_CASE("Verify metadata", "[test_metadata.cpp]")
 TEST_CASE("Load test", "[test_metadata.cpp]")
 {
     cucim::CuImage img{ g_config.get_input_path("private/philips_tiff_000.tif") };
+    REQUIRE(img.dtype() == DLDataType{ DLDataTypeCode::kDLUInt, 8, 1 });
+    REQUIRE(img.typestr() == "|u1");
 
     auto test = img.read_region({ -10, -10 }, { 100, 100 });
+
+    REQUIRE(test.dtype() == DLDataType{ DLDataTypeCode::kDLUInt, 8, 1 });
+    REQUIRE(test.typestr() == "|u1");
 
     fmt::print("{}", img.metadata());
 }

--- a/cucim.code-workspace
+++ b/cucim.code-workspace
@@ -13,7 +13,6 @@
 			"path": "python"
 		}
 	],
-	"remoteAuthority": "wsl+Ubuntu-20.04",
 	"extensions": {
 		"recommendations": [
 			"ms-vscode.cpptools-extension-pack",
@@ -33,7 +32,7 @@
 				"env": {
 					"CUCIM_TESTDATA_FOLDER": "${workspaceDirectory}/test_data",
 					// Add cuslide plugin's library path to LD_LIBRARY_PATH
-					"LD_LIBRARY_PATH": "${workspaceDirectory}/build-debug/lib:${workspaceDirectory}/cpp/plugins/cucim.kit.cuslide/build-debug/lib:${workspaceDirectory}/temp/cuda/lib64:${os_env:LD_LIBRARY_PATH}",
+					"LD_LIBRARY_PATH": "${workspaceDirectory}/build-debug/lib:${workspaceDirectory}/cpp/plugins/cucim.kit.cuslide/build-debug/lib:${workspaceDirectory}/cpp/plugins/cucim.kit.cumed/build-debug/lib:${workspaceDirectory}/temp/cuda/lib64:${os_env:LD_LIBRARY_PATH}",
 					"CUCIM_TEST_PLUGIN_PATH": "cucim.kit.cuslide@22.04.00.so"
 				},
 				"cwd": "${workspaceDirectory}",

--- a/python/cucim/src/cucim/clara/__init__.py
+++ b/python/cucim/src/cucim/clara/__init__.py
@@ -17,9 +17,11 @@ import os
 
 from . import cli, converter
 # import hidden methods
-from ._cucim import CuImage, __version__, cache, filesystem, io
+from ._cucim import (CuImage, DLDataType, DLDataTypeCode, __version__, cache,
+                     filesystem, io)
 
-__all__ = ['cli', 'CuImage', 'filesystem', 'io', 'cache', 'converter', '__version__']
+__all__ = ['cli', 'CuImage', 'DLDataType', 'DLDataTypeCode', 'filesystem',
+           'io', 'cache', 'converter', '__version__']
 
 
 from ._cucim import _get_plugin_root  # isort:skip

--- a/python/cucim/tests/unit/clara/test_load_image_metadata.py
+++ b/python/cucim/tests/unit/clara/test_load_image_metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,6 +17,8 @@ from ...util.io import open_image_cucim
 
 
 def test_load_image_metadata(testimg_tiff_stripe_32x24_16):
+    import numpy as np
+
     img = open_image_cucim(testimg_tiff_stripe_32x24_16)
 
     # True if image data is loaded & available.
@@ -36,6 +38,8 @@ def test_load_image_metadata(testimg_tiff_stripe_32x24_16):
     assert dtype.code == 1
     assert dtype.bits == 8
     assert dtype.lanes == 1
+    # The typestr of the image.
+    assert np.dtype(img.typestr) == np.uint8
     # A channel name list.
     assert img.channel_names == ['R', 'G', 'B']
     # Returns physical size in tuple.

--- a/python/cucim/tests/unit/clara/test_tiff_read_region.py
+++ b/python/cucim/tests/unit/clara/test_tiff_read_region.py
@@ -128,6 +128,20 @@ def test_region_image_level_data(testimg_tiff_stripe_4096x4096_256):
         assert resolutions["level_tile_sizes"][0] == (300, 400)
 
 
+def test_region_image_dtype(testimg_tiff_stripe_4096x4096_256):
+    from cucim.clara import DLDataType, DLDataTypeCode
+
+    cucim_img = open_image_cucim(testimg_tiff_stripe_4096x4096_256)
+
+    level_count = cucim_img.resolutions['level_count']
+
+    start_pos, size = ((0, 10), (20, 30))
+    for level in range(level_count):
+        region_img = cucim_img.read_region(start_pos, size, level)
+        assert region_img.dtype == DLDataType(DLDataTypeCode.DLUInt, 8, 1)
+        assert np.dtype(region_img.typestr) == np.uint8
+
+
 def test_array_interface_support(testimg_tiff_stripe_32x24_16_jpeg):
     img = open_image_cucim(testimg_tiff_stripe_32x24_16_jpeg)
     whole_img = img.read_region()

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -130,6 +130,8 @@ PYBIND11_MODULE(_cucim, m)
              ) //
         .def_property(
             "dtype", &CuImage::dtype, nullptr, doc::CuImage::doc_dtype, py::call_guard<py::gil_scoped_release>()) //
+        .def_property("typestr", &CuImage::typestr, nullptr, doc::CuImage::doc_typestr,
+                      py::call_guard<py::gil_scoped_release>()) //
         .def_property("channel_names", &CuImage::channel_names, nullptr, doc::CuImage::doc_channel_names,
                       py::call_guard<py::gil_scoped_release>()) //
         .def("spacing", &CuImage::spacing, doc::CuImage::doc_spacing, py::call_guard<py::gil_scoped_release>(), //
@@ -345,6 +347,7 @@ json py_metadata(const CuImage& cuimg)
         cucim_metadata.emplace(
             "dtype", json::object({ { "code", dtype.code }, { "bits", dtype.bits }, { "lanes", dtype.lanes } }));
     }
+    cucim_metadata.emplace("typestr", cuimg.typestr());
     cucim_metadata.emplace("channel_names", cuimg.channel_names());
     cucim_metadata.emplace("spacing", cuimg.spacing());
     cucim_metadata.emplace("spacing_units", cuimg.spacing_units());

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <pybind11/numpy.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -93,11 +94,13 @@ PYBIND11_MODULE(_cucim, m)
         .def_readonly("code", &DLDataType::code, doc::DLDataType::doc_code, py::call_guard<py::gil_scoped_release>()) //
         .def_readonly("bits", &DLDataType::bits, doc::DLDataType::doc_bits, py::call_guard<py::gil_scoped_release>()) //
         .def_readonly("lanes", &DLDataType::lanes, doc::DLDataType::doc_lanes, py::call_guard<py::gil_scoped_release>()) //
+        .def(py::self == py::self) //
+        .def(py::self != py::self) //
         .def(
             "__repr__",
             [](const DLDataType& dtype) {
-                return fmt::format("<cucim.DLDataType code:{}({}) bits:{} lanes:{}>", g_dldata_typecode.at(dtype.code),
-                                   dtype.code, dtype.bits, dtype.lanes);
+                return fmt::format("<cucim.clara.DLDataType code:{}({}) bits:{} lanes:{}>",
+                                   g_dldata_typecode.at(dtype.code), dtype.code, dtype.bits, dtype.lanes);
             },
             py::call_guard<py::gil_scoped_release>());
 

--- a/python/pybind11/cucim_pydoc.h
+++ b/python/pybind11/cucim_pydoc.h
@@ -138,6 +138,14 @@ PYDOC(dtype, R"doc(
 The data type of the image.
 )doc")
 
+// DLDataType typestr() const;
+PYDOC(typestr, R"doc(
+The data type of the image in string format.
+
+The value can be converted to NumPy's dtype using `numpy.dtype()`.
+(e.g., `numpy.dtype(img.typestr)`).
+)doc")
+
 // std::vector<std::string> channel_names() const;
 PYDOC(channel_names, R"doc(
 A channel name list.


### PR DESCRIPTION
- Expose typestr property on CuImage object
- Expose DLDataType and DLDataTypeCode under cucim.clara

Without this patch,
DLDataType and DLDataTypecode can be accessible with the below workaround.

```python
>>> from cucim import CuImage
>>> a = CuImage("notebooks/input/image.tif")
>>> b = a.read_region((0,0), (10,10))
>>> import numpy as np
>>> np.dtype(b.__array_interface__["typestr"]) # b would expose `__cuda_array_interface__` if memory is in GPU.
dtype('uint8')
```

With this patch, we can convert data type to NumPy's dtype easily, and also can access cuCIM's DLDataType.

```python
>>> from cucim import CuImage
>>> a = CuImage("notebooks/input/image.tif")
>>> b = a.read_region((0,0), (10,10))
>>> import numpy as np
>>> b.typestr
'|u1'
>>> np.dtype(b.typestr) == np.uint8
True
>>> from cucim.clara import DLDataType, DLDataTypeCode
>>> b.dtype == DLDataType(DLDataTypeCode.DLUInt, 8, 1)
True
```

Fixes #243 



<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
