### PR TITLE
Allow CuPy 11

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy >=9,<11.0.0a0
+    - cupy >=9,<12.0.0a0
     - numpy 1.19
     - scipy
     - scikit-image >=0.18.1,<0.20.0a0
@@ -38,7 +38,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy >=9,<11.0.0a0
+    - cupy >=9,<12.0.0a0
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-image >=0.18.1,<0.20.0a0


### PR DESCRIPTION
Allows cuCIM to be installed with CuPy 11.

xref: https://github.com/rapidsai/integration/pull/508