### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -23,8 +23,7 @@ requirements:
     - cmake >=3.18.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - sysroot_linux-64 {{ sysroot_version }} # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }} # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*
     - python {{ python_version }}.*

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -22,8 +22,7 @@ requirements:
     - cmake >=3.18.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - sysroot_linux-64 {{ sysroot_version }} # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }} # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
     - yasm # [x86_64]
   host:
     - cudatoolkit {{ cuda_version }}.*


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.