### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy >=9,<12.0.0a0
+    - cupy >=9,<11.0.0a0
     - numpy 1.19
     - scipy
     - scikit-image >=0.18.1,<0.20.0a0
@@ -38,7 +38,7 @@ requirements:
     - python {{ python_version }}.*
     - libcucim {{ version }}.*
     - click
-    - cupy >=9,<12.0.0a0
+    - cupy >=9,<11.0.0a0
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-image >=0.18.1,<0.20.0a0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.