### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 ######################################
 # ucx-py CPU conda build script for CI #
 ######################################
@@ -60,6 +60,9 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
+# FIXME: Remove
+gpuci_mamba_retry install -c conda-forge boa
+
 ################################################################################
 # BUILD - Conda package builds (conda deps: libcucim)
 ################################################################################
@@ -73,7 +76,7 @@ conda config --set ssl_verify False
 #          /opt/conda/envs/rapids/lib
 
 if [ "$BUILD_LIBCUCIM" == 1 ]; then
-  gpuci_conda_retry build -c conda-forge -c rapidsai-nightly \
+  gpuci_conda_retry mambabuild -c conda-forge -c rapidsai-nightly \
     --dirty \
     --no-remove-work-dir \
     --no-build-id \
@@ -89,7 +92,7 @@ if [ "$BUILD_CUCIM" == 1 ]; then
   # Set libcucim conda build folder for CPU build
   export LIBCUCIM_BLD_PATH=${WORKSPACE}/ci/artifacts/cucim/cpu/.conda-bld
 
-  gpuci_conda_retry build -c ${LIBCUCIM_BLD_PATH} -c conda-forge -c rapidsai-nightly \
+  gpuci_conda_retry mambabuild -c ${LIBCUCIM_BLD_PATH} -c conda-forge -c rapidsai-nightly \
     --python=${PYTHON_VER} \
     --dirty \
     --no-remove-work-dir \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #########################################
 # ucx-py GPU build and test script for CI #
 #########################################
@@ -64,7 +64,9 @@ LIBCUCIM_BLD_PATH=$WORKSPACE/ci/artifacts/cucim/cpu/.conda-bld
 CUCIM_BLD_PATH=/opt/conda/envs/rapids/conda-bld
 mkdir -p ${CUCIM_BLD_PATH}
 
-gpuci_mamba_retry build -c ${LIBCUCIM_BLD_PATH} -c conda-forge -c rapidsai-nightly \
+# TODO: Move boa install to gpuci/rapidsai
+gpuci_mamba_retry install -c conda-forge boa
+gpuci_conda_retry mambabuild -c ${LIBCUCIM_BLD_PATH} -c conda-forge -c rapidsai-nightly \
     --dirty \
     --no-remove-work-dir \
     --croot ${CUCIM_BLD_PATH} \


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.