### PR TITLE
add isotropic binary morphology functions

### DIFF
--- a/benchmarks/skimage/cucim_morphology_bench.py
+++ b/benchmarks/skimage/cucim_morphology_bench.py
@@ -53,7 +53,7 @@ class BinaryMorphologyBench(ImageBench):
         )
 
     def set_args(self, dtype):
-        imaged = cp.random.standard_normal(self.shape).astype(dtype) > 0
+        imaged = (cp.random.standard_normal(self.shape) > 0).astype(dtype)
         image = cp.asnumpy(imaged)
         self.args_cpu = (image,)
         self.args_gpu = (imaged,)
@@ -61,7 +61,7 @@ class BinaryMorphologyBench(ImageBench):
 
 class IsotropicMorphologyBench(ImageBench):
     def set_args(self, dtype):
-        imaged = cp.random.standard_normal(self.shape).astype(dtype) > 0
+        imaged = (cp.random.standard_normal(self.shape) > 0).astype(dtype)
         image = cp.asnumpy(imaged)
         self.args_cpu = (image,)
         self.args_gpu = (imaged,)

--- a/benchmarks/skimage/run-nv-bench-morphology.sh
+++ b/benchmarks/skimage/run-nv-bench-morphology.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 param_shape=(512,512 3840,2160 3840,2160,3 192,192,192)
-param_filt=(binary_erosion binary_dilation binary_opening binary_closing remove_small_objects remove_small_holes erosion dilation opening closing white_tophat black_tophat medial_axis thin reconstruction)
-
+param_filt=(binary_erosion binary_dilation binary_opening binary_closing isotropic_erosion isotropic_dilation isotropic_opening isotropic_closing remove_small_objects remove_small_holes erosion dilation opening closing white_tophat black_tophat medial_axis thin reconstruction)
 param_dt=(uint8)
 for shape in "${param_shape[@]}"; do
     for filt in "${param_filt[@]}"; do
         for dt in "${param_dt[@]}"; do
-            python cucim_morphology_bench.py -f $filt -i $shape -d $dt -t 10
+            python cucim_morphology_bench.py -f $filt -i $shape -d $dt -t 4
         done
     done
 done
@@ -18,7 +17,7 @@ param_dt=(float32)
 for shape in "${param_shape[@]}"; do
     for filt in "${param_filt[@]}"; do
         for dt in "${param_dt[@]}"; do
-            python cucim_morphology_bench.py -f $filt -i $shape -d $dt -t 10
+            python cucim_morphology_bench.py -f $filt -i $shape -d $dt -t 4
         done
     done
 done

