### PR TITLE
Stain extraction: use a less strict condition across channels when thresholding

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -314,7 +314,7 @@ def stain_extraction_pca(image, source_intensity=240, alpha=1, beta=0.345,
     )
 
     # remove transparent pixels
-    absorbance = absorbance[:, cp.all(absorbance > beta, axis=0)]
+    absorbance = absorbance[:, cp.any(absorbance > beta, axis=0)]
     if absorbance.size == 0:
         raise ValueError(
             "All pixels of the input image are below the threshold."


### PR DESCRIPTION
I think we want to allow pixels with substantial attenuation in **any** of the channels rather than requiring substantial attenuation in **all** channels. The Macenko et. al. reference does not actually explain how the threshold was applied (min, max or mean across channels). However, qualitatively, results looked closer to expected with the `any` condition proposed here when I was working on a pending stain normalization example/demo.

I have also seen third party implementations where there is an RGB->LUV conversion and thresholding is done on the L channel rather than in luminance space. That seems reasonable and perhaps is more intuitive in choice of the threshold number (easier to think in fraction of brightness rather than absorbance units). However, making that change would be a bigger deviation from the publication and would involve some small additional overhead of the RGB->luminance conversion.

I have marked this as breaking as it will affect the estimated stain vectors produced by `stain_extraction_pca`. 


<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
