### PR TITLE
add cucim.core.morphology to API docs + other docstring fixes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -55,6 +55,13 @@ intensity
     :members:
     :undoc-members:
 
+morphology
+----------
+
+.. automodule:: cucim.core.operations.morphology
+    :members:
+    :undoc-members:
+
 spatial
 -------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.mathjax',
     'numpydoc',
     'doi_role',
     'IPython.sphinxext.ipython_console_highlighting',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,10 +173,13 @@ texinfo_documents = [
 ]
 
 
-# Example configuration for intersphinx: refer to the Python standard library.
+# Configuration for intersphinx: refer to other projects documentation.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
+    'cupy': ('https://docs.cupy.dev/en/stable/', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'skimage': ('https://scikit-image.org/docs/stable/', None),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,7 +174,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+}
 
 
 # Config numpydoc

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -56,12 +56,9 @@ def image_to_absorbance(image, source_intensity=255.0, dtype=cp.float32):
     -----
     If `image` has an integer dtype it will be clipped to range
     ``[1, source_intensity]``, while float image inputs are clipped to range
-    ``[source_intensity/255, source_intensity]. The minimum is to avoid log(0).
-    Absorbance is then given by
-
-    .. math::
-
-        absorbance = \\log{\\frac{image}{source_intensity}}.
+    ``[source_intensity/255, source_intensity]``.
+    The minimum is to avoid log(0). Absorbance is then given by
+    ``absorbance = log(image / source_intensity)``.
     """
     dtype = cp.dtype(dtype)
     if dtype.kind != "f":

--- a/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
@@ -11,7 +11,7 @@ from ._pba_3d import _pba_3d
 def distance_transform_edt(image, sampling=None, return_distances=True,
                            return_indices=False, distances=None, indices=None,
                            *, block_params=None, float64_distances=False):
-    """Exact Euclidean distance transform.
+    r"""Exact Euclidean distance transform.
 
     This function calculates the distance transform of the `input`, by
     replacing each foreground (non-zero) element, with its shortest distance to
@@ -68,17 +68,18 @@ def distance_transform_edt(image, sampling=None, return_distances=True,
 
     Notes
     -----
-    The Euclidean distance transform gives values of the Euclidean distance::
+    The Euclidean distance transform gives values of the Euclidean distance.
 
-                    n
-      y_i = sqrt(sum (x[i]-b[i])**2)
-                    i
+    .. math::
 
-    where b[i] is the background point (value 0) with the smallest Euclidean
-    distance to input points x[i], and n is the number of dimensions.
+      y_i = \sqrt{\sum_{i}^{n} (x[i] - b[i])^2}
+
+    where :math:`b[i]` is the background point (value 0) with the smallest
+    Euclidean distance to input points :math:`x[i]`, and :math:`n` is the
+    number of dimensions.
 
     Note that the `indices` output may differ from the one given by
-    `scipy.ndimage.distance_transform_edt` in the case of input pixels that are
+    ``scipy.ndimage.distance_transform_edt`` in the case of input pixels that are
     equidistant from multiple background points.
 
     The parallel banding algorithm implemented here was originally described in
@@ -88,7 +89,7 @@ def distance_transform_edt(image, sampling=None, return_distances=True,
 
     References
     ----------
-    ..[1] Thanh-Tung Cao, Ke Tang, Anis Mohamed, and Tiow-Seng Tan. 2010.
+    .. [1] Thanh-Tung Cao, Ke Tang, Anis Mohamed, and Tiow-Seng Tan. 2010.
         Parallel Banding Algorithm to compute exact distance transform with the
         GPU. In Proceedings of the 2010 ACM SIGGRAPH symposium on Interactive
         3D Graphics and Games (I3D ’10). Association for Computing Machinery,

--- a/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
@@ -79,8 +79,8 @@ def distance_transform_edt(image, sampling=None, return_distances=True,
     number of dimensions.
 
     Note that the `indices` output may differ from the one given by
-    ``scipy.ndimage.distance_transform_edt`` in the case of input pixels that are
-    equidistant from multiple background points.
+    :func:`scipy.ndimage.distance_transform_edt` in the case of input pixels
+    that are equidistant from multiple background points.
 
     The parallel banding algorithm implemented here was originally described in
     [1]_. The kernels used here correspond to the revised PBA+ implementation


### PR DESCRIPTION
make sure `cucim.core.morphology` module is included in the core API docs

fix typo in references section of `distance_transform_edt` docstring

setup intersphinx link to SciPy docs (used in `distance_transform_edt`)

add `sphinx.ext.mathjax` for LaTeX rendering

fix sphinx warning/typo related to `image_to_absorbance` docstring