--- a/python/cucim/src/cucim/skimage/morphology/__init__.py
+++ b/python/cucim/src/cucim/skimage/morphology/__init__.py
@@ -6,6 +6,8 @@ from .footprints import (ball, cube, diamond, disk, octagon, octahedron,
 from .gray import (black_tophat, closing, dilation, erosion, opening,
                    white_tophat)
 from .grayreconstruct import reconstruction
+from .isotropic import (isotropic_dilation, isotropic_erosion,
+                        isotropic_opening, isotropic_closing)
 from .misc import remove_small_holes, remove_small_objects
 
 __all__ = [
@@ -13,6 +15,10 @@ __all__ = [
     "binary_dilation",
     "binary_opening",
     "binary_closing",
+    "isotropic_dilation",
+    "isotropic_erosion",
+    "isotropic_opening",
+    "isotropic_closing",
     "erosion",
     "dilation",
     "opening",

--- a/python/cucim/src/cucim/skimage/morphology/isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/isotropic.py
@@ -1,0 +1,196 @@
+"""
+Binary morphological operations
+"""
+import cupy as cp
+from cucim.core.operations.morphology import distance_transform_edt
+
+
+def isotropic_erosion(image, radius, out=None, spacing=None):
+    """Return binary morphological erosion of an image.
+
+    This function returns the same result as :func:`skimage.morphology.binary_erosion`
+    but performs faster for large circular structuring elements.
+    This works by applying a threshold to the exact Euclidean distance map
+    of the image [1]_, [2]_.
+    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+
+    Parameters
+    ----------
+    image : ndarray
+        Binary input image.
+    radius : float
+        The radius by which regions should be eroded.
+    out : ndarray of bool, optional
+        The array to store the result of the morphology. If None,
+        a new array will be allocated.
+    spacing : float, or sequence of float, optional
+        Spacing of elements along each dimension.
+        If a sequence, must be of length equal to the input's dimension
+        (number of axes). If a single number, this value is used for all axes.
+        If not specified, a grid spacing of unity is implied.
+
+    Returns
+    -------
+    eroded : ndarray of bool
+        The result of the morphological erosion taking values in
+        ``[False, True]``.
+
+    References
+    ---------------
+    .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
+        using local distance transformation by propagation, and applications,"
+        Image Processing And Its Applications, 1999. Seventh International
+        Conference on (Conf. Publ. No. 465), 1999, pp. 856-860 vol.2.
+        :DOI:`10.1049/cp:19990446`
+
+    .. [2] Ingemar Ragnemalm, Fast erosion and dilation by contour processing
+        and thresholding of distance maps, Pattern Recognition Letters,
+        Volume 13, Issue 3, 1992, Pages 161-166.
+        :DOI:`10.1016/0167-8655(92)90055-5`
+    """
+
+    dist = distance_transform_edt(image, sampling=spacing)
+    return cp.greater(dist, radius, out=out)
+
+
+def isotropic_dilation(image, radius, out=None, spacing=None):
+    """Return binary morphological dilation of an image.
+
+    This function returns the same result as :func:`skimage.morphology.binary_dilation`
+    but performs faster for large circular structuring elements.
+    This works by applying a threshold to the exact Euclidean distance map
+    of the inverted image [1]_, [2]_.
+    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+
+    Parameters
+    ----------
+    image : ndarray
+        Binary input image.
+    radius : float
+        The radius by which regions should be dilated.
+    out : ndarray of bool, optional
+        The array to store the result of the morphology. If None is
+        passed, a new array will be allocated.
+    spacing : float, or sequence of float, optional
+        Spacing of elements along each dimension.
+        If a sequence, must be of length equal to the input's dimension
+        (number of axes).
+        If a single number, this value is used for all axes.
+        If not specified, a grid spacing of unity is implied.
+
+    Returns
+    -------
+    dilated : ndarray of bool
+        The result of the morphological dilation with values in
+        ``[False, True]``.
+
+    References
+    ---------------
+    .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
+        using local distance transformation by propagation, and applications,"
+        Image Processing And Its Applications, 1999. Seventh International
+        Conference on (Conf. Publ. No. 465), 1999, pp. 856-860 vol.2.
+        :DOI:`10.1049/cp:19990446`
+
+    .. [2] Ingemar Ragnemalm, Fast erosion and dilation by contour processing
+        and thresholding of distance maps, Pattern Recognition Letters,
+        Volume 13, Issue 3, 1992, Pages 161-166.
+        :DOI:`10.1016/0167-8655(92)90055-5`
+    """
+
+    dist = distance_transform_edt(cp.logical_not(image), sampling=spacing)
+    return cp.less_equal(dist, radius, out=out)
+
+
+def isotropic_opening(image, radius, out=None, spacing=None):
+    """Return binary morphological opening of an image.
+
+    This function returns the same result as :func:`skimage.morphology.binary_opening`
+    but performs faster for large circular structuring elements.
+    This works by thresholding the exact Euclidean distance map [1]_, [2]_.
+    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+
+    Parameters
+    ----------
+    image : ndarray
+        Binary input image.
+    radius : float
+        The radius with which the regions should be opened.
+    out : ndarray of bool, optional
+        The array to store the result of the morphology. If None
+        is passed, a new array will be allocated.
+    spacing : float, or sequence of float, optional
+        Spacing of elements along each dimension.
+        If a sequence, must be of length equal to the input's dimension
+        (number of axes).
+        If a single number, this value is used for all axes.
+        If not specified, a grid spacing of unity is implied.
+
+    Returns
+    -------
+    opened : ndarray of bool
+        The result of the morphological opening.
+
+    References
+    ---------------
+    .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
+        using local distance transformation by propagation, and applications,"
+        Image Processing And Its Applications, 1999. Seventh International
+        Conference on (Conf. Publ. No. 465), 1999, pp. 856-860 vol.2.
+        :DOI:`10.1049/cp:19990446`
+
+    .. [2] Ingemar Ragnemalm, Fast erosion and dilation by contour processing
+        and thresholding of distance maps, Pattern Recognition Letters,
+        Volume 13, Issue 3, 1992, Pages 161-166.
+        :DOI:`10.1016/0167-8655(92)90055-5`
+    """
+
+    eroded = isotropic_erosion(image, radius, out=out, spacing=spacing)
+    return isotropic_dilation(eroded, radius, out=out, spacing=spacing)
+
+
+def isotropic_closing(image, radius, out=None, spacing=None):
+    """Return binary morphological closing of an image.
+
+    This function returns the same result as binary :func:`skimage.morphology.binary_closing`
+    but performs faster for large circular structuring elements.
+    This works by thresholding the exact Euclidean distance map [1]_, [2]_.
+    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+
+    Parameters
+    ----------
+    image : ndarray
+        Binary input image.
+    radius : float
+        The radius with which the regions should be closed.
+    out : ndarray of bool, optional
+        The array to store the result of the morphology. If None,
+        is passed, a new array will be allocated.
+    spacing : float, or sequence of float, optional
+        Spacing of elements along each dimension.
+        If a sequence, must be of length equal to the input's dimension
+        (number of axes).
+        If a single number, this value is used for all axes.
+        If not specified, a grid spacing of unity is implied.
+
+    Returns
+    -------
+    closed : ndarray of bool
+        The result of the morphological closing.
+
+    References
+    ---------------
+    .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
+        using local distance transformation by propagation, and applications,"
+        Image Processing And Its Applications, 1999. Seventh International
+        Conference on (Conf. Publ. No. 465), 1999, pp. 856-860 vol.2.
+        :DOI:`10.1049/cp:19990446`
+
+    .. [2] Ingemar Ragnemalm, Fast erosion and dilation by contour processing
+        and thresholding of distance maps, Pattern Recognition Letters,
+        Volume 13, Issue 3, 1992, Pages 161-166.
+        :DOI:`10.1016/0167-8655(92)90055-5`
+    """
+
+    dilated = isotropic_dilation(image, radius, out=out, spacing=spacing)
+    return isotropic_erosion(dilated, radius, out=out, spacing=spacing)

--- a/python/cucim/src/cucim/skimage/morphology/isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/isotropic.py
@@ -60,7 +60,13 @@ def isotropic_erosion(image, radius, out=None, spacing=None):
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
     dist = distance_transform_edt(image, sampling=spacing)
-    return cp.greater(dist, radius, out=out)
+    if out is not None:
+        # Copying instead of using the out= kwarg here since one CI test run
+        # on CentOS 7 failed for test_out_argument otherwise.
+        out[:] = cp.greater(dist, radius)
+    else:
+        out = cp.greater(dist, radius)
+    return out
 
 
 def isotropic_dilation(image, radius, out=None, spacing=None):
@@ -119,7 +125,13 @@ def isotropic_dilation(image, radius, out=None, spacing=None):
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
     dist = distance_transform_edt(cp.logical_not(image), sampling=spacing)
-    return cp.less_equal(dist, radius, out=out)
+    if out is not None:
+        # Copying instead of using the out= kwarg here since one CI test run
+        # on CentOS 7 failed for test_out_argument otherwise.
+        out[:] = cp.less_equal(dist, radius)
+    else:
+        out = cp.less_equal(dist, radius)
+    return out
 
 
 def isotropic_opening(image, radius, out=None, spacing=None):
@@ -175,7 +187,7 @@ def isotropic_opening(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-    eroded = isotropic_erosion(image, radius, out=out, spacing=spacing)
+    eroded = isotropic_erosion(image, radius, spacing=spacing)
     return isotropic_dilation(eroded, radius, out=out, spacing=spacing)
 
 
@@ -232,5 +244,5 @@ def isotropic_closing(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-    dilated = isotropic_dilation(image, radius, out=out, spacing=spacing)
+    dilated = isotropic_dilation(image, radius, spacing=spacing)
     return isotropic_erosion(dilated, radius, out=out, spacing=spacing)

--- a/python/cucim/src/cucim/skimage/morphology/isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/isotropic.py
@@ -36,8 +36,18 @@ def isotropic_erosion(image, radius, out=None, spacing=None):
         The result of the morphological erosion taking values in
         ``[False, True]``.
 
+    Notes
+    -----
+    Empirically, on an RTX A6000 GPU, it was observed that
+    ``isotropic_erosion`` is faster than ``binary_erosion`` with
+    ``decomposition=None`` at radius 12 in 2D and radius 3 in 3D. It becomes
+    faster than ``binary_erosion`` with ``decomposition="sequence"`` at radius
+    14 in 2D and radius 5 in 3D. In practice, the exact point at which these
+    isotropic functions become faster than their binary counterparts will also
+    be dependent on image shape and content.
+
     References
-    ---------------
+    ----------
     .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
         using local distance transformation by propagation, and applications,"
         Image Processing And Its Applications, 1999. Seventh International
@@ -49,7 +59,6 @@ def isotropic_erosion(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-
     dist = distance_transform_edt(image, sampling=spacing)
     return cp.greater(dist, radius, out=out)
 
@@ -86,8 +95,18 @@ def isotropic_dilation(image, radius, out=None, spacing=None):
         The result of the morphological dilation with values in
         ``[False, True]``.
 
+    Notes
+    -----
+    Empirically, on an RTX A6000 GPU, it was observed that
+    ``isotropic_dilation`` is faster than ``binary_dilation`` with
+    ``decomposition=None`` at radius 12 in 2D and radius 3 in 3D. It becomes
+    faster than ``binary_dilation`` with ``decomposition="sequence"`` at radius
+    14 in 2D and radius 5 in 3D. In practice, the exact point at which these
+    isotropic functions become faster than their binary counterparts will also
+    be dependent on image shape and content.
+
     References
-    ---------------
+    ----------
     .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
         using local distance transformation by propagation, and applications,"
         Image Processing And Its Applications, 1999. Seventh International
@@ -99,7 +118,6 @@ def isotropic_dilation(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-
     dist = distance_transform_edt(cp.logical_not(image), sampling=spacing)
     return cp.less_equal(dist, radius, out=out)
 
@@ -134,8 +152,18 @@ def isotropic_opening(image, radius, out=None, spacing=None):
     opened : ndarray of bool
         The result of the morphological opening.
 
+    Notes
+    -----
+    Empirically, on an RTX A6000 GPU, it was observed that
+    ``isotropic_opening`` is faster than ``binary_opening`` with
+    ``decomposition=None`` at radius 12 in 2D and radius 3 in 3D. It becomes
+    faster than ``binary_erosion`` with ``decomposition="sequence"`` at radius
+    14 in 2D and radius 5 in 3D. In practice, the exact point at which these
+    isotropic functions become faster than their binary counterparts will also
+    be dependent on image shape and content.
+
     References
-    ---------------
+    ----------
     .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
         using local distance transformation by propagation, and applications,"
         Image Processing And Its Applications, 1999. Seventh International
@@ -147,7 +175,6 @@ def isotropic_opening(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-
     eroded = isotropic_erosion(image, radius, out=out, spacing=spacing)
     return isotropic_dilation(eroded, radius, out=out, spacing=spacing)
 
@@ -182,8 +209,18 @@ def isotropic_closing(image, radius, out=None, spacing=None):
     closed : ndarray of bool
         The result of the morphological closing.
 
+    Notes
+    -----
+    Empirically, on an RTX A6000 GPU, it was observed that
+    ``isotropic_closing`` is faster than ``binary_closing`` with
+    ``decomposition=None`` at radius 12 in 2D and radius 3 in 3D. It becomes
+    faster than ``binary_erosion`` with ``decomposition="sequence"`` at radius
+    14 in 2D and radius 5 in 3D. In practice, the exact point at which these
+    isotropic functions become faster than their binary counterparts will also
+    be dependent on image shape and content.
+
     References
-    ---------------
+    ----------
     .. [1] Cuisenaire, O. and Macq, B., "Fast Euclidean morphological operators
         using local distance transformation by propagation, and applications,"
         Image Processing And Its Applications, 1999. Seventh International
@@ -195,6 +232,5 @@ def isotropic_closing(image, radius, out=None, spacing=None):
         Volume 13, Issue 3, 1992, Pages 161-166.
         :DOI:`10.1016/0167-8655(92)90055-5`
     """
-
     dilated = isotropic_dilation(image, radius, out=out, spacing=spacing)
     return isotropic_erosion(dilated, radius, out=out, spacing=spacing)

--- a/python/cucim/src/cucim/skimage/morphology/isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/isotropic.py
@@ -8,11 +8,12 @@ from cucim.core.operations.morphology import distance_transform_edt
 def isotropic_erosion(image, radius, out=None, spacing=None):
     """Return binary morphological erosion of an image.
 
-    This function returns the same result as :func:`skimage.morphology.binary_erosion`
-    but performs faster for large circular structuring elements.
-    This works by applying a threshold to the exact Euclidean distance map
-    of the image [1]_, [2]_.
-    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+    This function returns the same result as
+    :func:`skimage.morphology.binary_erosion` but performs faster for large
+    circular structuring elements. This works by applying a threshold to the
+    exact Euclidean distance map of the image [1]_, [2]_. The implementation is
+    based on:
+    func:`cucim.core.operations.morphology.distance_transform_edt`.
 
     Parameters
     ----------
@@ -56,11 +57,12 @@ def isotropic_erosion(image, radius, out=None, spacing=None):
 def isotropic_dilation(image, radius, out=None, spacing=None):
     """Return binary morphological dilation of an image.
 
-    This function returns the same result as :func:`skimage.morphology.binary_dilation`
-    but performs faster for large circular structuring elements.
-    This works by applying a threshold to the exact Euclidean distance map
-    of the inverted image [1]_, [2]_.
-    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+    This function returns the same result as
+    :func:`skimage.morphology.binary_dilation` but performs faster for large
+    circular structuring elements. This works by applying a threshold to the
+    exact Euclidean distance map of the inverted image [1]_, [2]_. The
+    implementation is based on:
+    func:`cucim.core.operations.morphology.distance_transform_edt`.
 
     Parameters
     ----------
@@ -105,10 +107,11 @@ def isotropic_dilation(image, radius, out=None, spacing=None):
 def isotropic_opening(image, radius, out=None, spacing=None):
     """Return binary morphological opening of an image.
 
-    This function returns the same result as :func:`skimage.morphology.binary_opening`
-    but performs faster for large circular structuring elements.
-    This works by thresholding the exact Euclidean distance map [1]_, [2]_.
-    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+    This function returns the same result as
+    :func:`skimage.morphology.binary_opening` but performs faster for large
+    circular structuring elements. This works by thresholding the exact
+    Euclidean distance map [1]_, [2]_. The implementation is based on:
+    func:`cucim.core.operations.morphology.distance_transform_edt`.
 
     Parameters
     ----------
@@ -152,10 +155,11 @@ def isotropic_opening(image, radius, out=None, spacing=None):
 def isotropic_closing(image, radius, out=None, spacing=None):
     """Return binary morphological closing of an image.
 
-    This function returns the same result as binary :func:`skimage.morphology.binary_closing`
-    but performs faster for large circular structuring elements.
-    This works by thresholding the exact Euclidean distance map [1]_, [2]_.
-    The implementation is based on: func:`scipy.ndimage.distance_transform_edt`.
+    This function returns the same result as binary
+    :func:`skimage.morphology.binary_closing` but performs faster for large
+    circular structuring elements. This works by thresholding the exact
+    Euclidean distance map [1]_, [2]_. The implementation is based on:
+    func:`cucim.core.operations.morphology.distance_transform_edt`.
 
     Parameters
     ----------

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -89,9 +89,11 @@ def test_footprint_overflow():
 
 
 def test_out_argument():
-    for func in (morphology.isotropic_erosion, morphology.isotropic_dilation):
+    for func in (morphology.isotropic_erosion, morphology.isotropic_dilation,
+                 morphology.isotropic_opening, morphology.isotropic_closing):
         radius = 3
         img = cp.ones((10, 10))
+        img[2:5, 2:5] = 0
         out = cp.zeros_like(img)
         out_saved = out.copy()
         func(img, radius, out=out)

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -1,6 +1,5 @@
 import cupy as cp
 import numpy as np
-import pytest
 from cupy.testing import assert_array_equal
 from skimage import data
 

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -1,5 +1,6 @@
 import cupy as cp
 import numpy as np
+import pytest
 from cupy.testing import assert_array_equal
 from skimage import data
 
@@ -44,6 +45,7 @@ def _disk_with_spacing(
     return cp.asarray((X ** 2 + Y ** 2) <= radius ** 2, dtype=dtype)
 
 
+@pytest.mark.xfail(reason="will fail until gh-406 is merged")
 def test_isotropic_erosion_spacing():
     isotropic_res = morphology.isotropic_dilation(bw_img, 6, spacing=(1, 2))
     binary_res = img_as_bool(

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -20,11 +20,15 @@ def test_non_square_image():
 
 def test_isotropic_erosion():
     isotropic_res = morphology.isotropic_erosion(bw_img, 3)
-    binary_res = img_as_bool(morphology.binary_erosion(bw_img, morphology.disk(3)))
+    binary_res = img_as_bool(
+        morphology.binary_erosion(bw_img, morphology.disk(3))
+    )
     assert_array_equal(isotropic_res, binary_res)
 
 
-def _disk_with_spacing(radius, dtype=cp.uint8, *, strict_radius=True, spacing=None):
+def _disk_with_spacing(
+    radius, dtype=cp.uint8, *, strict_radius=True, spacing=None
+):
     # Identical to morphology.disk, but with a spacing parameter and without
     # decomposition. This is different from morphology.ellipse which produces a
     # slightly different footprint.
@@ -41,9 +45,11 @@ def _disk_with_spacing(radius, dtype=cp.uint8, *, strict_radius=True, spacing=No
 
 
 def test_isotropic_erosion_spacing():
-    isotropic_res = morphology.isotropic_dilation(bw_img, 6, spacing=(1,2))
+    isotropic_res = morphology.isotropic_dilation(bw_img, 6, spacing=(1, 2))
     binary_res = img_as_bool(
-        morphology.binary_dilation(bw_img, _disk_with_spacing(6, spacing=(1,2)))
+        morphology.binary_dilation(
+            bw_img, _disk_with_spacing(6, spacing=(1, 2))
+        )
     )
     assert_array_equal(isotropic_res, binary_res)
 
@@ -58,13 +64,17 @@ def test_isotropic_dilation():
 
 def test_isotropic_closing():
     isotropic_res = morphology.isotropic_closing(bw_img, 3)
-    binary_res = img_as_bool(morphology.binary_closing(bw_img, morphology.disk(3)))
+    binary_res = img_as_bool(
+        morphology.binary_closing(bw_img, morphology.disk(3))
+    )
     assert_array_equal(isotropic_res, binary_res)
 
 
 def test_isotropic_opening():
     isotropic_res = morphology.isotropic_opening(bw_img, 3)
-    binary_res = img_as_bool(morphology.binary_opening(bw_img, morphology.disk(3)))
+    binary_res = img_as_bool(
+        morphology.binary_opening(bw_img, morphology.disk(3))
+    )
     assert_array_equal(isotropic_res, binary_res)
 
 
@@ -72,7 +82,9 @@ def test_footprint_overflow():
     img = cp.zeros((20, 20), dtype=bool)
     img[2:19, 2:19] = True
     isotropic_res = morphology.isotropic_erosion(img, 9)
-    binary_res = img_as_bool(morphology.binary_erosion(img, morphology.disk(9)))
+    binary_res = img_as_bool(
+        morphology.binary_erosion(img, morphology.disk(9))
+    )
     assert_array_equal(isotropic_res, binary_res)
 
 

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -1,0 +1,87 @@
+import cupy as cp
+import numpy as np
+from cupy.testing import assert_array_equal
+from skimage import data
+
+from cucim.skimage import color, morphology
+from cucim.skimage.util import img_as_bool
+
+
+img = color.rgb2gray(cp.asarray(data.astronaut()))
+bw_img = img > 100 / 255.
+
+
+def test_non_square_image():
+    isotropic_res = morphology.isotropic_erosion(bw_img[:100, :200], 3)
+    binary_res = img_as_bool(morphology.binary_erosion(
+        bw_img[:100, :200], morphology.disk(3)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_isotropic_erosion():
+    isotropic_res = morphology.isotropic_erosion(bw_img, 3)
+    binary_res = img_as_bool(morphology.binary_erosion(bw_img, morphology.disk(3)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def _disk_with_spacing(radius, dtype=cp.uint8, *, strict_radius=True, spacing=None):
+    # Identical to morphology.disk, but with a spacing parameter and without
+    # decomposition. This is different from morphology.ellipse which produces a
+    # slightly different footprint.
+    L = np.arange(-radius, radius + 1)
+    X, Y = np.meshgrid(L, L)
+
+    if spacing is not None:
+        X *= spacing[1]
+        Y *= spacing[0]
+
+    if not strict_radius:
+        radius += 0.5
+    return cp.asarray((X ** 2 + Y ** 2) <= radius ** 2, dtype=dtype)
+
+
+def test_isotropic_erosion_spacing():
+    isotropic_res = morphology.isotropic_dilation(bw_img, 6, spacing=(1,2))
+    binary_res = img_as_bool(
+        morphology.binary_dilation(bw_img, _disk_with_spacing(6, spacing=(1,2)))
+    )
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_isotropic_dilation():
+    isotropic_res = morphology.isotropic_dilation(bw_img, 3)
+    binary_res = img_as_bool(
+        morphology.binary_dilation(
+            bw_img, morphology.disk(3)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_isotropic_closing():
+    isotropic_res = morphology.isotropic_closing(bw_img, 3)
+    binary_res = img_as_bool(morphology.binary_closing(bw_img, morphology.disk(3)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_isotropic_opening():
+    isotropic_res = morphology.isotropic_opening(bw_img, 3)
+    binary_res = img_as_bool(morphology.binary_opening(bw_img, morphology.disk(3)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_footprint_overflow():
+    img = cp.zeros((20, 20), dtype=bool)
+    img[2:19, 2:19] = True
+    isotropic_res = morphology.isotropic_erosion(img, 9)
+    binary_res = img_as_bool(morphology.binary_erosion(img, morphology.disk(9)))
+    assert_array_equal(isotropic_res, binary_res)
+
+
+def test_out_argument():
+    for func in (morphology.isotropic_erosion, morphology.isotropic_dilation):
+        radius = 3
+        img = cp.ones((10, 10))
+        out = cp.zeros_like(img)
+        out_saved = out.copy()
+        func(img, radius, out=out)
+        assert cp.any(out != out_saved)
+        assert_array_equal(out, func(img, radius))

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -45,7 +45,6 @@ def _disk_with_spacing(
     return cp.asarray((X ** 2 + Y ** 2) <= radius ** 2, dtype=dtype)
 
 
-@pytest.mark.xfail(reason="will fail until gh-406 is merged")
 def test_isotropic_erosion_spacing():
     isotropic_res = morphology.isotropic_dilation(bw_img, 6, spacing=(1, 2))
     binary_res = img_as_bool(


### PR DESCRIPTION
related to #419

These are based on the distance transform and are a faster way of computing binary morphological operations for large diameter disk or ball footprints. Unlike the sequence footprint decomposition methods, the footprint is exactly circular (spherical).

One test case `test_isotropic_erosion_spacing` will require #407 to be merged first. 

#406 will also improve the performance of this implementation

