### PR TITLE
benchmarks: avoid use of deprecated pandas API

### DIFF
--- a/benchmarks/skimage/cucim_color_bench.py
+++ b/benchmarks/skimage/cucim_color_bench.py
@@ -122,7 +122,7 @@ for shape in [(256, 256, 3), (3840, 2160, 3), (192, 192, 192, 3)]:
                 module_gpu=cucim.skimage.color,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
     # rgb2hed and hed2rgb test combine_stains and separate_stains and all other
     # stains should have equivalent performance.
@@ -145,7 +145,7 @@ for shape in [(256, 256, 3), (3840, 2160, 3), (192, 192, 192, 3)]:
             module_gpu=cucim.skimage.color,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
     B = RGBABench(
         function_name="rgba2rgb",
@@ -157,7 +157,7 @@ for shape in [(256, 256, 3), (3840, 2160, 3), (192, 192, 192, 3)]:
         module_gpu=cucim.skimage.color,
     )
     results = B.run_benchmark(duration=1)
-    all_results = all_results.append(results["full"])
+    all_results = pd.concat([all_results, results["full"]])
 
     for contiguous_labels in [True, False]:
         if contiguous_labels:
@@ -176,7 +176,7 @@ for shape in [(256, 256, 3), (3840, 2160, 3), (192, 192, 192, 3)]:
             module_gpu=cucim.skimage.color,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cucim_exposure_bench.py
+++ b/benchmarks/skimage/cucim_exposure_bench.py
@@ -106,7 +106,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color in [
             module_gpu=cucim.skimage.exposure,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 for shape in [(512, 512), (3840, 2160), (3840, 2160, 3), (192, 192, 192)]:
@@ -124,7 +124,7 @@ for shape in [(512, 512), (3840, 2160), (3840, 2160, 3), (192, 192, 192)]:
         module_gpu=cucim.skimage.exposure,
     )
     results = B.run_benchmark(duration=1)
-    all_results = all_results.append(results["full"])
+    all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cucim_feature_bench.py
+++ b/benchmarks/skimage/cucim_feature_bench.py
@@ -89,7 +89,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.feature,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
@@ -118,7 +118,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.feature,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cucim_filters_bench.py
+++ b/benchmarks/skimage/cucim_filters_bench.py
@@ -150,7 +150,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.filters,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cucim_measure_bench.py
+++ b/benchmarks/skimage/cucim_measure_bench.py
@@ -180,7 +180,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
                 module_gpu=cucim.skimage.measure,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
@@ -268,7 +268,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.measure,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_metrics_bench.py
+++ b/benchmarks/skimage/cucim_metrics_bench.py
@@ -80,7 +80,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.metrics,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_morphology_bench.py
+++ b/benchmarks/skimage/cucim_morphology_bench.py
@@ -137,7 +137,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_nd in [
             module_gpu=cucim.skimage.morphology,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_nd in [
@@ -169,7 +169,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_nd in [
                 module_gpu=cucim.skimage.morphology,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_nd in [
@@ -200,7 +200,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_nd in [
             module_gpu=cucim.skimage.morphology,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
@@ -262,7 +262,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.morphology,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_registration_bench.py
+++ b/benchmarks/skimage/cucim_registration_bench.py
@@ -87,7 +87,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
                 module_gpu=cucim.skimage.registration,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
 
 for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
@@ -125,7 +125,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.registration,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_restoration_bench.py
+++ b/benchmarks/skimage/cucim_restoration_bench.py
@@ -144,7 +144,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.restoration,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 # function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd = ('unsupervised_wiener', dict(), dict(), False, True)
@@ -178,7 +178,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.restoration,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_segmentation_bench.py
+++ b/benchmarks/skimage/cucim_segmentation_bench.py
@@ -129,7 +129,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.segmentation,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 dtypes = [np.float32]
@@ -181,7 +181,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             module_gpu=cucim.skimage.segmentation,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cucim_transform_bench.py
+++ b/benchmarks/skimage/cucim_transform_bench.py
@@ -132,7 +132,7 @@ for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
             function_is_generator=function_is_generator,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cupyx_scipy_ndimage_filter_bench.py
+++ b/benchmarks/skimage/cupyx_scipy_ndimage_filter_bench.py
@@ -102,7 +102,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
             var_kwargs=var_kwargs,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
     for fname, wshape, var_kwargs in [
         ("convolve", weights_shape, dict(mode=modes)),
@@ -119,7 +119,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
             var_kwargs=var_kwargs,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cupyx_scipy_ndimage_fourier_bench.py
+++ b/benchmarks/skimage/cupyx_scipy_ndimage_fourier_bench.py
@@ -43,7 +43,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
             var_kwargs=var_kwargs,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 
 fbase = os.path.splitext(pfile)[0]

--- a/benchmarks/skimage/cupyx_scipy_ndimage_interp_bench.py
+++ b/benchmarks/skimage/cupyx_scipy_ndimage_interp_bench.py
@@ -56,7 +56,7 @@ for shape in [(512, 512), (3840, 2160), (4608, 3456), (192, 192, 192)]:
         var_kwargs=dict(mode=modes, order=orders),
     )
     results = B.run_benchmark(duration=1)
-    all_results = all_results.append(results["full"])
+    all_results = pd.concat([all_results, results["full"]])
 
     for fname, fixed_kwargs, var_kwargs in [
         (
@@ -139,7 +139,7 @@ for shape in [(512, 512), (3840, 2160), (4608, 3456), (192, 192, 192)]:
             var_kwargs=var_kwargs,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cupyx_scipy_ndimage_measurements_bench.py
+++ b/benchmarks/skimage/cupyx_scipy_ndimage_measurements_bench.py
@@ -145,7 +145,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
                 var_kwargs=var_kwargs,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
     for fname in [
         "sum",
@@ -180,7 +180,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
                     var_kwargs=var_kwargs,
                 )
                 results = B.run_benchmark(duration=1)
-                all_results = all_results.append(results["full"])
+                all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")

--- a/benchmarks/skimage/cupyx_scipy_ndimage_morphology_bench.py
+++ b/benchmarks/skimage/cupyx_scipy_ndimage_morphology_bench.py
@@ -126,7 +126,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
             var_kwargs=var_kwargs,
         )
         results = B.run_benchmark(duration=1)
-        all_results = all_results.append(results["full"])
+        all_results = pd.concat([all_results, results["full"]])
 
     iterations = [1, 10, 30]
     for fname, var_kwargs in [
@@ -152,7 +152,7 @@ for shape in [(512, 512), (3840, 2160), (192, 192, 192)]:
                 var_kwargs=var_kwargs,
             )
             results = B.run_benchmark(duration=1)
-            all_results = all_results.append(results["full"])
+            all_results = pd.concat([all_results, results["full"]])
 
 fbase = os.path.splitext(pfile)[0]
 all_results.to_csv(fbase + ".csv")


### PR DESCRIPTION
This is an update of the previously-approved #290 from branch-22.06 to branch-22.08