### PR TITLE
Performance optimizations to morphological segmentation functions

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/_gradient.py
+++ b/python/cucim/src/cucim/skimage/_shared/_gradient.py
@@ -39,10 +39,12 @@ def gradient(f, axis=None):
     if axis is None:
         axes = tuple(range(ndim))
     else:
-        for ax in axes:
+        if cupy.isscalar(axis):
+            axis = (axis,)
+        for ax in axis:
             if ax < -ndim or ax > ndim + 1:
                 raise ValueError(f"invalid axis: {ax}")
-        axes = tuple(ax + ndim if ax < 0 else ax for ax in axes)
+        axes = tuple(ax + ndim if ax < 0 else ax for ax in axis)
     len_axes = len(axes)
 
     # use central differences on interior and one-sided differences on the

--- a/python/cucim/src/cucim/skimage/_shared/_gradient.py
+++ b/python/cucim/src/cucim/skimage/_shared/_gradient.py
@@ -75,8 +75,6 @@ def gradient(f, axis=None):
         # result allocation
         out = cupy.empty_like(f, dtype=otype)
 
-        uniform_spacing = True
-
         # Numerical differentiation: 2nd order interior
         slice1[axis] = slice(1, -1)
         slice2[axis] = slice(None, -2)

--- a/python/cucim/src/cucim/skimage/_shared/_gradient.py
+++ b/python/cucim/src/cucim/skimage/_shared/_gradient.py
@@ -1,0 +1,111 @@
+"""
+Simplified version of cupy.gradient
+
+This version doesn't support non-unit spacing or 2nd order edges.
+
+Importantly, this version does not promote all integer dtypes to float64, but
+instead will promote 8 and 16-bit integer types to float32.
+"""
+import cupy
+
+from cucim.skimage._shared.utils import _supported_float_type
+
+
+def gradient(f, axis=None):
+    """Return the gradient of an N-dimensional array.
+
+    The gradient is computed using second order accurate central differences
+    in the interior points and either first or second order accurate one-sides
+    (forward or backwards) differences at the boundaries.
+    The returned gradient hence has the same shape as the input array.
+
+    Args:
+        f (cupy.ndarray): An N-dimensional array containing samples of a scalar
+            function.
+        axis (None or int or tuple of ints, optional): The gradient is
+            calculated only along the given axis or axes. The default
+            (axis = None) is to calculate the gradient for all the axes of the
+            input array. axis may be negative, in which case it counts from the
+            last to the first axis.
+
+    Returns:
+        gradient (cupy.ndarray or list of cupy.ndarray): A set of ndarrays
+        (or a single ndarray if there is only one dimension) corresponding
+        to the derivatives of f with respect to each dimension. Each
+        derivative has the same shape as f.
+
+    """
+    ndim = f.ndim  # number of dimensions
+    if axis is None:
+        axes = tuple(range(ndim))
+    else:
+        for ax in axes:
+            if ax < -ndim or ax > ndim + 1:
+                raise ValueError(f"invalid axis: {ax}")
+        axes = tuple(ax + ndim if ax < 0 else ax for ax in axes)
+    len_axes = len(axes)
+
+    # use central differences on interior and one-sided differences on the
+    # endpoints. This preserves second order-accuracy over the full domain.
+
+    outvals = []
+
+    # create slice objects --- initially all are [:, :, ..., :]
+    slice1 = [slice(None)] * ndim
+    slice2 = [slice(None)] * ndim
+    slice3 = [slice(None)] * ndim
+    slice4 = [slice(None)] * ndim
+
+    otype = f.dtype
+    if cupy.issubdtype(otype, cupy.inexact):
+        pass
+    else:
+        # All other types convert to floating point.
+        float_dtype = _supported_float_type(otype)
+        if cupy.issubdtype(otype, cupy.integer):
+            f = f.astype(float_dtype)
+        otype = float_dtype
+
+    for axis in axes:
+        if f.shape[axis] < 2:
+            raise ValueError(
+                "Shape of array too small to calculate a numerical gradient, "
+                "at least 2 elements are required."
+            )
+        # result allocation
+        out = cupy.empty_like(f, dtype=otype)
+
+        uniform_spacing = True
+
+        # Numerical differentiation: 2nd order interior
+        slice1[axis] = slice(1, -1)
+        slice2[axis] = slice(None, -2)
+        slice3[axis] = slice(1, -1)
+        slice4[axis] = slice(2, None)
+
+        out[tuple(slice1)] = (f[tuple(slice4)] - f[tuple(slice2)]) / 2.0
+
+        # Numerical differentiation: 1st order edges
+        slice1[axis] = 0
+        slice2[axis] = 1
+        slice3[axis] = 0
+        # 1D equivalent -- out[0] = (f[1] - f[0]) / (x[1] - x[0])
+        out[tuple(slice1)] = f[tuple(slice2)] - f[tuple(slice3)]
+
+        slice1[axis] = -1
+        slice2[axis] = -1
+        slice3[axis] = -2
+        # 1D equivalent -- out[-1] = (f[-1] - f[-2]) / (x[-1] - x[-2])
+        out[tuple(slice1)] = f[tuple(slice2)] - f[tuple(slice3)]
+        outvals.append(out)
+
+        # reset the slice object in this dimension to ":"
+        slice1[axis] = slice(None)
+        slice2[axis] = slice(None)
+        slice3[axis] = slice(None)
+        slice4[axis] = slice(None)
+
+    if len_axes == 1:
+        return outvals[0]
+    else:
+        return outvals

