### PR TITLE
Remove custom compiler environment variables

### DIFF
--- a/conda/recipes/cucim/build.sh
+++ b/conda/recipes/cucim/build.sh
@@ -4,14 +4,6 @@ CUCIM_BUILD_TYPE=${CUCIM_BUILD_TYPE:-release}
 
 echo "CC          : ${CC}"
 echo "CXX         : ${CXX}"
-echo "CUDAHOSTCXX : ${CUDAHOSTCXX}"
-
-# For now CUDAHOSTCXX is set to `/usr/bin/g++` by
-# https://github.com/rapidsai/docker/blob/161b200157206660d88fb02cf69fe58d363ac95e/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
-# To use GCC-9 in conda build environment, need to set it to $CXX (=$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++)
-# This can be removed once we switch to use gcc-9
-# : https://docs.rapids.ai/notices/rdn0002/
-export CUDAHOSTCXX=${CXX}
 
 # CUDA needs to include $PREFIX/include as system include path
 export CUDAFLAGS="-isystem $BUILD_PREFIX/include -isystem $PREFIX/include "

--- a/conda/recipes/libcucim/build.sh
+++ b/conda/recipes/libcucim/build.sh
@@ -4,15 +4,7 @@ CUCIM_BUILD_TYPE=${CUCIM_BUILD_TYPE:-release}
 
 echo "CC          : ${CC}"
 echo "CXX         : ${CXX}"
-echo "CUDAHOSTCXX : ${CUDAHOSTCXX}"
 echo "CUDA        : ${CUDA}"
-
-# For now CUDAHOSTCXX is set to `/usr/bin/g++` by
-# https://github.com/rapidsai/docker/blob/161b200157206660d88fb02cf69fe58d363ac95e/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile
-# To use GCC-9 in conda build environment, need to set it to $CXX (=$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++)
-# This can be removed once we switch to use gcc-9
-# : https://docs.rapids.ai/notices/rdn0002/
-export CUDAHOSTCXX=${CXX}
 
 # CUDA needs to include $PREFIX/include as system include path
 export CUDAFLAGS="-isystem $BUILD_PREFIX/include -isystem $PREFIX/include "


### PR DESCRIPTION
With the PR below merged, we no longer set the `CUDAHOSTCXX` variable in any of our CI images. This PR cleans up some references to `CUDAHOSTCXX`.


- https://github.com/rapidsai/gpuci-build-environment/pull/265