### PR TITLE
create SimilarityTransform using CuPy 9.x-compatible indexing

### DIFF
--- a/python/cucim/src/cucim/skimage/transform/_geometric.py
+++ b/python/cucim/src/cucim/skimage/transform/_geometric.py
@@ -1421,10 +1421,8 @@ class SimilarityTransform(EuclideanTransform):
             if translation is None:
                 translation = (0,) * dimensionality
             if dimensionality == 2:
-                ax = (0, 1)
                 c, s = _cos(rotation), _sin(rotation)
-                matrix[ax, ax] = c
-                matrix[ax, ax[::-1]] = -s, s
+                matrix[:2, :2] = xp.array([[c, -s], [s, c]], dtype=float)
             else:  # 3D rotation
                 matrix[:3, :3] = xp.asarray(_euler_rotation_matrix(rotation))
 


### PR DESCRIPTION
closes #364

This tiny fix resolves the local test failures I saw with CuPy 9.6. I also think the updated code is clearer in any case.