--- a/python/cucim/src/cucim/skimage/feature/_basic_features.py
+++ b/python/cucim/src/cucim/skimage/feature/_basic_features.py
@@ -6,6 +6,7 @@ from itertools import combinations_with_replacement
 import cupy as cp
 import numpy as np
 
+from .._shared._gradient import gradient
 from cucim.skimage import feature, filters
 from cucim.skimage._shared import utils
 from cucim.skimage.util import img_as_float32
@@ -14,7 +15,7 @@ from cucim.skimage.util import img_as_float32
 def _texture_filter(gaussian_filtered):
     combos = combinations_with_replacement
     H_elems = [
-        cp.gradient(cp.gradient(gaussian_filtered)[ax0], axis=ax1)
+        gradient(gradient(gaussian_filtered)[ax0], axis=ax1)
         for ax0, ax1 in combos(range(gaussian_filtered.ndim), 2)
     ]
     eigvals = feature.hessian_matrix_eigvals(H_elems)

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -9,6 +9,7 @@ from scipy import spatial  # TODO: use RAPIDS cuSpatial?
 from cucim.skimage.util import img_as_float
 
 # from ..transform import integral_image
+from .._shared._gradient import gradient
 from .._shared.utils import _supported_float_type
 from .peak import peak_local_max
 from .util import _prepare_grayscale_input_nD
@@ -217,14 +218,14 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
     gaussian_filtered = gaussian(image, sigma=sigma, mode=mode, cval=cval,
                                  channel_axis=channel_axis)
 
-    gradients = cp.gradient(gaussian_filtered)
+    gradients = gradient(gaussian_filtered)
     axes = range(image.ndim)
 
     if order == "rc":
         axes = reversed(axes)
 
     H_elems = [
-        cp.gradient(gradients[ax0], axis=ax1)
+        gradient(gradients[ax0], axis=ax1)
         for ax0, ax1 in combinations_with_replacement(axes, 2)
     ]
 

--- a/python/cucim/src/cucim/skimage/registration/_optical_flow.py
+++ b/python/cucim/src/cucim/skimage/registration/_optical_flow.py
@@ -9,6 +9,7 @@ from itertools import combinations_with_replacement
 import cupy as cp
 from cupyx.scipy import ndimage as ndi
 
+from .._shared._gradient import gradient
 from .._shared.utils import _supported_float_type
 from ..transform import warp
 from ._optical_flow_utils import coarse_to_fine, get_warp_points
@@ -79,7 +80,7 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
 
         image1_warp = warp(moving_image, get_warp_points(grid, flow_current),
                            mode='edge')
-        grad = cp.stack(cp.gradient(image1_warp))
+        grad = cp.stack(gradient(image1_warp))
         NI = (grad * grad).sum(0)
         NI[NI == 0] = 1
 
