### PR TITLE
Reduce memory overhead and improve performance of normalize_colors_pca

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -534,8 +534,8 @@ def normalize_colors_pca(
     image_norm = _normalized_from_concentrations(
         conc_raw=conc_raw,
         max_percentile=100 - alpha,
-        ref_max_conc=cp.asarray(ref_max_conc),
-        ref_stain_coeff=cp.asarray(ref_stain_coeff),
+        ref_max_conc=cp.asarray(ref_max_conc, dtype=conc_raw.dtype),
+        ref_stain_coeff=cp.asarray(ref_stain_coeff, dtype=conc_raw.dtype),
         source_intensity=source_intensity,
         channel_axis=channel_axis,
         original_shape=image.shape,

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -413,10 +413,6 @@ def _normalized_from_concentrations(conc_raw, max_percentile, ref_stain_coeff,
          for ch_raw in conc_raw]
     )
     normalization_factors = ref_max_conc / max_conc
-    # convert normalization factors to same precsision as conc_norm
-    # normalization_factors = normalization_factors.astype(
-    #     conc_raw.dtype, copy=False
-    # )
     conc_raw *= normalization_factors[:, cp.newaxis]
 
     # reconstruct the image based on the reference stain matrix

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -537,4 +537,3 @@ def normalize_colors_pca(
         original_shape=image.shape,
     )
     return image_norm
-


### PR DESCRIPTION
In this PR we change the following line:
```Python
conc_norm = conc_raw * normalization_factors[:, cp.newaxis]
```

to instead modify `conc_raw` in-place. The `conc_raw` array is an intermediate array of concentrations, so changing to an in-place operation will not effect user-facing code. The benefit is avoiding an extra copy of the concentrations array. It also avoids an unintended promotion to float64 due to multiplication by a `normalization_factors` array that was potentially higher precision than `conc_raw`.

For a fairly large uint8 input array of shape `(26420, 19920, 3)`, the `conc_raw` array ends up as an ~4GB float32 array. Without the change in this PR there will be a new 8GB float64 `conc_norm` array created.  By avoiding this we substantially reduce memory use. 

We also make sure the `ref_max_conc` and `ref_stain_coeff` inputs to `_normalized_from_concentration` match the precision of the image. Due to this, a 25% improvement in performance was observed (due to float32 rather than float64 computations in the remainder of the `_normalized_from_concentrations` function).

