### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/conda_build_config.yaml
+++ b/conda/recipes/cucim/conda_build_config.yaml
@@ -1,4 +1,8 @@
 c_compiler_version:
-  - 9.3
+  - 9
+
 cxx_compiler_version:
-  - 9.3
+  - 9
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -17,17 +17,14 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda_{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   build:
     - cmake >=3.18.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - sysroot_linux-64 2.17
+    - sysroot_linux-64 {{ sysroot_version }} # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }} # [aarch64]
   host:
     - cudatoolkit {{ cuda_version }}.*
     - python {{ python_version }}.*

--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -1,4 +1,8 @@
 c_compiler_version:
-  - 9.3
+  - 9
+
 cxx_compiler_version:
-  - 9.3
+  - 9
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -16,17 +16,14 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   build:
     - cmake >=3.18.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - sysroot_linux-64 2.17
+    - sysroot_linux-64 {{ sysroot_version }} # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }} # [aarch64]
     - yasm # [x86_64]
   host:
     - cudatoolkit {{ cuda_version }}.*


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.