@@ -288,7 +289,7 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian,
 
         moving_image_warp = warp(moving_image, get_warp_points(grid, flow),
                                  mode='edge')
-        grad = cp.stack(cp.gradient(moving_image_warp), axis=0)
+        grad = cp.stack(gradient(moving_image_warp), axis=0)
         error_image = ((grad * flow).sum(axis=0)
                        + reference_image - moving_image_warp)
 

--- a/python/cucim/src/cucim/skimage/registration/_optical_flow.py
+++ b/python/cucim/src/cucim/skimage/registration/_optical_flow.py
@@ -80,7 +80,8 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
 
         image1_warp = warp(moving_image, get_warp_points(grid, flow_current),
                            mode='edge')
-        grad = cp.stack(gradient(image1_warp))
+        # output_as_array=True stacks the gradients along the first axis
+        grad = gradient(image1_warp, output_as_array=True)
         NI = (grad * grad).sum(0)
         NI[NI == 0] = 1
 
@@ -289,7 +290,8 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian,
 
         moving_image_warp = warp(moving_image, get_warp_points(grid, flow),
                                  mode='edge')
-        grad = cp.stack(gradient(moving_image_warp), axis=0)
+        # output_as_array=True stacks the gradients along the first axis
+        grad = gradient(moving_image_warp, output_as_array=True)
         error_image = ((grad * flow).sum(axis=0)
                        + reference_image - moving_image_warp)
 

--- a/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
+++ b/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
@@ -7,10 +7,9 @@ from cupyx import rsqrt
 from cupyx.scipy import ndimage as ndi
 
 from cucim import _misc
+
 from .._shared._gradient import gradient
 from .._shared.utils import check_nD, deprecate_kwarg
