### PR TITLE
Remove logging from digital pathology transforms

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/jitter.py
+++ b/python/cucim/src/cucim/core/operations/color/jitter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import numbers
 from typing import Any, List, Optional, Tuple
 
@@ -21,8 +20,168 @@ import numpy as np
 
 from .kernel.cuda_kernel_source import cuda_kernel_code
 
-_logger = logging.getLogger("colorjitter_cucim")
 CUDA_KERNELS = cupy.RawModule(code=cuda_kernel_code)
+
+
+def _check_input(value, name, center=1, bound=(0, float('inf')),
+                 clip_first_on_zero=True):
+    if isinstance(value, numbers.Number):
+        if value < 0:
+            raise ValueError("If {} is a single number, \
+                             it must be non negative.".format(name))
+        value = [center - float(value), center + float(value)]
+        if clip_first_on_zero:
+            value[0] = max(value[0], 0.0)
+    elif isinstance(value, (tuple, list)) and len(value) == 2:
+        if not bound[0] <= value[0] <= value[1] <= bound[1]:
+            raise ValueError("{} values should be between {}"
+                             .format(name, bound))
+    else:
+        raise TypeError("{} should be a single number or a \
+                        list/tuple with length 2.".format(name))
+    # if value is 0 or (1., 1.) for brightness/contrast/saturation
+    # or (0., 0.) for hue, do nothing
+    if value[0] == value[1] == center:
+        value = None
+    return value
+
+
+def _get_params(brightness: Optional[List[float]],
+                contrast: Optional[List[float]],
+                saturation: Optional[List[float]],
+                hue: Optional[List[float]]
+                ) -> Tuple[np.ndarray, Optional[float],
+                           Optional[float], Optional[float],
+                           Optional[float]]:
+
+    fn_idx = np.random.permutation(4)
+
+    b = None
+    if brightness is not None:
+        b = float(np.random.uniform(brightness[0], brightness[1]))
+    c = None
+    if contrast is not None:
+        c = float(np.random.uniform(contrast[0], contrast[1]))
+    s = None
+    if saturation is not None:
+        s = float(np.random.uniform(saturation[0], saturation[1]))
+    h = None
+    if hue is not None:
+        h = float(np.random.uniform(hue[0], hue[1]))
+
+    return fn_idx, b, c, s, h
+
+
+# brightness jitter
+def _adjust_brightness(input_arr, brightness):
+    if len(input_arr.shape) == 4:
+        N, C, H, W = input_arr.shape
+    elif len(input_arr.shape) == 3:
+        C, H, W = input_arr.shape
+        N = 1
+
+    block = (128, 1, 1)
+    length = N * C * H * W
+    length = (length + 1) >> 2
+    grid = (int((length - 1) / block[0] + 1) , 1, 1)
+
+    result = cupy.ndarray(shape=input_arr.shape,
+                          dtype=input_arr.dtype)
+    kernel = CUDA_KERNELS.get_function("brightnessjitter_kernel")
+    kernel(grid, block, args=(input_arr,
+                              result,
+                              np.int32(N * C * H * W),
+                              np.float32(brightness)))
+    return result
+
+
+# contrast jitter
+def _adjust_contrast(input_arr, contrast):
+    # contrast: 0.0 grey image, 1.0 original image
+    # out RGB -> Grey
+    # new image with mean L, convert to RGB
+    # L -> RGB is just replicating L values across all channels
+    # blend again as LHS
+
+    if len(input_arr.shape) == 4:
+        N, C, H, W = input_arr.shape
+    elif len(input_arr.shape) == 3:
+        C, H, W = input_arr.shape
+        N = 1
+    block = (128, 1, 1)
+    pitch = W * H
+    grid = (int((pitch - 1) / block[0] + 1) , N, 1)
+
+    output_L32 = cupy.empty((N, H, W), dtype=cupy.uint32)
+    kernel_rgb2l = CUDA_KERNELS.get_function("rgb2l_kernel")
+    kernel_rgb2l(grid, block, args=(input_arr,
+                                    output_L32,
+                                    np.int32(pitch)))
+
+    L32_mean = output_L32.mean(axis=[1, 2], dtype=cupy.float32)
+
+    if len(input_arr.shape) == 3:
+        output_rgb = cupy.empty((C, H, W), dtype=cupy.uint8)
+    else:
+        output_rgb = cupy.empty((N, C, H, W), dtype=cupy.uint8)
+    kernel_blendconstant = \
+        CUDA_KERNELS.get_function("blendconstant_kernel")
+    kernel_blendconstant(grid, block, args=(input_arr,
+                                            output_rgb,
+                                            np.int32(pitch),
+                                            L32_mean,
+                                            np.float32(contrast)))
+
+    return output_rgb
+
+
+# saturation jitter
+def _adjust_saturation(input_arr, saturation):
+    # saturation (color enhance) 0.0 b/w image
+    if len(input_arr.shape) == 4:
+        N, C, H, W = input_arr.shape
+    elif len(input_arr.shape) == 3:
+        C, H, W = input_arr.shape
+        N = 1
+
+    pitch = W * H
+    block = (128, 1, 1)
+    grid = (int((pitch - 1) / block[0] + 1), N, 1)
+
+    output_rgb = cupy.empty(input_arr.shape, dtype=cupy.uint8)
+    kernel_satjitter = \
+        CUDA_KERNELS.get_function("saturationjitter_kernel")
+    kernel_satjitter(grid, block, args=(input_arr,
+                                        output_rgb,
+                                        np.int32(pitch),
+                                        np.float32(saturation)))
+
+    return output_rgb
+
+
+# hue jitter
+def _adjust_hue(input_arr, hue):
+    if not(-0.5 <= hue <= 0.5):
+        raise ValueError('hue factor({}) is not in [-0.5, 0.5].'.
+                         format(hue))
+
+    if len(input_arr.shape) == 4:
+        N, C, H, W = input_arr.shape
+    elif len(input_arr.shape) == 3:
+        C, H, W = input_arr.shape
+        N = 1
+
+    pitch = W * H
+    block = (128, 1, 1)
+    grid = (int((pitch - 1) / block[0] + 1), N, 1)
+    output_rgb = cupy.empty(input_arr.shape, dtype=cupy.uint8)
+    kernel_huejitter = CUDA_KERNELS.get_function("huejitter_kernel")
+    kernel_huejitter(grid, block, args=(input_arr,
+                                        output_rgb,
+                                        np.int32(pitch),
+                                        np.float32(hue)))
+
+    return output_rgb
 
 
 def color_jitter(
@@ -83,221 +242,62 @@ def color_jitter(
     >>> # input is channel first 3d array
     >>> output_array = ccl.color_jitter(input_arr,.25,.75,.25,.04)
     """
-    try:
-        # should be a class stateful implementation to caches values
-        # once instead of checking every time
-        def check_input(value, name, center=1, bound=(0, float('inf')),
-                        clip_first_on_zero=True):
-            if isinstance(value, numbers.Number):
-                if value < 0:
-                    raise ValueError("If {} is a single number, \
-                                     it must be non negative.".format(name))
-                value = [center - float(value), center + float(value)]
-                if clip_first_on_zero:
-                    value[0] = max(value[0], 0.0)
-            elif isinstance(value, (tuple, list)) and len(value) == 2:
-                if not bound[0] <= value[0] <= value[1] <= bound[1]:
-                    raise ValueError("{} values should be between {}"
-                                     .format(name, bound))
-            else:
-                raise TypeError("{} should be a single number or a \
-                                list/tuple with length 2.".format(name))
-            # if value is 0 or (1., 1.) for brightness/contrast/saturation
-            # or (0., 0.) for hue, do nothing
-            if value[0] == value[1] == center:
-                value = None
-            return value
+    # TODO: should be a class stateful implementation to caches values
+    #       once instead of checking every time
 
-        def get_params(brightness: Optional[List[float]],
-                       contrast: Optional[List[float]],
-                       saturation: Optional[List[float]],
-                       hue: Optional[List[float]]
-                       ) -> Tuple[np.ndarray, Optional[float],
-                                  Optional[float], Optional[float],
-                                  Optional[float]]:
+    # execution
+    f_brightness = _check_input(brightness, 'brightness')
+    f_contrast = _check_input(contrast, 'contrast')
+    f_saturation = _check_input(saturation, 'saturation')
+    f_hue = _check_input(hue, 'hue', center=0, bound=(-0.5, 0.5),
+                         clip_first_on_zero=False)
 
-            fn_idx = np.random.permutation(4)
+    to_cupy = False
 
-            b = None
-            if brightness is not None:
-                b = float(np.random.uniform(brightness[0], brightness[1]))
-            c = None
-            if contrast is not None:
-                c = float(np.random.uniform(contrast[0], contrast[1]))
-            s = None
-            if saturation is not None:
-                s = float(np.random.uniform(saturation[0], saturation[1]))
-            h = None
-            if hue is not None:
-                h = float(np.random.uniform(hue[0], hue[1]))
+    if isinstance(img, np.ndarray):
+        to_cupy = True
+        cupy_img = cupy.asarray(img, dtype=cupy.uint8, order="C")
+    elif not isinstance(img, cupy.ndarray):
+        raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    else:
+        cupy_img = cupy.ascontiguousarray(img)
 
-            return fn_idx, b, c, s, h
-
-        # brightness jitter
-        def adjust_brightness(input_arr, brightness):
-            if len(input_arr.shape) == 4:
-                N, C, H, W = input_arr.shape
-            elif len(input_arr.shape) == 3:
-                C, H, W = input_arr.shape
-                N = 1
-
-            block = (128, 1, 1)
-            length = N * C * H * W
-            length = (length + 1) >> 2
-            grid = (int((length - 1) / block[0] + 1) , 1, 1)
-
-            result = cupy.ndarray(shape=input_arr.shape,
-                                  dtype=input_arr.dtype)
-            kernel = CUDA_KERNELS.get_function("brightnessjitter_kernel")
-            kernel(grid, block, args=(input_arr,
-                                      result,
-                                      np.int32(N * C * H * W),
-                                      np.float32(brightness)))
-            return result
-
-        # contrast jitter
-        def adjust_contrast(input_arr, contrast):
-            # contrast: 0.0 grey image, 1.0 original image
-            # out RGB -> Grey
-            # new image with mean L, convert to RGB
-            # L -> RGB is just replicating L values across all channels
-            # blend again as LHS
-
-            if len(input_arr.shape) == 4:
-                N, C, H, W = input_arr.shape
-            elif len(input_arr.shape) == 3:
-                C, H, W = input_arr.shape
-                N = 1
-            block = (128, 1, 1)
-            pitch = W * H
-            grid = (int((pitch - 1) / block[0] + 1) , N, 1)
-
-            output_L32 = cupy.empty((N, H, W), dtype=cupy.uint32)
-            kernel_rgb2l = CUDA_KERNELS.get_function("rgb2l_kernel")
-            kernel_rgb2l(grid, block, args=(input_arr,
-                                            output_L32,
-                                            np.int32(pitch)))
-
-            L32_mean = output_L32.mean(axis=[1, 2], dtype=cupy.float32)
-
-            if len(input_arr.shape) == 3:
-                output_rgb = cupy.empty((C, H, W), dtype=cupy.uint8)
-            else:
-                output_rgb = cupy.empty((N, C, H, W), dtype=cupy.uint8)
-            kernel_blendconstant = \
-                CUDA_KERNELS.get_function("blendconstant_kernel")
-            kernel_blendconstant(grid, block, args=(input_arr,
-                                                    output_rgb,
-                                                    np.int32(pitch),
-                                                    L32_mean,
-                                                    np.float32(contrast)))
-
-            return output_rgb
-
-        # saturation jitter
-        def adjust_saturation(input_arr, saturation):
-            # saturation (color enhance) 0.0 b/w image
-            if len(input_arr.shape) == 4:
-                N, C, H, W = input_arr.shape
-            elif len(input_arr.shape) == 3:
-                C, H, W = input_arr.shape
-                N = 1
-
-            pitch = W * H
-            block = (128, 1, 1)
-            grid = (int((pitch - 1) / block[0] + 1), N, 1)
-
-            output_rgb = cupy.empty(input_arr.shape, dtype=cupy.uint8)
-            kernel_satjitter = \
-                CUDA_KERNELS.get_function("saturationjitter_kernel")
-            kernel_satjitter(grid, block, args=(input_arr,
-                                                output_rgb,
-                                                np.int32(pitch),
-                                                np.float32(saturation)))
-
-            return output_rgb
-
-        # hue jitter
-        def adjust_hue(input_arr, hue):
-            if not(-0.5 <= hue <= 0.5):
-                raise ValueError('hue factor({}) is not in [-0.5, 0.5].'.
-                                 format(hue))
-
-            if len(input_arr.shape) == 4:
-                N, C, H, W = input_arr.shape
-            elif len(input_arr.shape) == 3:
-                C, H, W = input_arr.shape
-                N = 1
-
-            pitch = W * H
-            block = (128, 1, 1)
-            grid = (int((pitch - 1) / block[0] + 1), N, 1)
-            output_rgb = cupy.empty(input_arr.shape, dtype=cupy.uint8)
-            kernel_huejitter = CUDA_KERNELS.get_function("huejitter_kernel")
-            kernel_huejitter(grid, block, args=(input_arr,
-                                                output_rgb,
-                                                np.int32(pitch),
-                                                np.float32(hue)))
-
-            return output_rgb
-
-        # execution
-        f_brightness = check_input(brightness, 'brightness')
-        f_contrast = check_input(contrast, 'contrast')
-        f_saturation = check_input(saturation, 'saturation')
-        f_hue = check_input(hue, 'hue', center=0, bound=(-0.5, 0.5),
-                            clip_first_on_zero=False)
-
-        to_cupy = False
-
-        if isinstance(img, np.ndarray):
-            to_cupy = True
-            cupy_img = cupy.asarray(img, dtype=cupy.uint8, order="C")
-        elif not isinstance(img, cupy.ndarray):
-            raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
-        else:
-            cupy_img = cupy.ascontiguousarray(img)
-
-        if cupy_img.dtype != cupy.uint8:
-            if cupy.can_cast(cupy_img.dtype, cupy.uint8, 'unsafe') is False:
-                raise ValueError(
-                    "Cannot cast type {cupy_img.dtype.name} to 'uint8'"
-                )
-            else:
-                cupy_img = cupy_img.astype(cupy.uint8)
-
-        if img.ndim not in (3, 4):
+    if cupy_img.dtype != cupy.uint8:
+        if cupy.can_cast(cupy_img.dtype, cupy.uint8, 'unsafe') is False:
             raise ValueError(
-                f"Unsupported img.ndim={img.ndim}. Expected `img` with "
-                "dimensions (C, H, W) or (N, C, H, W)."
+                "Cannot cast type {cupy_img.dtype.name} to 'uint8'"
             )
+        else:
+            cupy_img = cupy_img.astype(cupy.uint8)
 
-        fn_idx, brightness_factor, contrast_factor, saturation_factor, \
-            hue_factor = get_params(f_brightness, f_contrast,
-                                    f_saturation, f_hue)
+    if img.ndim not in (3, 4):
+        raise ValueError(
+            f"Unsupported img.ndim={img.ndim}. Expected `img` with "
+            "dimensions (C, H, W) or (N, C, H, W)."
+        )
 
-        for fn_id in fn_idx:
-            if fn_id == 0 and brightness_factor is not None:
-                cupy_img = adjust_brightness(cupy_img, brightness_factor)
-            elif fn_id == 1 and contrast_factor is not None:
-                cupy_img = adjust_contrast(cupy_img, contrast_factor)
-            elif fn_id == 2 and saturation_factor is not None:
-                cupy_img = adjust_saturation(cupy_img, saturation_factor)
-            elif fn_id == 3 and hue_factor is not None:
-                cupy_img = adjust_hue(cupy_img, hue_factor)
+    fn_idx, brightness_factor, contrast_factor, saturation_factor, \
+        hue_factor = _get_params(f_brightness, f_contrast,
+                                 f_saturation, f_hue)
 
-        if img.dtype != np.uint8:
-            cupy_img = cupy_img.astype(cupy.float32)
+    for fn_id in fn_idx:
+        if fn_id == 0 and brightness_factor is not None:
+            cupy_img = _adjust_brightness(cupy_img, brightness_factor)
+        elif fn_id == 1 and contrast_factor is not None:
+            cupy_img = _adjust_contrast(cupy_img, contrast_factor)
+        elif fn_id == 2 and saturation_factor is not None:
+            cupy_img = _adjust_saturation(cupy_img, saturation_factor)
+        elif fn_id == 3 and hue_factor is not None:
+            cupy_img = _adjust_hue(cupy_img, hue_factor)
 
-        result = cupy_img
-        if to_cupy is True:
-            result = cupy.asnumpy(cupy_img)
+    if img.dtype != np.uint8:
+        cupy_img = cupy_img.astype(cupy.float32)
 
-        return result
-    except Exception as e:
-        _logger.error("[cucim] " + str(e), exc_info=True)
-        _logger.info("Error executing color jitter on GPU")
-        raise
+    result = cupy_img
+    if to_cupy is True:
+        result = cupy.asnumpy(cupy_img)
+
+    return result
 
 
 def rand_color_jitter(

--- a/python/cucim/src/cucim/core/operations/color/jitter.py
+++ b/python/cucim/src/cucim/core/operations/color/jitter.py
@@ -252,10 +252,9 @@ def color_jitter(
     f_hue = _check_input(hue, 'hue', center=0, bound=(-0.5, 0.5),
                          clip_first_on_zero=False)
 
-    to_cupy = False
-
+    to_numpy = False
     if isinstance(img, np.ndarray):
-        to_cupy = True
+        to_numpy = True
         cupy_img = cupy.asarray(img, dtype=cupy.uint8, order="C")
     elif not isinstance(img, cupy.ndarray):
         raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
@@ -294,7 +293,7 @@ def color_jitter(
         cupy_img = cupy_img.astype(cupy.float32)
 
     result = cupy_img
-    if to_cupy is True:
+    if to_numpy:
         result = cupy.asnumpy(cupy_img)
 
     return result

--- a/python/cucim/src/cucim/core/operations/expose/transform.py
+++ b/python/cucim/src/cucim/core/operations/expose/transform.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cucim.core.operations.color import color_jitter, rand_color_jitter
-from cucim.core.operations.intensity import (normalize_data, rand_zoom,
+from cucim.core.operations.color import color_jitter, rand_color_jitter  # noqa
+from cucim.core.operations.intensity import (normalize_data, rand_zoom,  # noqa
                                              scale_intensity_range, zoom)
-from cucim.core.operations.spatial import (image_flip, image_rotate_90,
+from cucim.core.operations.spatial import (image_flip, image_rotate_90,  # noqa
                                            rand_image_flip,
                                            rand_image_rotate_90)

--- a/python/cucim/src/cucim/core/operations/intensity/scaling.py
+++ b/python/cucim/src/cucim/core/operations/intensity/scaling.py
@@ -73,10 +73,9 @@ def scale_intensity_range(
     if a_max - a_min == 0.0:
         raise ValueError("Original intensity range min and max are same")
 
-    to_cupy = False
-
+    to_numpy = False
     if isinstance(img, np.ndarray):
-        to_cupy = True
+        to_numpy = True
         cupy_img = cupy.asarray(img, dtype=cupy.float32, order='C')
     elif not isinstance(img, cupy.ndarray):
         raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
@@ -115,7 +114,7 @@ def scale_intensity_range(
     if img.dtype != cupy.float32:
         result = result.astype(img.dtype)
 
-    if to_cupy is True:
+    if to_numpy:
         result = cupy.asnumpy(result)
 
     return result

--- a/python/cucim/src/cucim/core/operations/intensity/scaling.py
+++ b/python/cucim/src/cucim/core/operations/intensity/scaling.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Any
 
 import cupy
@@ -21,7 +20,6 @@ import numpy as np
 from .kernel.cuda_kernel_source import cuda_kernel_code
 
 CUDA_KERNELS = cupy.RawModule(code=cuda_kernel_code)
-_logger = logging.getLogger("scaling_cucim")
 
 
 def scale_intensity_range(
@@ -72,57 +70,52 @@ def scale_intensity_range(
                                                  0.0, 255.0,
                                                  -1.0, 1.0, False)
     """
-    try:
-        if a_max - a_min == 0.0:
-            raise ValueError("Original intensity range min and max are same")
+    if a_max - a_min == 0.0:
+        raise ValueError("Original intensity range min and max are same")
 
-        to_cupy = False
+    to_cupy = False
 
-        if isinstance(img, np.ndarray):
-            to_cupy = True
-            cupy_img = cupy.asarray(img, dtype=cupy.float32, order='C')
-        elif not isinstance(img, cupy.ndarray):
-            raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    if isinstance(img, np.ndarray):
+        to_cupy = True
+        cupy_img = cupy.asarray(img, dtype=cupy.float32, order='C')
+    elif not isinstance(img, cupy.ndarray):
+        raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    else:
+        cupy_img = cupy.ascontiguousarray(img)
+
+    if cupy_img.dtype != cupy.float32:
+        if cupy.can_cast(img.dtype, cupy.float32) is False:
+            raise ValueError(
+                "Cannot safely cast type {cupy_img.dtype.name} to \
+                'float32'"
+            )
         else:
-            cupy_img = cupy.ascontiguousarray(img)
+            cupy_img = cupy_img.astype(cupy.float32)
 
-        if cupy_img.dtype != cupy.float32:
-            if cupy.can_cast(img.dtype, cupy.float32) is False:
-                raise ValueError(
-                    "Cannot safely cast type {cupy_img.dtype.name} to \
-                    'float32'"
-                )
-            else:
-                cupy_img = cupy_img.astype(cupy.float32)
+    scale = CUDA_KERNELS.get_function("scaleVolume")
 
-        scale = CUDA_KERNELS.get_function("scaleVolume")
+    x = (b_max - b_min) / (a_max - a_min)
+    y = a_min * x - b_min
+    if clip is False:
+        b_max = float('inf')
+        b_min = float('-inf')
 
-        x = (b_max - b_min) / (a_max - a_min)
-        y = a_min * x - b_min
-        if clip is False:
-            b_max = float('inf')
-            b_min = float('-inf')
+    sh = img.shape
+    total_size = np.prod(sh)
+    blockx = 128
+    gridx = int((total_size - 1) / blockx + 1)
 
-        sh = img.shape
-        total_size = np.prod(sh)
-        blockx = 128
-        gridx = int((total_size - 1) / blockx + 1)
+    result = cupy.empty(img.shape, dtype=cupy_img.dtype)
 
-        result = cupy.empty(img.shape, dtype=cupy_img.dtype)
+    scale((gridx, 1, 1), (blockx, 1, 1),
+          (cupy_img, result, np.float32(x), np.float32(y),
+          np.float32(b_min), np.float32(b_max),
+          np.int32(total_size)))
 
-        scale((gridx, 1, 1), (blockx, 1, 1),
-              (cupy_img, result, np.float32(x), np.float32(y),
-              np.float32(b_min), np.float32(b_max),
-              np.int32(total_size)))
+    if img.dtype != cupy.float32:
+        result = result.astype(img.dtype)
 
-        if img.dtype != cupy.float32:
-            result = result.astype(img.dtype)
-
-        if to_cupy is True:
-            result = cupy.asnumpy(result)
-
-    except Exception as e:
-        _logger.error("[cucim] " + str(e), exc_info=True)
-        raise
+    if to_cupy is True:
+        result = cupy.asnumpy(result)
 
     return result

--- a/python/cucim/src/cucim/core/operations/intensity/zoom.py
+++ b/python/cucim/src/cucim/core/operations/intensity/zoom.py
@@ -53,10 +53,9 @@ def zoom(
     >>> # input is channel first 3d array
     >>> output_array = its.zoom(input_arr,[1.1,1.1])
     """
-    to_cupy = False
-
+    to_numpy = False
     if isinstance(img, np.ndarray):
-        to_cupy = True
+        to_numpy = True
         cupy_img = cupy.asarray(img, dtype=cupy.float32, order="C")
     elif not isinstance(img, cupy.ndarray):
         raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
@@ -176,7 +175,7 @@ def zoom(
     if img.dtype != np.float32:
         result = result.astype(img.dtype)
 
-    if to_cupy is True:
+    if to_numpy:
         result = cupy.asnumpy(result)
 
     return result

--- a/python/cucim/src/cucim/core/operations/intensity/zoom.py
+++ b/python/cucim/src/cucim/core/operations/intensity/zoom.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import math
 from typing import Any, Sequence, Union
 
@@ -21,7 +20,6 @@ import numpy as np
 
 from .kernel.cuda_kernel_source import cuda_kernel_code
 
-_logger = logging.getLogger("zoom_cucim")
 CUDA_KERNELS = cupy.RawModule(code=cuda_kernel_code)
 
 
@@ -55,139 +53,133 @@ def zoom(
     >>> # input is channel first 3d array
     >>> output_array = its.zoom(input_arr,[1.1,1.1])
     """
-    try:
-        to_cupy = False
+    to_cupy = False
 
-        if isinstance(img, np.ndarray):
-            to_cupy = True
-            cupy_img = cupy.asarray(img, dtype=cupy.float32, order="C")
-        elif not isinstance(img, cupy.ndarray):
-            raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
-        else:
-            cupy_img = cupy.ascontiguousarray(img)
+    if isinstance(img, np.ndarray):
+        to_cupy = True
+        cupy_img = cupy.asarray(img, dtype=cupy.float32, order="C")
+    elif not isinstance(img, cupy.ndarray):
+        raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    else:
+        cupy_img = cupy.ascontiguousarray(img)
 
-        if cupy_img.dtype != cupy.float32:
-            if cupy.can_cast(img.dtype, cupy.float32) is False:
-                raise ValueError(
-                    "Cannot safely cast type {cupy_img.dtype.name} \
-                     to 'float32'"
-                )
-            else:
-                cupy_img = cupy_img.astype(cupy.float32)
-
-        if img.ndim not in (3, 4):
+    if cupy_img.dtype != cupy.float32:
+        if cupy.can_cast(img.dtype, cupy.float32) is False:
             raise ValueError(
-                f"Unsupported img.ndim={img.ndim}. Expected `img` with "
-                "dimensions (C, H, W) or (N, C, H, W)."
+                "Cannot safely cast type {cupy_img.dtype.name} \
+                 to 'float32'"
             )
-
-        if len(img.shape) == 4:
-            N, C, H, W = img.shape
-        elif len(img.shape) == 3:
-            C, H, W = img.shape
-            N = 1
-
-        output_size_cu = [N, C, int(math.floor(H * zoom_factor[0])),
-                          int(math.floor(W * zoom_factor[1]))]
-
-        if output_size_cu[2] == H and output_size_cu[3] == W:
-            return img
-
-        def get_block_size(output_size_cu, H, W):
-            max_smem = 48 * 1024
-            cu_block_options = [(16, 16, 1), (16, 8, 1), (8, 8, 1), (8, 4, 1)]
-            # compare for 48KB for standard CC optimal occupancy
-            # array is H, W but kernel is x--> W, y-->H
-            for param in cu_block_options:
-                h_stretch = [math.floor((0 * H) / output_size_cu[2]),
-                             math.ceil((param[1] * H) / output_size_cu[2])]
-                w_stretch = [math.floor((0 * W) / output_size_cu[3]),
-                             math.ceil((param[0] * W) / output_size_cu[3])]
-
-                smem_size = (h_stretch[1] + 1) * (w_stretch[1] + 1) * 4
-                if smem_size < max_smem:
-                    return param, smem_size
-
-            raise Exception("Random Zoom couldnt find a \
-                             shared memory configuration")
-
-        # input pitch
-        pitch = H * W
-
-        # get block size
-        block_config, smem_size = get_block_size(output_size_cu, H, W)
-        grid = (int((output_size_cu[3] - 1) / block_config[0] + 1),
-                int((output_size_cu[2] - 1) / block_config[1] + 1), C * N)
-
-        is_zoom_out = output_size_cu[2] < H and output_size_cu[3] < W
-        is_zoom_in = output_size_cu[2] > H and output_size_cu[3] > W
-
-        pad_dims = [[0, 0]] * 2  # zoom out
-        slice_dims = [[0, 0]] * 2  # zoom in
-        for idx, (orig, zoom) in enumerate(zip((H, W),
-                                           (output_size_cu[2],
-                                            output_size_cu[3]))):
-            diff = orig - zoom
-            half = abs(diff) // 2
-            if diff > 0:
-                pad_dims[idx] = [half, diff - half]
-            elif diff < 0:
-                slice_dims[idx] = [half, half + orig]
-
-        result = cupy.ndarray(cupy_img.shape, dtype=cupy.float32)
-
-        if is_zoom_in:
-            # slice
-            kernel = CUDA_KERNELS.get_function("zoom_in_kernel")
-            kernel(grid, block_config,
-                   args=(cupy_img, result, np.int32(H), np.int32(W),
-                         np.int32(output_size_cu[2]),
-                         np.int32(output_size_cu[3]),
-                         np.int32(pitch), np.int32(slice_dims[0][0]),
-                         np.int32(slice_dims[0][1]),
-                         np.int32(slice_dims[1][0]),
-                         np.int32(slice_dims[1][1])),
-                   shared_mem=smem_size)
-        elif is_zoom_out:
-            # pad
-            kernel = CUDA_KERNELS.get_function("zoom_out_kernel")
-            kernel(grid, block_config,
-                   args=(cupy_img, result, np.int32(H), np.int32(W),
-                         np.int32(output_size_cu[2]),
-                         np.int32(output_size_cu[3]),
-                         np.int32(pitch), np.int32(pad_dims[0][0]),
-                         np.int32(pad_dims[0][1]),
-                         np.int32(pad_dims[1][0]),
-                         np.int32(pad_dims[1][1])),
-                   shared_mem=smem_size)
-            # padding kernel
-            kernel = CUDA_KERNELS.get_function("zoomout_edge_pad")
-            grid = (int((W - 1) / block_config[0] + 1),
-                    int((H - 1) / block_config[1] + 1),
-                    C * N)
-            kernel(grid, block_config,
-                   args=(result, np.int32(H), np.int32(W), np.int32(pitch),
-                         np.int32(pad_dims[0][0]), np.int32(pad_dims[1][0]),
-                         np.int32(pad_dims[0][0] + output_size_cu[2]),
-                         np.int32(pad_dims[1][0] + output_size_cu[3])))
-
         else:
-            raise Exception("Can only handle simultaneous \
-                            expansion(or shrinkage) in both H,W dimension, \
-                            check zoom factors")
+            cupy_img = cupy_img.astype(cupy.float32)
 
-        if img.dtype != np.float32:
-            result = result.astype(img.dtype)
+    if img.ndim not in (3, 4):
+        raise ValueError(
+            f"Unsupported img.ndim={img.ndim}. Expected `img` with "
+            "dimensions (C, H, W) or (N, C, H, W)."
+        )
 
-        if to_cupy is True:
-            result = cupy.asnumpy(result)
+    if len(img.shape) == 4:
+        N, C, H, W = img.shape
+    elif len(img.shape) == 3:
+        C, H, W = img.shape
+        N = 1
 
-        return result
+    output_size_cu = [N, C, int(math.floor(H * zoom_factor[0])),
+                      int(math.floor(W * zoom_factor[1]))]
 
-    except Exception as e:
-        _logger.error("[cucim] " + str(e), exc_info=True)
-        _logger.info("Error executing random zoom on GPU")
-        raise
+    if output_size_cu[2] == H and output_size_cu[3] == W:
+        return img
+
+    def get_block_size(output_size_cu, H, W):
+        max_smem = 48 * 1024
+        cu_block_options = [(16, 16, 1), (16, 8, 1), (8, 8, 1), (8, 4, 1)]
+        # compare for 48KB for standard CC optimal occupancy
+        # array is H, W but kernel is x--> W, y-->H
+        for param in cu_block_options:
+            h_stretch = [math.floor((0 * H) / output_size_cu[2]),
+                         math.ceil((param[1] * H) / output_size_cu[2])]
+            w_stretch = [math.floor((0 * W) / output_size_cu[3]),
+                         math.ceil((param[0] * W) / output_size_cu[3])]
+
+            smem_size = (h_stretch[1] + 1) * (w_stretch[1] + 1) * 4
+            if smem_size < max_smem:
+                return param, smem_size
+
+        raise Exception("Random Zoom couldnt find a \
+                         shared memory configuration")
+
+    # input pitch
+    pitch = H * W
+
+    # get block size
+    block_config, smem_size = get_block_size(output_size_cu, H, W)
+    grid = (int((output_size_cu[3] - 1) / block_config[0] + 1),
+            int((output_size_cu[2] - 1) / block_config[1] + 1), C * N)
+
+    is_zoom_out = output_size_cu[2] < H and output_size_cu[3] < W
+    is_zoom_in = output_size_cu[2] > H and output_size_cu[3] > W
+
+    pad_dims = [[0, 0]] * 2  # zoom out
+    slice_dims = [[0, 0]] * 2  # zoom in
+    for idx, (orig, zoom) in enumerate(zip((H, W),
+                                       (output_size_cu[2],
+                                        output_size_cu[3]))):
+        diff = orig - zoom
+        half = abs(diff) // 2
+        if diff > 0:
+            pad_dims[idx] = [half, diff - half]
+        elif diff < 0:
+            slice_dims[idx] = [half, half + orig]
+
+    result = cupy.ndarray(cupy_img.shape, dtype=cupy.float32)
+
+    if is_zoom_in:
+        # slice
+        kernel = CUDA_KERNELS.get_function("zoom_in_kernel")
+        kernel(grid, block_config,
+               args=(cupy_img, result, np.int32(H), np.int32(W),
+                     np.int32(output_size_cu[2]),
+                     np.int32(output_size_cu[3]),
+                     np.int32(pitch), np.int32(slice_dims[0][0]),
+                     np.int32(slice_dims[0][1]),
+                     np.int32(slice_dims[1][0]),
+                     np.int32(slice_dims[1][1])),
+               shared_mem=smem_size)
+    elif is_zoom_out:
+        # pad
+        kernel = CUDA_KERNELS.get_function("zoom_out_kernel")
+        kernel(grid, block_config,
+               args=(cupy_img, result, np.int32(H), np.int32(W),
+                     np.int32(output_size_cu[2]),
+                     np.int32(output_size_cu[3]),
+                     np.int32(pitch), np.int32(pad_dims[0][0]),
+                     np.int32(pad_dims[0][1]),
+                     np.int32(pad_dims[1][0]),
+                     np.int32(pad_dims[1][1])),
+               shared_mem=smem_size)
+        # padding kernel
+        kernel = CUDA_KERNELS.get_function("zoomout_edge_pad")
+        grid = (int((W - 1) / block_config[0] + 1),
+                int((H - 1) / block_config[1] + 1),
+                C * N)
+        kernel(grid, block_config,
+               args=(result, np.int32(H), np.int32(W), np.int32(pitch),
+                     np.int32(pad_dims[0][0]), np.int32(pad_dims[1][0]),
+                     np.int32(pad_dims[0][0] + output_size_cu[2]),
+                     np.int32(pad_dims[1][0] + output_size_cu[3])))
+
+    else:
+        raise Exception("Can only handle simultaneous \
+                        expansion(or shrinkage) in both H,W dimension, \
+                        check zoom factors")
+
+    if img.dtype != np.float32:
+        result = result.astype(img.dtype)
+
+    if to_cupy is True:
+        result = cupy.asnumpy(result)
+
+    return result
 
 
 def get_zoom_factor(

--- a/python/cucim/src/cucim/core/operations/spatial/rotate_and_flip.py
+++ b/python/cucim/src/cucim/core/operations/spatial/rotate_and_flip.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Any
 
 import cupy
 import numpy as np
-
-_logger = logging.getLogger("spatial_cucim")
 
 
 def image_flip(
@@ -52,26 +49,21 @@ def image_flip(
     >>> # input is channel first 3d array
     >>> output_array = spt.image_flip(input_arr, (1, 2))
     """
-    try:
-        to_cupy = False
+    to_cupy = False
 
-        if isinstance(img, np.ndarray):
-            to_cupy = True
-            cupy_img = cupy.asarray(img, order="C")
-        elif not isinstance(img, cupy.ndarray):
-            raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
-        else:
-            cupy_img = cupy.ascontiguousarray(img)
+    if isinstance(img, np.ndarray):
+        to_cupy = True
+        cupy_img = cupy.asarray(img, order="C")
+    elif not isinstance(img, cupy.ndarray):
+        raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    else:
+        cupy_img = cupy.ascontiguousarray(img)
 
-        result = cupy.flip(cupy_img, spatial_axis)
-        if to_cupy is True:
-            result = cupy.asnumpy(result)
+    result = cupy.flip(cupy_img, spatial_axis)
+    if to_cupy is True:
+        result = cupy.asnumpy(result)
 
-        return result
-    except Exception as e:
-        _logger.error("[cucim] " + str(e), exc_info=True)
-        _logger.info("Error executing image flip on GPU")
-        raise
+    return result
 
 
 def image_rotate_90(
@@ -107,25 +99,20 @@ def image_rotate_90(
     >>> # input is channel first 3d array
     >>> output_array = spt.image_rotate_90(input_arr,1,(1,2))
     """
-    try:
-        to_cupy = False
+    to_cupy = False
 
-        if isinstance(img, np.ndarray):
-            to_cupy = True
-            cupy_img = cupy.asarray(img, order="C")
-        elif not isinstance(img, cupy.ndarray):
-            raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
-        else:
-            cupy_img = cupy.ascontiguousarray(img)
+    if isinstance(img, np.ndarray):
+        to_cupy = True
+        cupy_img = cupy.asarray(img, order="C")
+    elif not isinstance(img, cupy.ndarray):
+        raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
+    else:
+        cupy_img = cupy.ascontiguousarray(img)
 
-        result = cupy.rot90(cupy_img, k, spatial_axis)
-        if to_cupy is True:
-            result = cupy.asnumpy(result)
-        return result
-    except Exception as e:
-        _logger.error("[cucim] " + str(e), exc_info=True)
-        _logger.info("Error executing image rotation on GPU")
-        raise
+    result = cupy.rot90(cupy_img, k, spatial_axis)
+    if to_cupy is True:
+        result = cupy.asnumpy(result)
+    return result
 
 
 def rand_image_flip(

--- a/python/cucim/src/cucim/core/operations/spatial/rotate_and_flip.py
+++ b/python/cucim/src/cucim/core/operations/spatial/rotate_and_flip.py
@@ -49,10 +49,9 @@ def image_flip(
     >>> # input is channel first 3d array
     >>> output_array = spt.image_flip(input_arr, (1, 2))
     """
-    to_cupy = False
-
+    to_numpy = False
     if isinstance(img, np.ndarray):
-        to_cupy = True
+        to_numpy = True
         cupy_img = cupy.asarray(img, order="C")
     elif not isinstance(img, cupy.ndarray):
         raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
@@ -60,7 +59,7 @@ def image_flip(
         cupy_img = cupy.ascontiguousarray(img)
 
     result = cupy.flip(cupy_img, spatial_axis)
-    if to_cupy is True:
+    if to_numpy:
         result = cupy.asnumpy(result)
 
     return result
@@ -99,10 +98,9 @@ def image_rotate_90(
     >>> # input is channel first 3d array
     >>> output_array = spt.image_rotate_90(input_arr,1,(1,2))
     """
-    to_cupy = False
-
+    to_numpy = False
     if isinstance(img, np.ndarray):
-        to_cupy = True
+        to_numpy = True
         cupy_img = cupy.asarray(img, order="C")
     elif not isinstance(img, cupy.ndarray):
         raise TypeError("img must be a cupy.ndarray or numpy.ndarray")
@@ -110,7 +108,7 @@ def image_rotate_90(
         cupy_img = cupy.ascontiguousarray(img)
 
     result = cupy.rot90(cupy_img, k, spatial_axis)
-    if to_cupy is True:
+    if to_numpy:
         result = cupy.asnumpy(result)
     return result
 


### PR DESCRIPTION
closes #114

Removes the try/except wrappers with logging of errors from the digital pathology transforms added in #100. 

Also renames a variable `to_cupy` to `to_numpy` instead to reflect its actual function.

**For reviewers**: There appear to be many lines changed here, but it is mostly a change in indentation due to removal of `try/except` blocks with `_logger` calls. Also some nested function definitions within `color_jitter` were moved outside of that function.