### PR TITLE
Fix ImportError from vendored code

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/utils.py
+++ b/python/cucim/src/cucim/skimage/_shared/utils.py
@@ -738,6 +738,11 @@ new_float_type = {
     cp.float16().dtype.char: cp.float32,
     'g': cp.float64,      # cp.float128 ; doesn't exist on windows
     'G': cp.complex128,   # cp.complex256 ; doesn't exist on windows
+    # int types where the full range can be represented exactly in float32
+    cp.int8: cp.float32,
+    cp.uint8: cp.float32,
+    cp.int16: cp.float32,
+    cp.uint16: cp.float32,
 }
 
 

--- a/python/cucim/src/cucim/skimage/_shared/utils.py
+++ b/python/cucim/src/cucim/skimage/_shared/utils.py
@@ -738,11 +738,6 @@ new_float_type = {
     cp.float16().dtype.char: cp.float32,
     'g': cp.float64,      # cp.float128 ; doesn't exist on windows
     'G': cp.complex128,   # cp.complex256 ; doesn't exist on windows
-    # int types where the full range can be represented exactly in float32
-    cp.int8: cp.float32,
-    cp.uint8: cp.float32,
-    cp.int16: cp.float32,
-    cp.uint16: cp.float32,
 }
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1,0 +1,17 @@
+"""A vendored subset of cupyx.scipy.ndimage._filters"""
+
+import numpy
+
+import cupy
+
+from cucim.skimage._vendored import _ndimage_filters_core as _filters_core
+
+
+@cupy.memoize(for_each_device=True)
+def _get_correlate_kernel(mode, w_shape, int_type, offsets, cval):
+    return _filters_core._generate_nd_kernel(
+        'correlate',
+        'W sum = (W)0;',
+        'sum += cast<W>({value}) * wval;',
+        'y = cast<Y>(sum);',
+        mode, w_shape, int_type, offsets, cval, ctype='W')

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -1,0 +1,159 @@
+"""A vendored subset of cupyx.scipy.ndimage._filters_core"""
+
+import warnings
+
+import numpy
+import cupy
+
+from cucim.skimage._vendored import _ndimage_util as _util
+from cucim.skimage._vendored._internal import _normalize_axis_index
+
+
+includes = r'''
+// workaround for HIP: line begins with #include
+#include <type_traits>  // let Jitify handle this
+#include <cupy/math_constants.h>
+'''
+
+
+_CAST_FUNCTION = """
+// Implements a casting function to make it compatible with scipy
+// Use like cast<to_type>(value)
+template<> struct std::is_floating_point<float16> : std::true_type {};
+template<> struct std::is_signed<float16> : std::true_type {};
+template<class T> struct std::is_signed<complex<T>> : std::is_signed<T> {};
+
+template <class B, class A>
+__device__ __forceinline__
+typename std::enable_if<(!std::is_floating_point<A>::value
+                         || std::is_signed<B>::value), B>::type
+cast(A a) { return (B)a; }
+
+template <class B, class A>
+__device__ __forceinline__
+typename std::enable_if<(std::is_floating_point<A>::value
+                         && (!std::is_signed<B>::value)), B>::type
+cast(A a) { return (a >= 0) ? (B)a : -(B)(-a); }
+
+template <class T>
+__device__ __forceinline__ bool nonzero(T x) { return x != static_cast<T>(0); }
+"""
+
+
+def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
+                        offsets, cval, ctype='X', preamble='', options=(),
+                        has_weights=True, has_structure=False, has_mask=False,
+                        binary_morphology=False, all_weights_nonzero=False):
+    # Currently this code uses CArray for weights but avoids using CArray for
+    # the input data and instead does the indexing itself since it is faster.
+    # If CArray becomes faster than follow the comments that start with
+    # CArray: to switch over to using CArray for the input data as well.
+
+    ndim = len(w_shape)
+    in_params = 'raw X x'
+    if has_weights:
+        in_params += ', raw W w'
+    if has_structure:
+        in_params += ', raw S s'
+    if has_mask:
+        in_params += ', raw M mask'
+    out_params = 'Y y'
+
+    # for filters, "wrap" is a synonym for "grid-wrap"
+    mode = 'grid-wrap' if mode == 'wrap' else mode
+
+    # CArray: remove xstride_{j}=... from string
+    size = ('%s xsize_{j}=x.shape()[{j}], ysize_{j} = _raw_y.shape()[{j}]'
+            ', xstride_{j}=x.strides()[{j}];' % int_type)
+    sizes = [size.format(j=j) for j in range(ndim)]
+    inds = _util._generate_indices_ops(ndim, int_type, offsets)
+    # CArray: remove expr entirely
+    expr = ' + '.join(['ix_{}'.format(j) for j in range(ndim)])
+
+    ws_init = ws_pre = ws_post = ''
+    if has_weights or has_structure:
+        ws_init = 'int iws = 0;'
+        if has_structure:
+            ws_pre = 'S sval = s[iws];\n'
+        if has_weights:
+            ws_pre += 'W wval = w[iws];\n'
+            if not all_weights_nonzero:
+                ws_pre += 'if (nonzero(wval))'
+        ws_post = 'iws++;'
+
+    loops = []
+    for j in range(ndim):
+        if w_shape[j] == 1:
+            # CArray: string becomes 'inds[{j}] = ind_{j};', remove (int_)type
+            loops.append('{{ {type} ix_{j} = ind_{j} * xstride_{j};'.
+                         format(j=j, type=int_type))
+        else:
+            boundary = _util._generate_boundary_condition_ops(
+                mode, 'ix_{}'.format(j), 'xsize_{}'.format(j), int_type)
+            # CArray: last line of string becomes inds[{j}] = ix_{j};
+            loops.append('''
+    for (int iw_{j} = 0; iw_{j} < {wsize}; iw_{j}++)
+    {{
+        {type} ix_{j} = ind_{j} + iw_{j};
+        {boundary}
+        ix_{j} *= xstride_{j};
+        '''.format(j=j, wsize=w_shape[j], boundary=boundary, type=int_type))
+
+    # CArray: string becomes 'x[inds]', no format call needed
+    value = '(*(X*)&data[{expr}])'.format(expr=expr)
+    if mode == 'constant':
+        cond = ' || '.join(['(ix_{} < 0)'.format(j) for j in range(ndim)])
+
+    if cval is numpy.nan:
+        cval = 'CUDART_NAN'
+    elif cval == numpy.inf:
+        cval = 'CUDART_INF'
+    elif cval == -numpy.inf:
+        cval = '-CUDART_INF'
+
+    if binary_morphology:
+        found = found.format(cond=cond, value=value)
+    else:
+        if mode == 'constant':
+            value = '(({cond}) ? cast<{ctype}>({cval}) : {value})'.format(
+                cond=cond, ctype=ctype, cval=cval, value=value)
+        found = found.format(value=value)
+
+    # CArray: replace comment and next line in string with
+    #   {type} inds[{ndim}] = {{0}};
+    # and add ndim=ndim, type=int_type to format call
+    operation = '''
+    {sizes}
+    {inds}
+    // don't use a CArray for indexing (faster to deal with indexing ourselves)
+    const unsigned char* data = (const unsigned char*)&x[0];
+    {ws_init}
+    {pre}
+    {loops}
+        // inner-most loop
+        {ws_pre} {{
+            {found}
+        }}
+        {ws_post}
+    {end_loops}
+    {post}
+    '''.format(sizes='\n'.join(sizes), inds=inds, pre=pre, post=post,
+               ws_init=ws_init, ws_pre=ws_pre, ws_post=ws_post,
+               loops='\n'.join(loops), found=found, end_loops='}'*ndim)
+
+    mode_str = mode.replace('-', '_')  # avoid potential hyphen in kernel name
+    name = 'cupyx_scipy_ndimage_{}_{}d_{}_w{}'.format(
+        name, ndim, mode_str, '_'.join(['{}'.format(x) for x in w_shape]))
+    if all_weights_nonzero:
+        name += '_all_nonzero'
+    if int_type == 'ptrdiff_t':
+        name += '_i64'
+    if has_structure:
+        name += '_with_structure'
+    if has_mask:
+        name += '_with_mask'
+    preamble = includes + _CAST_FUNCTION + preamble
+    options += ('--std=c++11', '-DCUPY_USE_JITIFY')
+    return cupy.ElementwiseKernel(in_params, out_params, operation, name,
+                                  reduce_dims=False, preamble=preamble,
+                                  options=options)

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
@@ -1,4 +1,58 @@
-"""Copy of private functions from CuPy's cupyx.scipy.ndimage._util"""
+"""A vendored subset of cupyx.scipy.ndimage._util"""
+
+
+def _get_output(output, input, shape=None, complex_output=False):
+    shape = input.shape if shape is None else shape
+    if output is None:
+        if complex_output:
+            _dtype = cupy.promote_types(input.dtype, cupy.complex64)
+        else:
+            _dtype = input.dtype
+        output = cupy.zeros(shape, dtype=_dtype)
+    elif isinstance(output, (type, cupy.dtype)):
+        if complex_output and cupy.dtype(output).kind != 'c':
+            warnings.warn("promoting specified output dtype to complex")
+            output = cupy.promote_types(output, cupy.complex64)
+        output = cupy.zeros(shape, dtype=output)
+    elif isinstance(output, str):
+        output = numpy.sctypeDict[output]
+        if complex_output and cupy.dtype(output).kind != 'c':
+            raise RuntimeError("output must have complex dtype")
+        output = cupy.zeros(shape, dtype=output)
+    elif output.shape != shape:
+        raise RuntimeError("output shape not correct")
+    elif complex_output and output.dtype.kind != 'c':
+        raise RuntimeError("output must have complex dtype")
+    return output
+
+
+def _fix_sequence_arg(arg, ndim, name, conv=lambda x: x):
+    if isinstance(arg, str):
+        return [conv(arg)] * ndim
+    try:
+        arg = iter(arg)
+    except TypeError:
+        return [conv(arg)] * ndim
+    lst = [conv(x) for x in arg]
+    if len(lst) != ndim:
+        msg = "{} must have length equal to input rank".format(name)
+        raise RuntimeError(msg)
+    return lst
+
+
+def _check_mode(mode):
+    if mode not in ('reflect', 'constant', 'nearest', 'mirror', 'wrap',
+                    'grid-mirror', 'grid-wrap', 'grid-reflect'):
+        msg = f'boundary mode not supported (actual: {mode})'
+        raise RuntimeError(msg)
+    return mode
+
+
+def _check_origin(origin, width):
+    origin = int(origin)
+    if (width // 2 + origin < 0) or (width // 2 + origin >= width):
+        raise ValueError('invalid origin')
+    return origin
 
 
 def _get_inttype(input):
@@ -9,3 +63,62 @@ def _get_inttype(input):
     nbytes = sum((x - 1) * abs(stride) for x, stride in
                  zip(input.shape, input.strides)) + input.dtype.itemsize
     return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
+
+
+def _generate_boundary_condition_ops(mode, ix, xsize, int_t="int",
+                                     float_ix=False):
+    min_func = "fmin" if float_ix else "min"
+    max_func = "fmax" if float_ix else "max"
+    if mode in ['reflect', 'grid-mirror']:
+        ops = '''
+        if ({ix} < 0) {{
+            {ix} = - 1 -{ix};
+        }}
+        {ix} %= {xsize} * 2;
+        {ix} = {min}({ix}, 2 * {xsize} - 1 - {ix});'''.format(
+            ix=ix, xsize=xsize, min=min_func)
+    elif mode == 'mirror':
+        ops = '''
+        if ({xsize} == 1) {{
+            {ix} = 0;
+        }} else {{
+            if ({ix} < 0) {{
+                {ix} = -{ix};
+            }}
+            {ix} = 1 + ({ix} - 1) % (({xsize} - 1) * 2);
+            {ix} = {min}({ix}, 2 * {xsize} - 2 - {ix});
+        }}'''.format(ix=ix, xsize=xsize, min=min_func)
+    elif mode == 'nearest':
+        ops = '''
+        {ix} = {min}({max}(({T}){ix}, ({T})0), ({T})({xsize} - 1));'''.format(
+            ix=ix, xsize=xsize, min=min_func, max=max_func,
+            # force using 64-bit signed integer for ptrdiff_t,
+            # see cupy/cupy#6048
+            T=('int' if int_t == 'int' else 'long long'))
+    elif mode == 'grid-wrap':
+        ops = '''
+        {ix} %= {xsize};
+        if ({ix} < 0) {{
+            {ix} += {xsize};
+        }}'''.format(ix=ix, xsize=xsize)
+    elif mode == 'wrap':
+        ops = '''
+        if ({ix} < 0) {{
+            {ix} += ({sz} - 1) * (({int_t})(-{ix} / ({sz} - 1)) + 1);
+        }} else if ({ix} > ({sz} - 1)) {{
+            {ix} -= ({sz} - 1) * ({int_t})({ix} / ({sz} - 1));
+        }};'''.format(ix=ix, sz=xsize, int_t=int_t)
+    elif mode in ['constant', 'grid-constant']:
+        ops = '''
+        if (({ix} < 0) || {ix} >= {xsize}) {{
+            {ix} = -1;
+        }}'''.format(ix=ix, xsize=xsize)
+    return ops
+
+
+def _generate_indices_ops(ndim, int_type, offsets):
+    code = '{type} ind_{j} = _i % ysize_{j} - {offset}; _i /= ysize_{j};'
+    body = [code.format(type=int_type, j=j, offset=offsets[j])
+            for j in range(ndim-1, 0, -1)]
+    return '{type} _i = i;\n{body}\n{type} ind_0 = _i - {offset};'.format(
+        type=int_type, body='\n'.join(body), offset=offsets[0])

--- a/python/cucim/src/cucim/skimage/_vendored/_signaltools_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_signaltools_core.py
@@ -1,9 +1,11 @@
+"""A vendored subset of cupyx.scipy.signal._signaltools_core"""
+
 import cupy
 from cupyx.scipy import fft
-from cupyx.scipy.ndimage import filters
 
 from . import _internal as internal
 from . import _ndimage_util as _util
+from cucim.skimage._vendored._ndimage_filters import _get_correlate_kernel
 
 
 def _check_conv_inputs(in1, in2, mode, convolution=True):
@@ -67,7 +69,7 @@ def _direct_correlate(in1, in2, mode='full', output=float, convolution=False,
 
     # Get and run the CuPy kernel
     int_type = _util._get_inttype(in1)
-    kernel = filters._get_correlate_kernel(
+    kernel = _get_correlate_kernel(
         boundary, in2.shape, int_type, offsets, fillvalue)
     in2 = _reverse_and_conj(in2) if convolution else in2
     if not swapped_inputs:

--- a/python/cucim/src/cucim/skimage/_vendored/signaltools.py
+++ b/python/cucim/src/cucim/skimage/_vendored/signaltools.py
@@ -1,3 +1,5 @@
+"""A vendored subset of cupyx.scipy.signal.signaltools"""
+
 import timeit
 import warnings
 
@@ -7,22 +9,9 @@ from cupyx.scipy.ndimage import uniform_filter, rank_filter
 
 from cucim import _misc
 from cucim.skimage._vendored import _signaltools_core as _st_core
+from cucim.skimage._vendored._ndimage_util import _fix_sequence_arg
 
 _prod = _misc.prod
-
-
-def _fix_sequence_arg(arg, ndim, name, conv=lambda x: x):
-    if isinstance(arg, str):
-        return [conv(arg)] * ndim
-    try:
-        arg = iter(arg)
-    except TypeError:
-        return [conv(arg)] * ndim
-    lst = [conv(x) for x in arg]
-    if len(lst) != ndim:
-        msg = "{} must have length equal to input rank".format(name)
-        raise RuntimeError(msg)
-    return lst
 
 
 def convolve(in1, in2, mode='full', method='auto'):

--- a/python/cucim/src/cucim/skimage/_vendored/signaltools.py
+++ b/python/cucim/src/cucim/skimage/_vendored/signaltools.py
@@ -3,7 +3,8 @@ import warnings
 
 import cupy
 import numpy as np
-from cupyx.scipy.ndimage import _util, filters
+from cupyx.scipy.ndimage import _util
+from cupyx.scipy.ndimage import uniform_filter, rank_filter
 
 from cucim import _misc
 from cucim.skimage._vendored import _signaltools_core as _st_core
@@ -611,10 +612,10 @@ def wiener(im, mysize=None, noise=None):
     im = im.astype(float, copy=False)
 
     # Estimate the local mean
-    local_mean = filters.uniform_filter(im, mysize, mode='constant')
+    local_mean = uniform_filter(im, mysize, mode='constant')
 
     # Estimate the local variance
-    local_var = filters.uniform_filter(im * im, mysize, mode='constant')
+    local_var = uniform_filter(im * im, mysize, mode='constant')
     local_var -= local_mean * local_mean
 
     # Estimate the noise power if needed.
@@ -657,7 +658,7 @@ def order_filter(a, domain, rank):
     if any(x % 2 != 1 for x in domain.shape):
         raise ValueError("Each dimension of domain argument "
                          " should have an odd number of elements.")
-    return filters.rank_filter(a, rank, footprint=domain, mode='constant')
+    return rank_filter(a, rank, footprint=domain, mode='constant')
 
 
 def medfilt(volume, kernel_size=None):
@@ -682,7 +683,7 @@ def medfilt(volume, kernel_size=None):
     """
     if volume.dtype.kind == 'c':
         # scipy doesn't support complex
-        # (and filters.rank_filter raise TypeError)
+        # (and rank_filter raise TypeError)
         raise ValueError("complex types not supported")
     # output is forced to float64 to match scipy
     kernel_size = _get_kernel_size(kernel_size, volume.ndim)
@@ -691,7 +692,7 @@ def medfilt(volume, kernel_size=None):
                       'volume will be zero-padded')
 
     size = np.prod(kernel_size)
-    return filters.rank_filter(volume, size // 2, size=kernel_size,
+    return rank_filter(volume, size // 2, size=kernel_size,
                                output=float, mode='constant')
 
 
@@ -725,7 +726,7 @@ def medfilt2d(input, kernel_size=3):
         raise ValueError('input must be 2d')
     kernel_size = _get_kernel_size(kernel_size, input.ndim)
     order = kernel_size[0] * kernel_size[1] // 2
-    return filters.rank_filter(input, order, size=kernel_size, mode='constant')
+    return rank_filter(input, order, size=kernel_size, mode='constant')
 
 
 def _get_kernel_size(kernel_size, ndim):

--- a/python/cucim/src/cucim/skimage/_vendored/signaltools.py
+++ b/python/cucim/src/cucim/skimage/_vendored/signaltools.py
@@ -1,4 +1,10 @@
-"""A vendored subset of cupyx.scipy.signal.signaltools"""
+"""A vendored subset of cupyx.scipy.signal.signaltools
+
+Note:
+
+The version of ``choose_conv_method`` here differs from the one in CuPy and
+does not restrict the choice of fftconvolve to only 1D arrays.
+"""
 
 import timeit
 import warnings


### PR DESCRIPTION
closes #251 by avoiding imports from private CuPy code

The new files here are just subsets of files present in CuPy that are not part of its public API. Only a few functions use functionality from thi`s `_vendored` folder.

The whole folder is mainly here in order to have a version of `cupyx.scipy.signal.fftconvolve` with a modified `choose_conv_mode`. We should eventually just update the convolution selection code in CuPy so that we can remove these files.

I think `fftconvolve` itself was not present at all in CuPy 9.x, but even in the current development branch, the [convolution choice function is still restricted to 1D](https://github.com/cupy/cupy/blob/ec6d2c9a98440b19a133868576fb299972c21f6c/cupy/_math/misc.py#L23-L25)