-
-
 
 __all__ = ['morphological_chan_vese',
            'morphological_geodesic_active_contour',
@@ -77,8 +76,8 @@ def inf_sup(u, footprints, workspace=None):
     return dilations.min(0)
 
 
-_curvop = _fcycle([lambda u, f, w: sup_inf(inf_sup(u, f, w), f ,w),   # SIoIS
-                   lambda u, f, w: inf_sup(sup_inf(u, f, w), f ,w)])  # ISoSI
+_curvop = _fcycle([lambda u, f, w: sup_inf(inf_sup(u, f, w), f, w),   # SIoIS
+                   lambda u, f, w: inf_sup(sup_inf(u, f, w), f, w)])  # ISoSI
 
 
 def _check_input(image, init_level_set):
@@ -321,7 +320,7 @@ def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
     if _misc.ndim(u) == 2:
         footprints = _get_P2()
     elif _misc.ndim(u) == 3:
-        footprints  = _get_P3()
+        footprints = _get_P3()
     else:
         raise ValueError("u has an invalid number of dimensions "
                          "(should be 2 or 3)")
@@ -340,7 +339,7 @@ def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
         # Image attachment
         du = gradient(u)
         abs_du = _abs_grad_kernel(du[0], du[1])
-        aux_lt0, aux_gt0 =  _fused_variance_kernel(
+        aux_lt0, aux_gt0 = _fused_variance_kernel(
             image, c1, c0, lambda1, lambda2, abs_du
         )
         u[aux_lt0] = 1
@@ -457,7 +456,7 @@ def morphological_geodesic_active_contour(gimage, num_iter,
     if _misc.ndim(u) == 2:
         footprints = _get_P2()
     elif _misc.ndim(u) == 3:
-        footprints  = _get_P3()
+        footprints = _get_P3()
     else:
         raise ValueError("u has an invalid number of dimensions "
                          "(should be 2 or 3)")

--- a/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
+++ b/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
@@ -29,64 +29,53 @@ class _fcycle(object):
 
 
 # SI and IS operators for 2D and 3D.
-_P2 = [np.eye(3),
-       np.array([[0, 1, 0]] * 3),
-       np.flipud(np.eye(3)),
-       np.rot90([[0, 1, 0]] * 3)]
-_P3 = [np.zeros((3, 3, 3)) for i in range(9)]
-
-_P3[0][:, :, 1] = 1
-_P3[1][:, 1, :] = 1
-_P3[2][1, :, :] = 1
-_P3[3][:, [0, 1, 2], [0, 1, 2]] = 1
-_P3[4][:, [0, 1, 2], [2, 1, 0]] = 1
-_P3[5][[0, 1, 2], :, [0, 1, 2]] = 1
-_P3[6][[0, 1, 2], :, [2, 1, 0]] = 1
-_P3[7][[0, 1, 2], [0, 1, 2], :] = 1
-_P3[8][[0, 1, 2], [2, 1, 0], :] = 1
+def _get_P2():
+    _P2 = [cp.eye(3),
+           cp.array([[0, 1, 0]] * 3),
+           cp.array(np.flipud(np.eye(3))),
+           cp.array(np.rot90([[0, 1, 0]] * 3))]
+    return _P2
 
 
-def sup_inf(u):
+def _get_P3():
+    _P3 = [np.zeros((3, 3, 3)) for i in range(9)]
+
+    _P3[0][:, :, 1] = 1
+    _P3[1][:, 1, :] = 1
+    _P3[2][1, :, :] = 1
+    _P3[3][:, [0, 1, 2], [0, 1, 2]] = 1
+    _P3[4][:, [0, 1, 2], [2, 1, 0]] = 1
+    _P3[5][[0, 1, 2], :, [0, 1, 2]] = 1
+    _P3[6][[0, 1, 2], :, [2, 1, 0]] = 1
+    _P3[7][[0, 1, 2], [0, 1, 2], :] = 1
+    _P3[8][[0, 1, 2], [2, 1, 0], :] = 1
+    return [cp.array(p) for p in _P3]
+
+
+def sup_inf(u, footprints, workspace=None):
     """SI operator."""
-
-    if _misc.ndim(u) == 2:
-        P = _P2
-    elif _misc.ndim(u) == 3:
-        P = _P3
+    if workspace is None:
+        erosions = cp.empty(((len(footprints),) + u.shape), dtype=u.dtype)
     else:
-        raise ValueError("u has an invalid number of dimensions "
-                         "(should be 2 or 3)")
-
-    erosions = []
-    for P_i in P:
-        e = ndi.binary_erosion(u, cp.asarray(P_i)).astype(np.int8, copy=False)
-        erosions.append(e)
-
-    return cp.stack(erosions, axis=0).max(0)
+        erosions = workspace
+    for i, footprint in enumerate(footprints):
+        erosions[i, ...] = ndi.binary_erosion(u, footprint)
+    return erosions.max(0)
 
 
-def inf_sup(u):
+def inf_sup(u, footprints, workspace=None):
     """IS operator."""
-
-    if _misc.ndim(u) == 2:
-        P = _P2
-    elif _misc.ndim(u) == 3:
-        P = _P3
+    if workspace is None:
+        dilations = cp.empty(((len(footprints),) + u.shape), dtype=u.dtype)
     else:
-        raise ValueError("u has an invalid number of dimensions "
-                         "(should be 2 or 3)")
-
-    dilations = []
-    for P_i in P:
-        d = ndi.binary_dilation(u, cp.asarray(P_i)).astype(np.int8,
-                                                           copy=False)
-        dilations.append(d)
-
-    return cp.stack(dilations, axis=0).min(0)
+        dilations = workspace
+    for i, footprint in enumerate(footprints):
+        dilations[i, ...] = ndi.binary_dilation(u, footprint)
+    return dilations.min(0)
 
 
-_curvop = _fcycle([lambda u: sup_inf(inf_sup(u)),   # SIoIS
-                   lambda u: inf_sup(sup_inf(u))])  # ISoSI
+_curvop = _fcycle([lambda u, f, w: sup_inf(inf_sup(u, f, w), f ,w),   # SIoIS
+                   lambda u, f, w: inf_sup(sup_inf(u, f, w), f ,w)])  # ISoSI
 
 
 def _check_input(image, init_level_set):
@@ -219,6 +208,29 @@ def inverse_gaussian_gradient(image, alpha=100.0, sigma=5.0):
     return 1.0 / cp.sqrt(1.0 + alpha * gradnorm)
 
 
+@cp.fuse()
+def _abs_grad_kernel(gx, gy):
+    return cp.abs(gx) + cp.abs(gy)
+
+
+@cp.fuse()
+def _fused_variance_kernel(
+    image, c1, c2, lam1, lam2, abs_du,
+):
+    difference_term = image - c1
+    difference_term *= difference_term
+    difference_term *= lam1
+    term2 = image - c2
+    term2 *= term2
+    term2 *= lam2
+    difference_term -= term2
+
+    aux = abs_du * difference_term
+    aux_lt0 = aux < 0
+    aux_gt0 = aux > 0
+    return aux_lt0, aux_gt0
+
+
 @deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0",
                  deprecated_version="0.19")
 def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
@@ -298,28 +310,37 @@ def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
 
     u = (init_level_set > 0).astype(cp.int8)
 
-    iter_callback(u)
+    if _misc.ndim(u) == 2:
+        footprints = _get_P2()
+    elif _misc.ndim(u) == 3:
+        footprints  = _get_P3()
+    else:
+        raise ValueError("u has an invalid number of dimensions "
+                         "(should be 2 or 3)")
+    workspace = cp.empty(((len(footprints),) + u.shape), dtype=u.dtype)
 
-    for _ in range(num_iter):
+    iter_callback(u)
+    for i in range(num_iter):
 
         # inside = u > 0
         # outside = u <= 0
-        c0 = (image * (1 - u)).sum() / float((1 - u).sum() + 1e-8)
-        c1 = (image * u).sum() / float(u.sum() + 1e-8)
+        c0 = (image * (1 - u)).sum()
+        c0 /= float((1 - u).sum() + 1e-8)
+        c1 = (image * u).sum()
+        c1 /= float(u.sum() + 1e-8)
 
         # Image attachment
         du = cp.gradient(u)
-        abs_du = cp.abs(cp.stack(du, axis=0)).sum(0)
-        aux = abs_du * (
-            lambda1 * (image - c1) ** 2 - lambda2 * (image - c0) ** 2
+        abs_du = _abs_grad_kernel(du[0], du[1])
+        aux_lt0, aux_gt0 =  _fused_variance_kernel(
+            image, c1, c0, lambda1, lambda2, abs_du
         )
-
-        u[aux < 0] = 1
-        u[aux > 0] = 0
+        u[aux_lt0] = 1
+        u[aux_gt0] = 0
 
         # Smoothing
         for _ in range(smoothing):
-            u = _curvop(u)
+            u = _curvop(u, footprints, workspace)
 
         iter_callback(u)
 
@@ -425,6 +446,15 @@ def morphological_geodesic_active_contour(gimage, num_iter,
 
     u = (init_level_set > 0).astype(cp.int8)
 
+    if _misc.ndim(u) == 2:
+        footprints = _get_P2()
+    elif _misc.ndim(u) == 3:
+        footprints  = _get_P3()
+    else:
+        raise ValueError("u has an invalid number of dimensions "
+                         "(should be 2 or 3)")
+    workspace = cp.empty(((len(footprints),) + u.shape), dtype=u.dtype)
+
     iter_callback(u)
 
     for _ in range(num_iter):
@@ -447,7 +477,7 @@ def morphological_geodesic_active_contour(gimage, num_iter,
 
         # Smoothing
         for _ in range(smoothing):
-            u = _curvop(u)
+            u = _curvop(u, footprints, workspace)
 
         iter_callback(u)
 


### PR DESCRIPTION
This PR is purely a performance refactor without a change in behavior. The main changes to `morphological_chan_vese` are:

- Use a simplified version of `cupy.gradient` that does not promote all integer types to float64 and omits a couple of division operations by assuming unit spacing. Currently we don't have any places where non-uniform spacing or non first-order edges are needed, but we can always still use `cupy.gradient` for those if they come up in the future. 

- apply kernel fusion via `cupy.fuse()` decorators.

- avoid repeated transfer of footprints to the GPU and reuse the same workspace array for repeated `_curveop` calculations.

Overall, these changes give around 1/3 reduction in run-time for `morphological_chan_vese`.

All other places using `cp.gradient` were also changed to use the simplified `gradient` defined here. These include:
`cucim.skimage.features.hessian_matrix`
`cucim.skimage.features.multiscale_basic_features`
`cucim.skimage.registration.optical_flow_tvl1`
