### PR TITLE
Fix: return object-typed properties as NumPy arrays in `skimage.measure.regionprops_table`

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops.py
@@ -84,11 +84,6 @@ PROPS = {
     'weighted_moments_normalized': 'moments_weighted_normalized',
 }
 
-OBJECT_COLUMNS = {
-    'image', 'coords', 'image_convex', 'slice',
-    'image_filled', 'image_intensity'
-}
-
 COL_DTYPES = {
     'area': int,
     'area_bbox': int,
@@ -131,6 +126,8 @@ COL_DTYPES = {
     'slice': object,
     'solidity': float,
 }
+
+OBJECT_COLUMNS = [col for col, dtype in COL_DTYPES.items() if dtype == object]
 
 PROP_VALS = set(PROPS.values())
 

--- a/python/cucim/src/cucim/skimage/measure/_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops.py
@@ -818,18 +818,16 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
             or prop in OBJECT_COLUMNS
             or dtype is np.object_
         ):
-            if prop == 'slice':
-                # keep slice objects in a NumPy array
+            if prop in OBJECT_COLUMNS:
+                # keep objects in a NumPy array
                 column_buffer = np.empty(n, dtype=dtype)
                 for i in range(n):
                     column_buffer[i] = regions[i][prop]
                 out[orig_prop] = np.copy(column_buffer)
             else:
-                column_buffer = []
+                column_buffer = cp.empty(n, dtype=dtype)
                 for i in range(n):
-                    p = regions[i][prop]
-                    column_buffer.append(p)
-                column_buffer = cp.array(column_buffer)
+                    column_buffer[i] = regions[i][prop]
                 out[orig_prop] = column_buffer
         else:
             if isinstance(rp, cp.ndarray):

--- a/python/cucim/src/cucim/skimage/measure/_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops.py
@@ -825,9 +825,11 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
                     column_buffer[i] = regions[i][prop]
                 out[orig_prop] = np.copy(column_buffer)
             else:
-                column_buffer = cp.empty(n, dtype=dtype)
+                column_buffer = []
                 for i in range(n):
-                    column_buffer[i] = regions[i][prop]
+                    p = regions[i][prop]
+                    column_buffer.append(p)
+                column_buffer = cp.array(column_buffer)
                 out[orig_prop] = column_buffer
         else:
             if isinstance(rp, cp.ndarray):

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -604,7 +604,7 @@ def test_props_to_dict():
     regions = regionprops(SAMPLE_MULTIPLE)
     out = _props_to_dict(regions, properties=('coords',))
     coords = np.empty(2, object)
-    coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
+    coords[0] = cp.stack((cp.arange(10),) * 2, axis=-1)
     coords[1] = cp.array([[3, 7], [4, 7]])
     assert out['coords'].shape == coords.shape
     assert_array_equal(out['coords'][0], coords[0])
@@ -625,7 +625,7 @@ def test_regionprops_table():
 
     out = regionprops_table(SAMPLE_MULTIPLE, properties=('coords',))
     coords = np.empty(2, object)
-    coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
+    coords[0] = cp.stack((cp.arange(10),) * 2, axis=-1)
     coords[1] = cp.array([[3, 7], [4, 7]])
     assert out['coords'].shape == coords.shape
     assert_array_equal(out['coords'][0], coords[0])

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -601,6 +601,15 @@ def test_props_to_dict():
                    'bbox+0': cp.array([0]), 'bbox+1': cp.array([0]),
                    'bbox+2': cp.array([10]), 'bbox+3': cp.array([18])}
 
+    regions = regionprops(SAMPLE_MULTIPLE)
+    out = _props_to_dict(regions, properties=['coords'])
+    coords = np.empty(2, object)
+    coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
+    coords[1] = cp.array([[3, 7], [4, 7]])
+    assert out['coords'].shape == coords.shape
+    assert_array_equal(out['coords'][0], coords[0])
+    assert_array_equal(out['coords'][1], coords[1])
+
 
 def test_regionprops_table():
     out = regionprops_table(SAMPLE)
@@ -613,6 +622,14 @@ def test_regionprops_table():
     assert out == {'label': cp.array([1]), 'area': cp.array([72]),
                    'bbox+0': cp.array([0]), 'bbox+1': cp.array([0]),
                    'bbox+2': cp.array([10]), 'bbox+3': cp.array([18])}
+    
+    out = regionprops_table(SAMPLE_MULTIPLE, properties=['coords'])
+    coords = np.empty(2, object)
+    coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
+    coords[1] = cp.array([[3, 7], [4, 7]])
+    assert out['coords'].shape == coords.shape
+    assert_array_equal(out['coords'][0], coords[0])
+    assert_array_equal(out['coords'][1], coords[1])
 
 
 def test_regionprops_table_deprecated_vector_property():

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -602,7 +602,7 @@ def test_props_to_dict():
                    'bbox+2': cp.array([10]), 'bbox+3': cp.array([18])}
 
     regions = regionprops(SAMPLE_MULTIPLE)
-    out = _props_to_dict(regions, properties=['coords'])
+    out = _props_to_dict(regions, properties=('coords',))
     coords = np.empty(2, object)
     coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
     coords[1] = cp.array([[3, 7], [4, 7]])
@@ -622,8 +622,8 @@ def test_regionprops_table():
     assert out == {'label': cp.array([1]), 'area': cp.array([72]),
                    'bbox+0': cp.array([0]), 'bbox+1': cp.array([0]),
                    'bbox+2': cp.array([10]), 'bbox+3': cp.array([18])}
-    
-    out = regionprops_table(SAMPLE_MULTIPLE, properties=['coords'])
+
+    out = regionprops_table(SAMPLE_MULTIPLE, properties=('coords',))
     coords = np.empty(2, object)
     coords[0] = cp.array((cp.arange(10), cp.arange(10))).T
     coords[1] = cp.array([[3, 7], [4, 7]])


### PR DESCRIPTION
This PR fixes adding properties whose results are objects to the dictionary that is returned by `skimage.measure.regionprops_table`.

Minimal example reproducing the issue:
```python
from cucim.skimage.measure import regionprops_table

SAMPLE_MULTIPLE = cp.eye(10, dtype=cp.int32)
SAMPLE_MULTIPLE[3:5, 7:8] = 2

props = regionprops_table(SAMPLE_MULTIPLE, properties=['coords'])
```

raises `TypeError: Implicit conversion to a NumPy array is not allowed.`, while returning correct values is expected (also see modified unit tests).

For some reason, only `slice` property was [checked for](https://github.com/rapidsai/cucim/pull/272/commits/380bcc27584a7b4ec5dc2d27f98dd9b9d9433a70#diff-0019b8f1fc21c156da7d64a20335392909b847c2bf6f4cb115915065ce8353e5L821), although the list of such properties already exists in `OBJECT_COLUMNS`.