### PR TITLE
Protect against obscure divide by zero error in edge case of `normalize_colors_pca`

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import warnings
 from typing import Union
 
 import cupy as cp

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -313,7 +313,7 @@ def stain_extraction_pca(image, source_intensity=240, alpha=1, beta=0.345,
     # remove transparent pixels
     absorbance = absorbance[:, cp.all(absorbance > beta, axis=0)]
     if absorbance.size == 0 or absorbance.shape[1] <= 1:
-        raise RuntimeError(
+        raise ValueError(
             "Multiple pixels of the input must be above the `beta` threshold."
         )
 

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -209,9 +209,7 @@ def _covariance(a):
     ddof = 1
     fact = X.shape[1] - ddof
     if fact <= 0:
-        warnings.warn("Degrees of freedom <= 0 for slice",
-                      RuntimeWarning, stacklevel=2)
-        fact = 0.0
+        raise RuntimeError("Degrees of freedom <= 0")
 
     X -= X.mean(axis=1, keepdims=True)
     if not X.flags.f_contiguous:
@@ -315,9 +313,9 @@ def stain_extraction_pca(image, source_intensity=240, alpha=1, beta=0.345,
 
     # remove transparent pixels
     absorbance = absorbance[:, cp.all(absorbance > beta, axis=0)]
-    if absorbance.size == 0:
-        raise ValueError(
-            "All pixels of the input image are below the threshold."
+    if absorbance.size == 0 or absorbance.shape[1] <= 1:
+        raise RuntimeError(
+            "Multiple pixels of the input must be above the `beta` threshold."
         )
 
     # compute eigenvectors (do small 3x3 matrix calculations on the host)

--- a/python/cucim/tests/unit/core/test_stain_normalizer.py
+++ b/python/cucim/tests/unit/core/test_stain_normalizer.py
@@ -22,15 +22,15 @@ from cucim.core.operations.color import (normalize_colors_pca,
 
 class TestStainExtractorMacenko():
     @pytest.mark.parametrize(
-        'image',
+        'image, ErrorClass',
         [
-            cp.full((3, 2, 4), -1),   # negative value
-            cp.full((3, 2, 4), 256),  # out of range value
-            None,
-            cp.full((3, 2, 4), 240),  # uniformly below the beta threshold
-        ]
+            (cp.full((3, 2, 4), -1), ValueError),   # negative value
+            (cp.full((3, 2, 4), 256), ValueError),  # out of range value
+            (None, TypeError),
+            (cp.full((3, 2, 4), 240), ValueError),  # uniformly below the beta threshold  # noqa
+        ],
     )
-    def test_transparent_image(self, image):
+    def test_transparent_image(self, image, ErrorClass):
         """
         Test HE stain extraction on an image that comprises
         only transparent pixels - pixels with absorbance below the
@@ -38,12 +38,8 @@ class TestStainExtractorMacenko():
         since once the transparent pixels are removed, there are no
         remaining pixels to compute eigenvectors.
         """
-        if image is None:
-            with pytest.raises(TypeError):
-                stain_extraction_pca(image)
-        else:
-            with pytest.raises(ValueError):
-                stain_extraction_pca(image)
+        with pytest.raises(ErrorClass):
+            stain_extraction_pca(image)
 
     @pytest.mark.parametrize(
         'image',


### PR DESCRIPTION
This PR updates `normalize_colors_pca` to raise a more helpful error message in the case that there is only a single pixel above the specified `beta` threshold. Currently this leads to a not very helpful `DivideByZeroError` because the degrees of freedom during an internal covariance calculation becomes zero in this case.

This does also change the error type when there are no pixels above the threshold from `ValueError` to `RuntimeError` which seems more appropriate to me.
