### PR TITLE
Add missing imports of euler_number and perimeter_crofton

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/__init__.py
+++ b/python/cucim/src/cucim/skimage/measure/__init__.py
@@ -4,7 +4,8 @@ from ._moments import (centroid, inertia_tensor, inertia_tensor_eigvals,
                        moments, moments_central, moments_coords,
                        moments_coords_central, moments_hu, moments_normalized)
 from ._polygon import approximate_polygon, subdivide_polygon
-from ._regionprops import perimeter, regionprops, regionprops_table
+from ._regionprops import (euler_number, perimeter, perimeter_crofton,
+                           regionprops, regionprops_table)
 from .block import block_reduce
 from .entropy import shannon_entropy
 from .profile import profile_line

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -13,11 +13,11 @@ from cucim.skimage import transform
 from cucim.skimage._shared._warnings import expected_warnings
 from cucim.skimage.measure._regionprops import \
     _inertia_eigvals_to_axes_lengths_3D  # noqa
+from cucim.skimage.measure import (euler_number, perimeter, perimeter_crofton,
+                                   regionprops, regionprops_table)
 from cucim.skimage.measure._regionprops import (COL_DTYPES, OBJECT_COLUMNS,
                                                 PROPS, _parse_docs,
-                                                _props_to_dict, euler_number,
-                                                perimeter, perimeter_crofton,
-                                                regionprops, regionprops_table)
+                                                _props_to_dict)
 
 # fmt: off
 SAMPLE = cp.array(


### PR DESCRIPTION
These functions had been implemented, but were missing from the `__init__.py` in `skimage.measure`. This was not caught because the test cases had imported them from the private submodule!

