### PR TITLE
analytical moments computations, support pixel spacings in moments and regionprops

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -4,6 +4,7 @@ import cupy as cp
 import numpy as np
 
 from .._shared.utils import _supported_float_type, check_nD
+from ._moments_analytical import moments_raw_to_central
 
 
 def moments_coords(coords, order=3):
@@ -258,7 +259,10 @@ def moments_central(image, center=None, order=3, **kwargs):
            [ 0.,  0.,  0.,  0.]])
     """
     if center is None:
-        center = centroid(image)
+        # Note: No need for an explicit call to centroid.
+        #       The centroid will be obtained from the raw moments.
+        moments_raw = moments(image, order=order)
+        return moments_raw_to_central(moments_raw)
     float_dtype = _supported_float_type(image.dtype)
     calc = image.astype(float_dtype, copy=False)
     powers = cp.arange(order + 1, dtype=float_dtype)
@@ -341,7 +345,7 @@ def moments_normalized(mu, order=3):
 def moments_hu(nu):
     """Calculate Hu's set of image moments (2D-only).
 
-    Note that this set of moments is proofed to be translation, scale and
+    Note that this set of moments is proved to be translation, scale and
     rotation invariant.
 
     Parameters

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -374,6 +374,11 @@ def moments_normalized(mu, order=3, spacing=None):
     nu : (``order + 1``,[ ...,] ``order + 1``) array
         Normalized central image moments.
 
+    Notes
+    -----
+    Differs from the scikit-image implementation in that any moments greater
+    than the requested `order` will be set to ``nan``.
+
     References
     ----------
     .. [1] Wilhelm Burger, Mark Burge. Principles of Digital Image Processing:

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -221,9 +221,9 @@ def moments(image, order=3, *, spacing=None):
         else:
             delta = _delta[:dim_length] * spacing[dim]
             powers_of_delta = delta ** powers
-        calc = cp.rollaxis(calc, dim, image.ndim)
+        calc = cp.moveaxis(calc, source=dim, destination=-1)
         calc = cp.dot(calc, powers_of_delta)
-        calc = cp.rollaxis(calc, -1, dim)
+        calc = cp.moveaxis(calc, source=-1, destination=dim)
     return calc
 
 
@@ -292,9 +292,9 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
     for dim, dim_length in enumerate(image.shape):
         delta = _delta[:dim_length] * spacing[dim] - center[dim]
         powers_of_delta = delta ** powers
-        calc = cp.rollaxis(calc, dim, image.ndim)
+        calc = cp.moveaxis(calc, source=dim, destination=-1)
         calc = cp.dot(calc, powers_of_delta)
-        calc = cp.rollaxis(calc, -1, dim)
+        calc = cp.moveaxis(calc, source=-1, destination=dim)
     return calc
 
 

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -498,18 +498,17 @@ def centroid(image, *, spacing=None):
     --------
     >>> import cupy as cp
     >>> from cucim.skimage.measure import centroid
-    >>> image = cp.zeros((20, 20), dtype=np.float64)
+    >>> image = cp.zeros((20, 20), dtype=cp.float64)
     >>> image[13:17, 13:17] = 0.5
     >>> image[10:12, 10:12] = 1
     >>> centroid(image)
     array([13.16666667, 13.16666667])
     """
-    M = moments_central(image, center=(0,) * image.ndim, order=1, spacing=spacing)
-    center = (
-        M[tuple(cp.eye(image.ndim, dtype=int))]  # array of weighted sums
-        # for each axis
-        / M[(0,) * image.ndim]
-    )  # weighted sum of all points
+    mu = moments(image, order=1, spacing=spacing)
+    ndim = image.ndim
+    mu0 = mu[(0,) * ndim]
+    center = mu[tuple((0,)*dim + (1,) + (0,)*(ndim - dim - 1) for dim in range(ndim))]
+    center /= mu0
     return center
 
 

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -336,12 +336,12 @@ def _get_moments_norm_operation(ndim, order, unit_scale=True):
     if unit_scale:
         operation += """
         denom = pow(mu0, static_cast<double>(order_of_current_index) / ndim + 1);
-        nu = mu[i] / denom;"""
+        nu = mu[i] / denom;"""  # noqa
     else:
         operation += """
         s_pow = pow(scale, static_cast<double>(order_of_current_index));
         denom = pow(mu0, static_cast<double>(order_of_current_index) / ndim + 1);
-        nu = (mu[i] / s_pow) / denom;"""
+        nu = (mu[i] / s_pow) / denom;"""  # noqa
     return operation
 
 
@@ -507,7 +507,8 @@ def centroid(image, *, spacing=None):
     mu = moments(image, order=1, spacing=spacing)
     ndim = image.ndim
     mu0 = mu[(0,) * ndim]
-    center = mu[tuple((0,)*dim + (1,) + (0,)*(ndim - dim - 1) for dim in range(ndim))]
+    center = mu[tuple((0,) * dim + (1,) + (0,) * (ndim - dim - 1)
+                for dim in range(ndim))]
     center /= mu0
     return center
 
@@ -549,7 +550,8 @@ def inertia_tensor(image, mu=None, *, spacing=None, xp=cp):
            Scientific Applications. (Chapter 8: Tensor Methods) Springer, 1993.
     """
     if mu is None:
-        mu = moments_central(image, order=2, spacing=spacing)  # don't need higher-order moments
+        # don't need higher-order moments
+        mu = moments_central(image, order=2, spacing=spacing)
     # CuPy Backend: mu and result are tiny, so faster on the CPU
     mu = cp.asnumpy(mu)
     mu0 = mu[(0,) * image.ndim]

--- a/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
@@ -199,7 +199,8 @@ def moments_raw_to_central(moments_raw):
     if ndim in [2, 3] and order < 4:
         # fast path with analytical GPU kernels
         # (avoids any host/device transfers)
-        return _moments_raw_to_central_fast(moments_raw)
+        moments_central = _moments_raw_to_central_fast(moments_raw)
+        return moments_central.astype(moments_raw.dtype, copy=False)
 
     # Fallback to general formula applied on the host
     m = cp.asnumpy(moments_raw)  # synchronize

--- a/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
@@ -1,0 +1,243 @@
+import itertools
+import math
+
+import cupy as cp
+import numpy as np
+
+
+_order0_or_1 = """
+    mc[0] = m[0];
+"""
+
+_order2_2d = """
+    /* Implementation of the commented code below with C-order raveled
+     * indices into 3 x 3 matrices, m and mc.
+     *
+     * mc[0, 0] = m[0, 0];
+     * cx = m[1, 0] / m[0, 0];
+     * cy = m[0, 1] / m[0, 0];
+     * mc[1, 1] = m[1, 1] - cx*m[0, 1];
+     * mc[2, 0] = m[2, 0] - cx*m[1, 0];
+     * mc[0, 2] = m[0, 2] - cy*m[0, 1];
+     */
+    mc[0] = m[0];
+    F cx = m[3] / m[0];
+    F cy = m[1] / m[0];
+    mc[4] = m[4] - cx*m[1];
+    mc[6] = m[6] - cx*m[3];
+    mc[2] = m[2] - cy*m[1];
+"""
+
+_order3_2d = """
+    /* Implementation of the commented code below with C-order raveled
+     * indices into 4 x 4 matrices, m and mc.
+     *
+     * mc[0, 0] = m[0, 0];
+     * cx = m[1, 0] / m[0, 0];
+     * cy = m[0, 1] / m[0, 0];
+     * mc[1, 1] = m[1, 1] - cx*m[0, 1];
+     * mc[2, 0] = m[2, 0] - cx*m[1, 0];
+     * mc[0, 2] = m[0, 2] - cy*m[0, 1];
+     * mc[2, 1] = (m[2, 1] - 2*cx*m[1, 1] - cy*m[2, 0] + cx*cx*m[0, 1] + cy*cx*m[1, 0]);
+     * mc[1, 2] = (m[1, 2] - 2*cy*m[1, 1] - cx*m[0, 2] + 2*cy*cx*m[0, 1]);
+     * mc[3, 0] = m[3, 0] - 3*cx*m[2, 0] + 2*cx*cx*m[1, 0];
+     * mc[0, 3] = m[0, 3] - 3*cy*m[0, 2] + 2*cy*cx*m[0, 1];
+     */
+
+    mc[0] = m[0];
+    F cx = m[4] / m[0];
+    F cy = m[1] / m[0];
+    // 2nd order moments
+    mc[5] = m[5] - cx*m[1];
+    mc[8] = m[8] - cx*m[4];
+    mc[2] = m[2] - cy*m[1];
+    // 3rd order moments
+    mc[9] = (m[9] - 2*cx*m[5] - cy*m[8] + cx*cx*m[1] + cy*cx*m[4]);
+    mc[6] = (m[6] - 2*cy*m[5] - cx*m[2] + 2*cy*cx*m[1]);
+    mc[12] = m[12] - 3*cx*m[8] + 2*cx*cx*m[4];
+    mc[3] = m[3] - 3*cy*m[2] + 2*cy*cy*m[1];
+"""
+
+
+# Note for 2D kernels using C-order raveled indices
+_order2_3d = """
+    /* Implementation of the commented code below with C-order raveled
+     * indices into shape (3, 3, 3) matrices, m and mc.
+     *
+     * mc[0, 0, 0] = m[0, 0, 0];
+     * cx = m[1, 0, 0] / m[0, 0, 0];
+     * cy = m[0, 1, 0] / m[0, 0, 0];
+     * cz = m[0, 0, 1] / m[0, 0, 0];
+     * mc[0, 0, 2] = -cz*m[0, 0, 1] + m[0, 0, 2];
+     * mc[0, 1, 1] = -cy*m[0, 0, 1] + m[0, 1, 1];
+     * mc[0, 2, 0] = -cy*m[0, 1, 0] + m[0, 2, 0];
+     * mc[1, 0, 1] = -cx*m[0, 0, 1] + m[1, 0, 1];
+     * mc[1, 1, 0] = -cx*m[0, 1, 0] + m[1, 1, 0];
+     * mc[2, 0, 0] = -cx*m[1, 0, 0] + m[2, 0, 0];
+     */
+    mc[0] = m[0];
+    F cx = m[9] / m[0];
+    F cy = m[3] / m[0];
+    F cz = m[1] / m[0];
+    // 2nd order moments
+    mc[2] = -cz*m[1] + m[2];
+    mc[4] = -cy*m[1] + m[4];
+    mc[6] = -cy*m[3] + m[6];
+    mc[10] = -cx*m[1] + m[10];
+    mc[12] = -cx*m[3] + m[12];
+    mc[18] = -cx*m[9] + m[18];
+"""
+
+_order3_3d = """
+    /* Implementation of the commented code below with C-order raveled
+     * indices into shape (4, 4, 4) matrices, m and mc.
+     *
+     * mc[0, 0, 0] = m[0, 0, 0];
+     * cx = m[1, 0, 0] / m[0, 0, 0];
+     * cy = m[0, 1, 0] / m[0, 0, 0];
+     * cz = m[0, 0, 1] / m[0, 0, 0];
+     * // 2nd order moments
+     * mc[0, 0, 2] = -cz*m[0, 0, 1] + m[0, 0, 2];
+     * mc[0, 1, 1] = -cy*m[0, 0, 1] + m[0, 1, 1];
+     * mc[0, 2, 0] = -cy*m[0, 1, 0] + m[0, 2, 0];
+     * mc[1, 0, 1] = -cx*m[0, 0, 1] + m[1, 0, 1];
+     * mc[1, 1, 0] = -cx*m[0, 1, 0] + m[1, 1, 0];
+     * mc[2, 0, 0] = -cx*m[1, 0, 0] + m[2, 0, 0];
+     * // 3rd order moments
+     * mc[0, 0, 3] = (2*cz*cz*m[0, 0, 1] - 3*cz*m[0, 0, 2] + m[0, 0, 3]);
+     * mc[0, 1, 2] = (-cy*m[0, 0, 2] + 2*cz*(cy*m[0, 0, 1] - m[0, 1, 1]) + m[0, 1, 2]);
+     * mc[0, 2, 1] = (cy*cy*m[0, 0, 1] - 2*cy*m[0, 1, 1] + cz*(cy*m[0, 1, 0] - m[0, 2, 0]) + m[0, 2, 1]);
+     * mc[0, 3, 0] = (2*cy*cy*m[0, 1, 0] - 3*cy*m[0, 2, 0] + m[0, 3, 0]);
+     * mc[1, 0, 2] = (-cx*m[0, 0, 2] + 2*cz*(cx*m[0, 0, 1] - m[1, 0, 1]) + m[1, 0, 2]);
+     * mc[1, 1, 1] = (-cx*m[0, 1, 1] + cy*(cx*m[0, 0, 1] - m[1, 0, 1]) + cz*(cx*m[0, 1, 0] - m[1, 1, 0]) + m[1, 1, 1]);
+     * mc[1, 2, 0] = (-cx*m[0, 2, 0] - 2*cy*(-cx*m[0, 1, 0] + m[1, 1, 0]) + m[1, 2, 0]);
+     * mc[2, 0, 1] = (cx*cx*m[0, 0, 1] - 2*cx*m[1, 0, 1] + cz*(cx*m[1, 0, 0] - m[2, 0, 0]) + m[2, 0, 1]);
+     * mc[2, 1, 0] = (cx*cx*m[0, 1, 0] - 2*cx*m[1, 1, 0] + cy*(cx*m[1, 0, 0] - m[2, 0, 0]) + m[2, 1, 0]);
+     * mc[3, 0, 0] = (2*cx*cx*m[1, 0, 0] - 3*cx*m[2, 0, 0] + m[3, 0, 0]);
+     */
+    mc[0] = m[0];
+    F cx = m[16] / m[0];
+    F cy = m[4] / m[0];
+    F cz = m[1] / m[0];
+    // 2nd order moments
+    mc[2] = -cz*m[1] + m[2];
+    mc[5] = -cy*m[1] + m[5];
+    mc[8] = -cy*m[4] + m[8];
+    mc[17] = -cx*m[1] + m[17];
+    mc[20] = -cx*m[4] + m[20];
+    mc[32] = -cx*m[16] + m[32];
+    // 3rd order moments
+    mc[3] = (2*cz*cz*m[1] - 3*cz*m[2] + m[3]);
+    mc[6] = (-cy*m[2] + 2*cz*(cy*m[1] - m[5]) + m[6]);
+    mc[9] = (cy*cy*m[1] - 2*cy*m[5] + cz*(cy*m[4] - m[8]) + m[9]);
+    mc[12] = (2*cy*cy*m[4] - 3*cy*m[8] + m[12]);
+    mc[18] = (-cx*m[2] + 2*cz*(cx*m[1] - m[17]) + m[18]);
+    mc[21] = (-cx*m[5] + cy*(cx*m[1] - m[17]) + cz*(cx*m[4] - m[20]) + m[21]);
+    mc[24] = (-cx*m[8] - 2*cy*(-cx*m[4] + m[20]) + m[24]);
+    mc[33] = (cx*cx*m[1] - 2*cx*m[17] + cz*(cx*m[16] - m[32]) + m[33]);
+    mc[36] = (cx*cx*m[4] - 2*cx*m[20] + cy*(cx*m[16] - m[32]) + m[36]);
+    mc[48] = (2*cx*cx*m[16] - 3*cx*m[32] + m[48]);
+"""
+
+
+def _moments_raw_to_central_fast(moments_raw):
+    """Analytical formulae for 2D and 3D central moments of order < 4.
+
+    `moments_raw_to_central` will automatically call this function when
+    ndim < 4 and order < 4.
+
+    Parameters
+    ----------
+    moments_raw : ndarray
+        The raw moments.
+
+    Returns
+    -------
+    moments_central : ndarray
+        The central moments.
+    """
+    ndim = moments_raw.ndim
+    order = moments_raw.shape[0] - 1
+    float_dtype = moments_raw.dtype
+    # convert to float64 during the computation for better accuracy
+    moments_raw = moments_raw.astype(cp.float64, copy=False)
+    moments_central = cp.zeros_like(moments_raw)
+    if order >= 4 or ndim not in [2, 3]:
+        raise ValueError(
+            "This function only supports 2D or 3D moments of order < 4."
+        )
+    m = moments_raw
+    if ndim == 2:
+        if order < 2:
+            operation = _order0_or_1
+        elif order == 2:
+            operation = _order2_2d
+        elif order == 3:
+            operation = _order3_2d
+    elif ndim == 3:
+        if order < 2:
+            operation = _order0_or_1
+        elif order == 2:
+            operation = _order2_3d
+        elif order == 3:
+            operation = _order3_3d
+
+    kernel = cp.ElementwiseKernel(
+        'raw F m',
+        'raw F mc',
+        operation=operation,
+        name=f"order{order}_{ndim}d_kernel"
+    )
+    # run a single-threaded kernel, so we can avoid device->host->device copy
+    kernel(moments_raw, moments_central, size=1)
+    return moments_central
+
+
+def moments_raw_to_central(moments_raw):
+    ndim = moments_raw.ndim
+    order = moments_raw.shape[0] - 1
+    if ndim in [2, 3] and order < 4:
+        # fast path with analytical GPU kernels
+        # (avoids any host/device transfers)
+        return _moments_raw_to_central_fast(moments_raw)
+
+    # Fallback to general formula applied on the host
+    m = cp.asnumpy(moments_raw)  # synchronize
+    moments_central = np.zeros_like(moments_raw)
+    # centers as computed in centroid above
+    centers = tuple(m[tuple(np.eye(ndim, dtype=int))] / m[(0,)*ndim])
+
+    if ndim == 2:
+        # This is the general 2D formula from
+        # https://en.wikipedia.org/wiki/Image_moment#Central_moments
+        for p in range(order + 1):
+            for q in range(order + 1):
+                if p + q > order:
+                    continue
+                for i in range(p + 1):
+                    term1 = math.comb(p, i)
+                    term1 *= (-centers[0]) ** (p - i)
+                    for j in range(q + 1):
+                        term2 = math.comb(q, j)
+                        term2 *= (-centers[1]) ** (q - j)
+                        moments_central[p, q] += term1*term2*m[i, j]
+        return moments_central
+
+    # The nested loops below are an n-dimensional extension of the 2D formula
+    # given at https://en.wikipedia.org/wiki/Image_moment#Central_moments
+
+    # iterate over all [0, order] (inclusive) on each axis
+    for orders in itertools.product(*((range(order + 1),) * ndim)):
+        # `orders` here is the index into the `moments_central` output array
+        if sum(orders) > order:
+            # skip any moment that is higher than the requested order
+            continue
+        # loop over terms from `m` contributing to `moments_central[orders]`
+        for idxs in itertools.product(*[range(o + 1) for o in orders]):
+            val = m[idxs]
+            for i_order, c, idx in zip(orders, centers, idxs):
+                val *= math.comb(i_order, idx)
+                val *= (-c) ** (i_order - idx)
+            moments_central[orders] += val
+
+    return cp.asarray(moments_central)

--- a/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
@@ -158,7 +158,6 @@ def _moments_raw_to_central_fast(moments_raw):
     """
     ndim = moments_raw.ndim
     order = moments_raw.shape[0] - 1
-    float_dtype = moments_raw.dtype
     # convert to float64 during the computation for better accuracy
     moments_raw = moments_raw.astype(cp.float64, copy=False)
     moments_central = cp.zeros_like(moments_raw)
@@ -166,7 +165,6 @@ def _moments_raw_to_central_fast(moments_raw):
         raise ValueError(
             "This function only supports 2D or 3D moments of order < 4."
         )
-    m = moments_raw
     if ndim == 2:
         if order < 2:
             operation = _order0_or_1
@@ -206,7 +204,7 @@ def moments_raw_to_central(moments_raw):
     m = cp.asnumpy(moments_raw)  # synchronize
     moments_central = np.zeros_like(moments_raw)
     # centers as computed in centroid above
-    centers = tuple(m[tuple(np.eye(ndim, dtype=int))] / m[(0,)*ndim])
+    centers = tuple(m[tuple(np.eye(ndim, dtype=int))] / m[(0,) * ndim])
 
     if ndim == 2:
         # This is the general 2D formula from
@@ -221,7 +219,7 @@ def moments_raw_to_central(moments_raw):
                     for j in range(q + 1):
                         term2 = math.comb(q, j)
                         term2 *= (-centers[1]) ** (q - j)
-                        moments_central[p, q] += term1*term2*m[i, j]
+                        moments_central[p, q] += term1 * term2 * m[i, j]
         return moments_central
 
     # The nested loops below are an n-dimensional extension of the 2D formula

--- a/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
@@ -56,7 +56,7 @@ _order3_2d = """
     mc[6] = (m[6] - 2*cy*m[5] - cx*m[2] + 2*cy*cx*m[1]);
     mc[12] = m[12] - 3*cx*m[8] + 2*cx*cx*m[4];
     mc[3] = m[3] - 3*cy*m[2] + 2*cy*cy*m[1];
-"""
+"""  # noqa
 
 
 # Note for 2D kernels using C-order raveled indices
@@ -137,7 +137,7 @@ _order3_3d = """
     mc[33] = (cx*cx*m[1] - 2*cx*m[17] + cz*(cx*m[16] - m[32]) + m[33]);
     mc[36] = (cx*cx*m[4] - 2*cx*m[20] + cy*(cx*m[16] - m[32]) + m[36]);
     mc[48] = (2*cx*cx*m[16] - 3*cx*m[32] + m[48]);
-"""
+"""  # noqa
 
 
 def _moments_raw_to_central_fast(moments_raw):

--- a/python/cucim/src/cucim/skimage/measure/_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops.py
@@ -581,21 +581,29 @@ class RegionProperties:
     @property
     @_cached
     def moments(self):
-        M = _moments.moments(self.image.astype(cp.uint8), 3, spacing=self._spacing)
+        M = _moments.moments(
+            self.image.astype(cp.uint8), 3, spacing=self._spacing
+        )
         return M
 
     @property
     @_cached
     def moments_central(self):
-        mu = _moments.moments_central(self.image.astype(cp.uint8),
-                                      self.centroid_local, order=3, spacing=self._spacing)
+        mu = _moments.moments_central(
+            self.image.astype(cp.uint8),
+            self.centroid_local,
+            order=3,
+            spacing=self._spacing
+        )
         return mu
 
     @property
     @only2d
     def moments_hu(self):
         if any(s != 1.0 for s in self._spacing):
-            raise NotImplementedError('`moments_hu` supports spacing = (1, 1) only')
+            raise NotImplementedError(
+                '`moments_hu` supports spacing = (1, 1) only'
+            )
         return _moments.moments_hu(self.moments_normalized)
 
     @property
@@ -620,14 +628,18 @@ class RegionProperties:
     @only2d
     def perimeter(self):
         if len(np.unique(self._spacing)) != 1:
-            raise NotImplementedError('`perimeter` supports isotropic spacings only')
+            raise NotImplementedError(
+                '`perimeter` supports isotropic spacings only'
+            )
         return perimeter(self.image, 4) * self._spacing[0]
 
     @property
     @only2d
     def perimeter_crofton(self):
         if len(np.unique(self._spacing)) != 1:
-            raise NotImplementedError('`perimeter` supports isotropic spacings only')
+            raise NotImplementedError(
+                '`perimeter` supports isotropic spacings only'
+            )
         return perimeter_crofton(self.image, 4) * self._spacing[0]
 
     @property
@@ -652,8 +664,9 @@ class RegionProperties:
         image = self._image_intensity_double()
         if self._multichannel:
             moments = cp.stack(
-                [_moments.moments(image[..., i], order=3, spacing=self._spacing)
-                    for i in range(image.shape[-1])],
+                [_moments.moments(image[..., i], order=3,
+                                  spacing=self._spacing)
+                 for i in range(image.shape[-1])],
                 axis=-1,
             )
         else:
@@ -668,20 +681,27 @@ class RegionProperties:
         if self._multichannel:
             moments_list = [
                 _moments.moments_central(
-                    image[..., i], center=ctr[..., i], order=3, spacing=self._spacing
+                    image[..., i],
+                    center=ctr[..., i],
+                    order=3,
+                    spacing=self._spacing
                 )
                 for i in range(image.shape[-1])
             ]
             moments = cp.stack(moments_list, axis=-1)
         else:
-            moments = _moments.moments_central(image, ctr, order=3, spacing=self._spacing)
+            moments = _moments.moments_central(
+                image, ctr, order=3, spacing=self._spacing
+            )
         return moments
 
     @property
     @only2d
     def moments_weighted_hu(self):
         if not (np.array(self._spacing) == np.array([1, 1])).all():
-            raise NotImplementedError('`moments_hu` supports spacing = (1, 1) only')
+            raise NotImplementedError(
+                '`moments_hu` supports spacing = (1, 1) only'
+            )
         nu = self.moments_weighted_normalized
         if self._multichannel:
             nchannels = self._intensity_image.shape[-1]
@@ -908,7 +928,8 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
 def regionprops_table(label_image, intensity_image=None,
                       properties=('label', 'bbox'),
                       *,
-                      cache=True, separator='-', extra_properties=None, spacing=None):
+                      cache=True, separator='-', extra_properties=None,
+                      spacing=None):
     """Compute image properties and return them as a pandas-compatible table.
 
     The table is a dictionary mapping column names to value arrays. See Notes
@@ -1044,7 +1065,8 @@ def regionprops_table(label_image, intensity_image=None,
 
     """
     regions = regionprops(label_image, intensity_image=intensity_image,
-                          cache=cache, extra_properties=extra_properties, spacing=spacing)
+                          cache=cache, extra_properties=extra_properties,
+                          spacing=spacing)
     if extra_properties is not None:
         properties = (
             list(properties) + [prop.__name__ for prop in extra_properties]
@@ -1060,7 +1082,8 @@ def regionprops_table(label_image, intensity_image=None,
                 dtype=intensity_image.dtype,
             )
         regions = regionprops(label_image, intensity_image=intensity_image,
-                              cache=cache, extra_properties=extra_properties, spacing=spacing)
+                              cache=cache, extra_properties=extra_properties,
+                              spacing=spacing)
 
         out_d = _props_to_dict(regions, properties=properties,
                                separator=separator)
@@ -1324,7 +1347,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     >>> props[1]['pixelcount']
     array(42)
 
-    """
+    """  # noqa
 
     if label_image.ndim not in (2, 3):
         raise TypeError('Only 2-D and 3-D images supported.')
@@ -1368,7 +1391,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
         label = i + 1
 
         props = RegionProperties(sl, label, label_image, intensity_image,
-                                 cache, spacing=spacing, extra_properties=extra_properties)
+                                 cache, spacing=spacing,
+                                 extra_properties=extra_properties)
         regions.append(props)
 
     return regions

--- a/python/cucim/src/cucim/skimage/measure/tests/test_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_moments.py
@@ -252,7 +252,7 @@ def test_analytical_moments_calculation(dtype, order, ndim):
     m2 = moments_central(x, center=centroid(x), order=order)
 
     # ensure numeric and analytical central moments are close
-    thresh = 1e-4 if _supported_float_type(x.dtype) == np.float32 else 1e-11
+    thresh = 5e-4 if _supported_float_type(x.dtype) == np.float32 else 1e-11
     compare_moments(m1, m2, thresh=thresh)
 
 

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -575,10 +575,10 @@ def test_axis_minor_length():
     # MATLAB has different interpretation of ellipse than found in literature,
     # here implemented as found in literature
     target_length = 9.739302807263
-    assert_almost_equal(length, target_length)
+    assert_almost_equal(length, target_length, decimal=5)
 
     length = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].axis_minor_length
-    assert_almost_equal(length, 1.5 * target_length)
+    assert_almost_equal(length, 1.5 * target_length, decimal=5)
 
     from skimage.draw import ellipse
     img = cp.zeros((10, 12), dtype=np.uint8)
@@ -904,9 +904,9 @@ def test_moments_weighted_normalized():
     # fmt: off
     ref = np.array(
         [[np.nan,        np.nan, 0.2301467830, -0.0162529732],         # noqa
-         [np.nan, -0.0160405109, 0.0457932622, -0.0104598869],         # noqa
-         [0.0873590903, -0.0031421072, 0.0165315478, -0.0028544152],   # noqa
-         [-0.0161217406, -0.0031376984, 0.0043903193, -0.0011057191]]  # noqa
+         [np.nan, -0.0160405109, 0.0457932622, np.nan],         # noqa
+         [0.0873590903, -0.0031421072, np.nan, np.nan],   # noqa
+         [-0.0161217406, np.nan, np.nan, np.nan]]  # noqa
     )
     # fmt: on
     assert_array_almost_equal(wnu, ref)
@@ -921,15 +921,9 @@ def test_moments_weighted_normalized():
     assert_almost_equal(wnu[0, 3], -0.0162529732)
     assert_almost_equal(wnu[1, 1], -0.0160405109)
     assert_almost_equal(wnu[1, 2], 0.0457932622)
-    assert_almost_equal(wnu[1, 3], -0.0104598869)
     assert_almost_equal(wnu[2, 0], 0.0873590903)
     assert_almost_equal(wnu[2, 1], -0.0031421072)
-    assert_almost_equal(wnu[2, 2], 0.0165315478)
-    assert_almost_equal(wnu[2, 3], -0.0028544152)
     assert_almost_equal(wnu[3, 0], -0.0161217406)
-    assert_almost_equal(wnu[3, 1], -0.0031376984)
-    assert_almost_equal(wnu[3, 2], 0.0043903193)
-    assert_almost_equal(wnu[3, 3], -0.0011057191)
 
 
 def test_label_sequence():

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -50,28 +50,35 @@ INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
 
 def get_moment_function(img, spacing=(1, 1)):
     rows, cols = img.shape
-    Y, X = np.meshgrid(cp.linspace(0, rows * spacing[0], rows, endpoint=False),
-                       cp.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
+    Y, X = np.meshgrid(
+        cp.linspace(0, rows * spacing[0], rows, endpoint=False),
+        cp.linspace(0, cols * spacing[1], cols, endpoint=False),
+        indexing='ij'
+    )
     return lambda p, q: cp.sum(Y ** p * X ** q * img)
 
 
 def get_moment3D_function(img, spacing=(1, 1, 1)):
     slices, rows, cols = img.shape
-    Z, Y, X = np.meshgrid(cp.linspace(0, slices * spacing[0], slices, endpoint=False),
-                          cp.linspace(0, rows * spacing[1], rows, endpoint=False),
-                          cp.linspace(0, cols * spacing[2], cols, endpoint=False), indexing='ij')
+    Z, Y, X = np.meshgrid(
+        cp.linspace(0, slices * spacing[0], slices, endpoint=False),
+        cp.linspace(0, rows * spacing[1], rows, endpoint=False),
+        cp.linspace(0, cols * spacing[2], cols, endpoint=False),
+        indexing='ij'
+    )
     return lambda p, q, r: cp.sum(Z ** p * Y ** q * X ** r * img)
 
 
 def get_central_moment_function(img, spacing=(1, 1)):
     rows, cols = img.shape
-    Y, X = np.meshgrid(cp.linspace(0, rows * spacing[0], rows, endpoint=False),
-                       cp.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
-
+    Y, X = np.meshgrid(
+        cp.linspace(0, rows * spacing[0], rows, endpoint=False),
+        cp.linspace(0, cols * spacing[1], cols, endpoint=False),
+        indexing='ij'
+    )
     Mpq = get_moment_function(img, spacing=spacing)
     cY = Mpq(1, 0) / Mpq(0, 0)
     cX = Mpq(0, 1) / Mpq(0, 0)
-
     return lambda p, q: cp.sum((Y - cY) ** p * (X - cX) ** q * img)
 
 
@@ -147,17 +154,18 @@ def test_feret_diameter_max():
     test_result = regionprops(SAMPLE)[0].feret_diameter_max
     assert cp.abs(test_result - comparator_result) < 1
     comparator_result_spacing = 10
-    test_result_spacing = regionprops(SAMPLE, spacing=[1, 0.1])[0].feret_diameter_max
+    test_result_spacing = regionprops(SAMPLE, spacing=[1, 0.1])[0].feret_diameter_max  # noqa
     assert cp.abs(test_result_spacing - comparator_result_spacing) < 1
     # square, test that Feret diameter is sqrt(2) * square side
     img = cp.zeros((20, 20), dtype=cp.uint8)
     img[2:-2, 2:-2] = 1
     feret_diameter_max = regionprops(img)[0].feret_diameter_max
     assert cp.abs(feret_diameter_max - 16 * math.sqrt(2)) < 1
-    # Due to marching-squares with a level of .5 the diagonal goes from (0, 0.5) to (16, 15.5).
+    # Due to marching-squares with a level of .5 the diagonal goes
+    # from (0, 0.5) to (16, 15.5).
     assert cp.abs(feret_diameter_max - np.sqrt(16 ** 2 + (16 - 1) ** 2)) < 1e-6
     spacing = (2, 1)
-    feret_diameter_max = regionprops(img, spacing=spacing)[0].feret_diameter_max
+    feret_diameter_max = regionprops(img, spacing=spacing)[0].feret_diameter_max  # noqa
     # For anisotropic spacing the shift is applied to the smaller spacing.
     assert cp.abs(feret_diameter_max - cp.sqrt(
         (spacing[0] * 16 - (spacing[0] <= spacing[1])) ** 2 +
@@ -170,12 +178,14 @@ def test_feret_diameter_max_3d():
     img[2:-2, 2:-2] = 1
     img_3d = cp.dstack((img,) * 3)
     feret_diameter_max = regionprops(img_3d)[0].feret_diameter_max
-    # Due to marching-cubes with a level of .5 -1=2*0.5 has to be subtracted from two axes.
-    # There are three combinations (x-1, y-1, z), (x-1, y, z-1), (x, y-1, z-1). The option
-    # yielding the longest diagonal is the computed max_feret_diameter.
-    assert cp.abs(feret_diameter_max - cp.sqrt((16 - 1) ** 2 + 16 ** 2 + (3 - 1) ** 2)) < 1e-6
+    # Due to marching-cubes with a level of .5 -1=2*0.5 has to be subtracted
+    # from two axes. There are three combinations
+    # (x-1, y-1, z), (x-1, y, z-1), (x, y-1, z-1).
+    # The option yielding the longest diagonal is the computed
+    # max_feret_diameter.
+    assert cp.abs(feret_diameter_max - cp.sqrt((16 - 1) ** 2 + 16 ** 2 + (3 - 1) ** 2)) < 1e-6  # noqa
     spacing = (1, 2, 3)
-    feret_diameter_max = regionprops(img_3d, spacing=spacing)[0].feret_diameter_max
+    feret_diameter_max = regionprops(img_3d, spacing=spacing)[0].feret_diameter_max  # noqa
     # The longest of the three options is the max_feret_diameter
     assert cp.abs(feret_diameter_max - cp.sqrt(
         (spacing[0] * (16 - 1)) ** 2 +
@@ -214,9 +224,13 @@ def test_bbox():
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[:, -1] = 0
     bbox = regionprops(SAMPLE_mod)[0].bbox
-    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
+    assert_array_almost_equal(
+        bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1)
+    )
     bbox = regionprops(SAMPLE_mod, spacing=(3, 2))[0].bbox
-    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
+    assert_array_almost_equal(
+        bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1)
+    )
 
     bbox = regionprops(SAMPLE_3D)[0].bbox
     assert_array_almost_equal(bbox, (1, 1, 1, 4, 3, 3))
@@ -670,7 +684,9 @@ def test_orientation():
     assert_almost_equal(orient_diag, -np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(cp.fliplr(cp.flipud(diag)))[0].orientation
     assert_almost_equal(orient_diag, -math.pi / 4)
-    orient_diag = regionprops(np.fliplr(np.flipud(diag)), spacing=(1, 2))[0].orientation
+    orient_diag = regionprops(
+        np.fliplr(np.flipud(diag)), spacing=(1, 2)
+    )[0].orientation
     assert_almost_equal(orient_diag, np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
 
 
@@ -789,7 +805,9 @@ def test_centroid_weighted():
     Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
     cY = float(Mpq(0, 1) / Mpq(0, 0))
     cX = float(Mpq(1, 0) / Mpq(0, 0))
-    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    centroid = regionprops(
+        SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing
+    )[0].centroid_weighted
     centroid = tuple(float(c) for c in centroid)
     assert_almost_equal(centroid, (cX, cY))
     assert_almost_equal(centroid, tuple(2 * c for c in target_centroid))
@@ -798,7 +816,9 @@ def test_centroid_weighted():
     Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
     cY = float(Mpq(0, 1) / Mpq(0, 0))
     cX = float(Mpq(1, 0) / Mpq(0, 0))
-    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    centroid = regionprops(
+        SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing
+    )[0].centroid_weighted
     centroid = tuple(float(c) for c in centroid)
     assert_almost_equal(centroid, (cX, cY))
 
@@ -892,7 +912,9 @@ def test_moments_weighted_normalized():
     assert_array_almost_equal(wnu, ref)
 
     spacing = (3, 3)
-    wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].moments_weighted_normalized
+    wnu = regionprops(
+        SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing
+    )[0].moments_weighted_normalized
 
     # Normalized moments are scale invariant
     assert_almost_equal(wnu[0, 2], 0.2301467830)

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -17,7 +17,8 @@ from cucim.skimage.measure import (euler_number, perimeter, perimeter_crofton,
                                    regionprops, regionprops_table)
 from cucim.skimage.measure._regionprops import (COL_DTYPES, OBJECT_COLUMNS,
                                                 PROPS, _parse_docs,
-                                                _props_to_dict)
+                                                _props_to_dict,
+                                                _require_intensity_image)
 
 # fmt: off
 SAMPLE = cp.array(
@@ -45,6 +46,33 @@ SAMPLE_3D = cp.zeros((6, 6, 6), dtype=cp.uint8)
 SAMPLE_3D[1:3, 1:3, 1:3] = 1
 SAMPLE_3D[3, 2, 2] = 1
 INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
+
+
+def get_moment_function(img, spacing=(1, 1)):
+    rows, cols = img.shape
+    Y, X = np.meshgrid(cp.linspace(0, rows * spacing[0], rows, endpoint=False),
+                       cp.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
+    return lambda p, q: cp.sum(Y ** p * X ** q * img)
+
+
+def get_moment3D_function(img, spacing=(1, 1, 1)):
+    slices, rows, cols = img.shape
+    Z, Y, X = np.meshgrid(cp.linspace(0, slices * spacing[0], slices, endpoint=False),
+                          cp.linspace(0, rows * spacing[1], rows, endpoint=False),
+                          cp.linspace(0, cols * spacing[2], cols, endpoint=False), indexing='ij')
+    return lambda p, q, r: cp.sum(Z ** p * Y ** q * X ** r * img)
+
+
+def get_central_moment_function(img, spacing=(1, 1)):
+    rows, cols = img.shape
+    Y, X = np.meshgrid(cp.linspace(0, rows * spacing[0], rows, endpoint=False),
+                       cp.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
+
+    Mpq = get_moment_function(img, spacing=spacing)
+    cY = Mpq(1, 0) / Mpq(0, 0)
+    cX = Mpq(0, 1) / Mpq(0, 0)
+
+    return lambda p, q: cp.sum((Y - cY) ** p * (X - cX) ** q * img)
 
 
 def test_all_props():
@@ -83,13 +111,21 @@ def test_all_props_3d():
             pass
 
 
+def test_num_pixels():
+    num_pixels = regionprops(SAMPLE)[0].num_pixels
+    assert num_pixels == 72
+
+    num_pixels = regionprops(SAMPLE, spacing=(2, 1))[0].num_pixels
+    assert num_pixels == 72
+
+
 def test_dtype():
     regionprops(cp.zeros((10, 10), dtype=int))
     regionprops(cp.zeros((10, 10), dtype=cp.uint))
     with pytest.raises(TypeError):
         regionprops(cp.zeros((10, 10), dtype=float))
     with pytest.raises(TypeError):
-        regionprops(cp.zeros((10, 10), dtype=cp.double))
+        regionprops(cp.zeros((10, 10), dtype=cp.float64))
     with pytest.raises(TypeError):
         regionprops(cp.zeros((10, 10), dtype=bool))
 
@@ -110,11 +146,22 @@ def test_feret_diameter_max():
     comparator_result = 18
     test_result = regionprops(SAMPLE)[0].feret_diameter_max
     assert cp.abs(test_result - comparator_result) < 1
+    comparator_result_spacing = 10
+    test_result_spacing = regionprops(SAMPLE, spacing=[1, 0.1])[0].feret_diameter_max
+    assert cp.abs(test_result_spacing - comparator_result_spacing) < 1
     # square, test that Feret diameter is sqrt(2) * square side
     img = cp.zeros((20, 20), dtype=cp.uint8)
     img[2:-2, 2:-2] = 1
     feret_diameter_max = regionprops(img)[0].feret_diameter_max
     assert cp.abs(feret_diameter_max - 16 * math.sqrt(2)) < 1
+    # Due to marching-squares with a level of .5 the diagonal goes from (0, 0.5) to (16, 15.5).
+    assert cp.abs(feret_diameter_max - np.sqrt(16 ** 2 + (16 - 1) ** 2)) < 1e-6
+    spacing = (2, 1)
+    feret_diameter_max = regionprops(img, spacing=spacing)[0].feret_diameter_max
+    # For anisotropic spacing the shift is applied to the smaller spacing.
+    assert cp.abs(feret_diameter_max - cp.sqrt(
+        (spacing[0] * 16 - (spacing[0] <= spacing[1])) ** 2 +
+        (spacing[1] * 16 - (spacing[1] < spacing[0])) ** 2)) < 1e-6
 
 
 @pytest.mark.skip('feret_diameter_max not implmented on the GPU')
@@ -123,28 +170,57 @@ def test_feret_diameter_max_3d():
     img[2:-2, 2:-2] = 1
     img_3d = cp.dstack((img,) * 3)
     feret_diameter_max = regionprops(img_3d)[0].feret_diameter_max
-    assert cp.abs(feret_diameter_max - 16 * math.sqrt(2)) < 1
+    # Due to marching-cubes with a level of .5 -1=2*0.5 has to be subtracted from two axes.
+    # There are three combinations (x-1, y-1, z), (x-1, y, z-1), (x, y-1, z-1). The option
+    # yielding the longest diagonal is the computed max_feret_diameter.
+    assert cp.abs(feret_diameter_max - cp.sqrt((16 - 1) ** 2 + 16 ** 2 + (3 - 1) ** 2)) < 1e-6
+    spacing = (1, 2, 3)
+    feret_diameter_max = regionprops(img_3d, spacing=spacing)[0].feret_diameter_max
+    # The longest of the three options is the max_feret_diameter
+    assert cp.abs(feret_diameter_max - cp.sqrt(
+        (spacing[0] * (16 - 1)) ** 2 +
+        (spacing[1] * (16 - 0)) ** 2 +
+        (spacing[2] * (3 - 1)) ** 2)) < 1e-6
+    assert cp.abs(feret_diameter_max - cp.sqrt(
+        (spacing[0] * (16 - 1)) ** 2 +
+        (spacing[1] * (16 - 1)) ** 2 +
+        (spacing[2] * (3 - 0)) ** 2)) > 1e-6
+    assert cp.abs(feret_diameter_max - cp.sqrt(
+        (spacing[0] * (16 - 0)) ** 2 +
+        (spacing[1] * (16 - 1)) ** 2 +
+        (spacing[2] * (3 - 1)) ** 2)) > 1e-6
 
 
 def test_area():
     area = regionprops(SAMPLE)[0].area
     assert area == cp.sum(SAMPLE)
+    spacing = (1, 2)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area
+    assert area == cp.sum(SAMPLE * math.prod(spacing))
     area = regionprops(SAMPLE_3D)[0].area
     assert area == cp.sum(SAMPLE_3D)
+    spacing = (2, 1, 3)
+    area = regionprops(SAMPLE_3D, spacing=spacing)[0].area
+    assert area == cp.sum(SAMPLE_3D * math.prod(spacing))
 
 
 def test_bbox():
     bbox = regionprops(SAMPLE)[0].bbox
     assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1]))
 
+    bbox = regionprops(SAMPLE, spacing=(1, 2))[0].bbox
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1]))
+
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[:, -1] = 0
     bbox = regionprops(SAMPLE_mod)[0].bbox
-    assert_array_almost_equal(
-        bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1)
-    )
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
+    bbox = regionprops(SAMPLE_mod, spacing=(3, 2))[0].bbox
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
 
     bbox = regionprops(SAMPLE_3D)[0].bbox
+    assert_array_almost_equal(bbox, (1, 1, 1, 4, 3, 3))
+    bbox = regionprops(SAMPLE_3D, spacing=(0.5, 2, 7))[0].bbox
     assert_array_almost_equal(bbox, (1, 1, 1, 4, 3, 3))
 
 
@@ -152,6 +228,10 @@ def test_area_bbox():
     padded = cp.pad(SAMPLE, 5, mode='constant')
     bbox_area = regionprops(padded)[0].area_bbox
     assert_array_almost_equal(bbox_area, SAMPLE.size)
+
+    spacing = (0.5, 3)
+    bbox_area = regionprops(padded, spacing=spacing)[0].area_bbox
+    assert_array_almost_equal(bbox_area, SAMPLE.size * math.prod(spacing))
 
 
 def test_moments_central():
@@ -166,22 +246,81 @@ def test_moments_central():
     assert_almost_equal(mu[1, 2], 2000.296296296291, decimal=2)
     assert_almost_equal(mu[0, 3], -760.0246913580195, decimal=2)
 
+    # Verify central moment test functions
+    centralMpq = get_central_moment_function(SAMPLE, spacing=(1, 1))
+    assert_almost_equal(centralMpq(2, 0), mu[2, 0], decimal=3)
+    assert_almost_equal(centralMpq(3, 0), mu[3, 0], decimal=3)
+    assert_almost_equal(centralMpq(1, 1), mu[1, 1], decimal=3)
+    assert_almost_equal(centralMpq(2, 1), mu[2, 1], decimal=3)
+    assert_almost_equal(centralMpq(0, 2), mu[0, 2], decimal=3)
+    assert_almost_equal(centralMpq(1, 2), mu[1, 2], decimal=3)
+    assert_almost_equal(centralMpq(0, 3), mu[0, 3], decimal=3)
+
+    # Test spacing against verified central moment test function
+    spacing = (1.8, 0.8)
+    centralMpq = get_central_moment_function(SAMPLE, spacing=spacing)
+
+    mu = regionprops(SAMPLE, spacing=spacing)[0].moments_central
+    assert_almost_equal(mu[2, 0], centralMpq(2, 0), decimal=3)
+    assert_almost_equal(mu[3, 0], centralMpq(3, 0), decimal=2)
+    assert_almost_equal(mu[1, 1], centralMpq(1, 1), decimal=3)
+    assert_almost_equal(mu[2, 1], centralMpq(2, 1), decimal=2)
+    assert_almost_equal(mu[0, 2], centralMpq(0, 2), decimal=3)
+    assert_almost_equal(mu[1, 2], centralMpq(1, 2), decimal=2)
+    assert_almost_equal(mu[0, 3], centralMpq(0, 3), decimal=2)
+
 
 def test_centroid():
     centroid = regionprops(SAMPLE)[0].centroid
     # determined with MATLAB
-    assert_almost_equal(centroid, (5.66666666666666, 9.444444444444444))
+    assert_array_almost_equal(centroid, (5.66666666666666, 9.444444444444444))
+
+    # Verify test moment function with spacing=(1, 1)
+    Mpq = get_moment_function(SAMPLE, spacing=(1, 1))
+    cY = float(Mpq(1, 0) / Mpq(0, 0))
+    cX = float(Mpq(0, 1) / Mpq(0, 0))
+
+    assert_array_almost_equal((cY, cX), centroid)
+
+    spacing = (1.8, 0.8)
+    # Moment
+    Mpq = get_moment_function(SAMPLE, spacing=spacing)
+    cY = float(Mpq(1, 0) / Mpq(0, 0))
+    cX = float(Mpq(0, 1) / Mpq(0, 0))
+
+    centroid = regionprops(SAMPLE, spacing=spacing)[0].centroid
+    assert_array_almost_equal(centroid, (cY, cX))
 
 
 def test_centroid_3d():
     centroid = regionprops(SAMPLE_3D)[0].centroid
     # determined by mean along axis 1 of SAMPLE_3D.nonzero()
-    assert_almost_equal(centroid, (1.66666667, 1.55555556, 1.55555556))
+    assert_array_almost_equal(centroid, (1.66666667, 1.55555556, 1.55555556))
+
+    # Verify moment 3D test function
+    Mpqr = get_moment3D_function(SAMPLE_3D, spacing=(1, 1, 1))
+    cZ = float(Mpqr(1, 0, 0) / Mpqr(0, 0, 0))
+    cY = float(Mpqr(0, 1, 0) / Mpqr(0, 0, 0))
+    cX = float(Mpqr(0, 0, 1) / Mpqr(0, 0, 0))
+    assert_array_almost_equal((cZ, cY, cX), centroid)
+
+    # Test spacing
+    spacing = (2, 1, 0.8)
+    Mpqr = get_moment3D_function(SAMPLE_3D, spacing=spacing)
+    cZ = float(Mpqr(1, 0, 0) / Mpqr(0, 0, 0))
+    cY = float(Mpqr(0, 1, 0) / Mpqr(0, 0, 0))
+    cX = float(Mpqr(0, 0, 1) / Mpqr(0, 0, 0))
+    centroid = regionprops(SAMPLE_3D, spacing=spacing)[0].centroid
+    assert_array_almost_equal(centroid, (cZ, cY, cX))
 
 
 def test_area_convex():
     area = regionprops(SAMPLE)[0].area_convex
     assert area == 125
+
+    spacing = (1, 4)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area_convex
+    assert area == 125 * np.prod(spacing)
 
 
 def test_image_convex():
@@ -209,12 +348,32 @@ def test_coordinates():
     sample[coords[:, 0], coords[:, 1]] = 1
     prop_coords = regionprops(sample)[0].coords
     assert_array_equal(prop_coords, coords)
+    prop_coords = regionprops(sample, spacing=(0.5, 1.2))[0].coords
+    assert_array_equal(prop_coords, coords)
+
+
+def test_coordinates_scaled():
+    sample = cp.zeros((10, 10), dtype=np.int8)
+    coords = cp.array([[3, 2], [3, 3], [3, 4]])
+    sample[coords[:, 0], coords[:, 1]] = 1
+
+    spacing = (1, 1)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
+    assert_array_equal(prop_coords, coords * cp.array(spacing))
+
+    spacing = (1, 0.5)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
+    assert_array_equal(prop_coords, coords * cp.array(spacing))
 
     sample = cp.zeros((6, 6, 6), dtype=cp.int8)
     coords = cp.array([[1, 1, 1], [1, 2, 1], [1, 3, 1]])
     sample[coords[:, 0], coords[:, 1], coords[:, 2]] = 1
-    prop_coords = regionprops(sample)[0].coords
+    prop_coords = regionprops(sample)[0].coords_scaled
     assert_array_equal(prop_coords, coords)
+
+    spacing = (0.2, 3, 2.3)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
+    assert_array_equal(prop_coords, coords * cp.array(spacing))
 
 
 def test_slice():
@@ -224,14 +383,24 @@ def test_slice():
     expected = (slice(2, 2 + nrow), slice(5, 5 + ncol))
     assert_array_equal(result, expected)
 
+    spacing = (2, 0.2)
+    result = regionprops(padded, spacing=spacing)[0].slice
+    assert_equal(result, expected)
+
 
 def test_eccentricity():
     eps = regionprops(SAMPLE)[0].eccentricity
     assert_almost_equal(eps, 0.814629313427)
 
+    eps = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].eccentricity
+    assert_almost_equal(eps, 0.814629313427)
+
     img = cp.zeros((5, 5), dtype=int)
     img[2, 2] = 1
     eps = regionprops(img)[0].eccentricity
+    assert_almost_equal(eps, 0)
+
+    eps = regionprops(img, spacing=(3, 3))[0].eccentricity
     assert_almost_equal(eps, 0)
 
 
@@ -240,21 +409,27 @@ def test_equivalent_diameter_area():
     # determined with MATLAB
     assert_almost_equal(diameter, 9.57461472963)
 
+    spacing = (1, 3)
+    diameter = regionprops(SAMPLE, spacing=spacing)[0].equivalent_diameter_area
+    equivalent_area = cp.pi * (diameter / 2.) ** 2
+    assert_almost_equal(equivalent_area, SAMPLE.sum() * math.prod(spacing))
+
 
 def test_euler_number():
-    en = regionprops(SAMPLE)[0].euler_number
-    assert en == 0
+    for spacing in [(1, 1), (2.1, 0.9)]:
+        en = regionprops(SAMPLE, spacing=spacing)[0].euler_number
+        assert en == 0
 
-    SAMPLE_mod = SAMPLE.copy()
-    SAMPLE_mod[7, -3] = 0
-    en = regionprops(SAMPLE_mod)[0].euler_number
-    assert en == -1
+        SAMPLE_mod = SAMPLE.copy()
+        SAMPLE_mod[7, -3] = 0
+        en = regionprops(SAMPLE_mod, spacing=spacing)[0].euler_number
+        assert en == -1
 
-    en = euler_number(SAMPLE, 1)
-    assert en == 2
+        en = euler_number(SAMPLE, 1)
+        assert en == 2
 
-    en = euler_number(SAMPLE_mod, 1)
-    assert en == 1
+        en = euler_number(SAMPLE_mod, 1)
+        assert en == 1
 
     en = euler_number(SAMPLE_3D, 1)
     assert en == 1
@@ -276,6 +451,8 @@ def test_euler_number():
 def test_extent():
     extent = regionprops(SAMPLE)[0].extent
     assert_almost_equal(extent, 0.4)
+    extent = regionprops(SAMPLE, spacing=(5, 0.2))[0].extent
+    assert_almost_equal(extent, 0.4)
 
 
 def test_moments_hu():
@@ -293,6 +470,9 @@ def test_moments_hu():
     # fmt: on
     # bug in OpenCV caused in Central Moments calculation?
     assert_array_almost_equal(hu, ref)
+
+    with pytest.raises(NotImplementedError):
+        regionprops(SAMPLE, spacing=(2, 1))[0].moments_hu
 
 
 def test_image():
@@ -315,14 +495,23 @@ def test_area_filled():
     area = regionprops(SAMPLE)[0].area_filled
     assert area == cp.sum(SAMPLE)
 
+    spacing = (2, 1.2)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area_filled
+    assert area == cp.sum(SAMPLE) * math.prod(spacing)
+
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[7, -3] = 0
     area = regionprops(SAMPLE_mod)[0].area_filled
     assert area == cp.sum(SAMPLE)
 
+    area = regionprops(SAMPLE_mod, spacing=spacing)[0].area_filled
+    assert area == cp.sum(SAMPLE) * math.prod(spacing)
+
 
 def test_image_filled():
     img = regionprops(SAMPLE)[0].image_filled
+    assert_array_equal(img, SAMPLE)
+    img = regionprops(SAMPLE, spacing=(1, 4))[0].image_filled
     assert_array_equal(img, SAMPLE)
 
 
@@ -330,7 +519,23 @@ def test_axis_major_length():
     length = regionprops(SAMPLE)[0].axis_major_length
     # MATLAB has different interpretation of ellipse than found in literature,
     # here implemented as found in literature
-    assert_almost_equal(length, 16.7924234999, decimal=5)
+    target_length = 16.7924234999
+    assert_almost_equal(length, target_length, decimal=4)
+
+    length = regionprops(SAMPLE, spacing=(2, 2))[0].axis_major_length
+    assert_almost_equal(length, 2 * target_length, decimal=4)
+
+    from skimage.draw import ellipse
+    img = cp.zeros((20, 24), dtype=cp.uint8)
+    rr, cc = ellipse(11, 11, 7, 9, rotation=np.deg2rad(45))
+    img[rr, cc] = 1
+
+    target_length = regionprops(img, spacing=(1, 1))[0].axis_major_length
+    length_wo_spacing = regionprops(img[::2], spacing=(1, 1))[
+        0].axis_minor_length
+    assert abs(length_wo_spacing - target_length) > 0.1
+    length = regionprops(img[:, ::2], spacing=(1, 2))[0].axis_major_length
+    assert_almost_equal(length, target_length, decimal=0)
 
 
 def test_intensity_max():
@@ -355,7 +560,23 @@ def test_axis_minor_length():
     length = regionprops(SAMPLE)[0].axis_minor_length
     # MATLAB has different interpretation of ellipse than found in literature,
     # here implemented as found in literature
-    assert_almost_equal(length, 9.739302807263, decimal=5)
+    target_length = 9.739302807263
+    assert_almost_equal(length, target_length)
+
+    length = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].axis_minor_length
+    assert_almost_equal(length, 1.5 * target_length)
+
+    from skimage.draw import ellipse
+    img = cp.zeros((10, 12), dtype=np.uint8)
+    rr, cc = ellipse(5, 6, 3, 5, rotation=np.deg2rad(30))
+    img[rr, cc] = 1
+
+    target_length = regionprops(img, spacing=(1, 1))[0].axis_minor_length
+    length_wo_spacing = regionprops(img[::2], spacing=(1, 1))[
+        0].axis_minor_length
+    assert abs(length_wo_spacing - target_length) > 0.1
+    length = regionprops(img[::2], spacing=(2, 1))[0].axis_minor_length
+    assert_almost_equal(length, target_length, decimal=1)
 
 
 def test_moments():
@@ -372,6 +593,34 @@ def test_moments():
     assert_almost_equal(m[2, 1], 24836.0)
     assert_almost_equal(m[3, 0], 19776.0)
 
+    # Verify moment test function
+    Mpq = get_moment_function(SAMPLE, spacing=(1, 1))
+    assert_almost_equal(Mpq(0, 0), m[0, 0])
+    assert_almost_equal(Mpq(0, 1), m[0, 1])
+    assert_almost_equal(Mpq(0, 2), m[0, 2])
+    assert_almost_equal(Mpq(0, 3), m[0, 3])
+    assert_almost_equal(Mpq(1, 0), m[1, 0])
+    assert_almost_equal(Mpq(1, 1), m[1, 1])
+    assert_almost_equal(Mpq(1, 2), m[1, 2])
+    assert_almost_equal(Mpq(2, 0), m[2, 0])
+    assert_almost_equal(Mpq(2, 1), m[2, 1])
+    assert_almost_equal(Mpq(3, 0), m[3, 0])
+
+    # Test moment on spacing
+    spacing = (2, 0.3)
+    m = regionprops(SAMPLE, spacing=spacing)[0].moments
+    Mpq = get_moment_function(SAMPLE, spacing=spacing)
+    assert_almost_equal(m[0, 0], Mpq(0, 0), decimal=3)
+    assert_almost_equal(m[0, 1], Mpq(0, 1), decimal=3)
+    assert_almost_equal(m[0, 2], Mpq(0, 2), decimal=3)
+    assert_almost_equal(m[0, 3], Mpq(0, 3), decimal=3)
+    assert_almost_equal(m[1, 0], Mpq(1, 0), decimal=3)
+    assert_almost_equal(m[1, 1], Mpq(1, 1), decimal=3)
+    assert_almost_equal(m[1, 2], Mpq(1, 2), decimal=3)
+    assert_almost_equal(m[2, 0], Mpq(2, 0), decimal=3)
+    assert_almost_equal(m[2, 1], Mpq(2, 1), decimal=2)
+    assert_almost_equal(m[3, 0], Mpq(3, 0), decimal=3)
+
 
 def test_moments_normalized():
     nu = regionprops(SAMPLE)[0].moments_normalized
@@ -384,42 +633,83 @@ def test_moments_normalized():
     assert_almost_equal(nu[2, 0], 0.08410493827160502)
     assert_almost_equal(nu[2, 1], -0.002899800614433943)
 
+    spacing = (3, 3)
+    nu = regionprops(SAMPLE, spacing=spacing)[0].moments_normalized
+
+    # Normalized moments are scale invariant.
+    assert_almost_equal(nu[0, 2], 0.24301268861454037)
+    assert_almost_equal(nu[0, 3], -0.017278118992041805)
+    assert_almost_equal(nu[1, 1], -0.016846707818929982)
+    assert_almost_equal(nu[1, 2], 0.045473992910668816)
+    assert_almost_equal(nu[2, 0], 0.08410493827160502)
+    assert_almost_equal(nu[2, 1], -0.002899800614433943)
+
 
 def test_orientation():
     orient = regionprops(SAMPLE)[0].orientation
     # determined with MATLAB
-    assert_almost_equal(orient, -1.4663278802756865)
+    target_orient = -1.4663278802756865
+    assert_almost_equal(orient, target_orient)
+
+    orient = regionprops(SAMPLE, spacing=(2, 2))[0].orientation
+    assert_almost_equal(orient, target_orient)
+
     # test diagonal regions
     diag = cp.eye(10, dtype=int)
     orient_diag = regionprops(diag)[0].orientation
     assert_almost_equal(orient_diag, -math.pi / 4)
+    orient_diag = regionprops(diag, spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(cp.flipud(diag))[0].orientation
     assert_almost_equal(orient_diag, math.pi / 4)
+    orient_diag = regionprops(cp.flipud(diag), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, -np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(cp.fliplr(diag))[0].orientation
     assert_almost_equal(orient_diag, math.pi / 4)
+    orient_diag = regionprops(cp.fliplr(diag), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, -np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(cp.fliplr(cp.flipud(diag)))[0].orientation
     assert_almost_equal(orient_diag, -math.pi / 4)
+    orient_diag = regionprops(np.fliplr(np.flipud(diag)), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, np.arccos(0.5 / math.sqrt(1 + 0.5 ** 2)))
 
 
 def test_perimeter():
     per = regionprops(SAMPLE)[0].perimeter
-    assert_almost_equal(per, 55.2487373415)
+    target_per = 55.2487373415
+    assert_almost_equal(per, target_per)
+    per = regionprops(SAMPLE, spacing=(2, 2))[0].perimeter
+    assert_almost_equal(per, 2 * target_per)
 
-    per = perimeter(SAMPLE.astype('double'), neighbourhood=8)
+    with expected_warnings(["`neighbourhood` is a deprecated argument name"]):
+        per = perimeter(SAMPLE.astype(float), neighbourhood=8)
     assert_almost_equal(per, 46.8284271247)
+
+    with pytest.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].perimeter
 
 
 def test_perimeter_crofton():
     per = regionprops(SAMPLE)[0].perimeter_crofton
-    assert_almost_equal(per, 61.0800637973)
+    target_per_crof = 61.0800637973
+    assert_almost_equal(per, target_per_crof)
+    per = regionprops(SAMPLE, spacing=(2, 2))[0].perimeter_crofton
+    assert_almost_equal(per, 2 * target_per_crof)
 
     per = perimeter_crofton(SAMPLE.astype('double'), directions=2)
     assert_almost_equal(per, 64.4026493985)
 
+    with pytest.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].perimeter_crofton
+
 
 def test_solidity():
     solidity = regionprops(SAMPLE)[0].solidity
-    assert_almost_equal(solidity, 0.576)
+    target_solidity = 0.576
+    assert_almost_equal(solidity, target_solidity)
+
+    solidity = regionprops(SAMPLE, spacing=(3, 9))[0].solidity
+    assert_almost_equal(solidity, target_solidity)
 
 
 def test_moments_weighted_central():
@@ -439,12 +729,78 @@ def test_moments_weighted_central():
     np.set_printoptions(precision=10)
     assert_array_almost_equal(wmu, ref)
 
+    # Verify test function
+    centralMpq = get_central_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    assert_almost_equal(centralMpq(0, 0), ref[0, 0])
+    assert_almost_equal(centralMpq(0, 1), ref[0, 1])
+    assert_almost_equal(centralMpq(0, 2), ref[0, 2])
+    assert_almost_equal(centralMpq(0, 3), ref[0, 3])
+    assert_almost_equal(centralMpq(1, 0), ref[1, 0])
+    assert_almost_equal(centralMpq(1, 1), ref[1, 1])
+    assert_almost_equal(centralMpq(1, 2), ref[1, 2])
+    assert_almost_equal(centralMpq(1, 3), ref[1, 3])
+    assert_almost_equal(centralMpq(2, 0), ref[2, 0])
+    assert_almost_equal(centralMpq(2, 1), ref[2, 1])
+    assert_almost_equal(centralMpq(2, 2), ref[2, 2])
+    assert_almost_equal(centralMpq(2, 3), ref[2, 3])
+    assert_almost_equal(centralMpq(3, 0), ref[3, 0])
+    assert_almost_equal(centralMpq(3, 1), ref[3, 1])
+    assert_almost_equal(centralMpq(3, 2), ref[3, 2])
+    assert_almost_equal(centralMpq(3, 3), ref[3, 3])
+
+    # Test spacing
+    spacing = (3.2, 1.2)
+    wmu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE,
+                      spacing=spacing)[0].moments_weighted_central
+    centralMpq = get_central_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    assert_almost_equal(wmu[0, 0], centralMpq(0, 0))
+    assert_almost_equal(wmu[0, 1], centralMpq(0, 1))
+    assert_almost_equal(wmu[0, 2], centralMpq(0, 2))
+    assert_almost_equal(wmu[0, 3], centralMpq(0, 3))
+    assert_almost_equal(wmu[1, 0], centralMpq(1, 0))
+    assert_almost_equal(wmu[1, 1], centralMpq(1, 1))
+    assert_almost_equal(wmu[1, 2], centralMpq(1, 2))
+    assert_almost_equal(wmu[1, 3], centralMpq(1, 3))
+    assert_almost_equal(wmu[2, 0], centralMpq(2, 0))
+    assert_almost_equal(wmu[2, 1], centralMpq(2, 1))
+    assert_almost_equal(wmu[2, 2], centralMpq(2, 2))
+    assert_almost_equal(wmu[2, 3], centralMpq(2, 3))
+    assert_almost_equal(wmu[3, 0], centralMpq(3, 0))
+    assert_almost_equal(wmu[3, 1], centralMpq(3, 1))
+    assert_almost_equal(wmu[3, 2], centralMpq(3, 2))
+    assert_almost_equal(wmu[3, 3], centralMpq(3, 3))
+
 
 def test_centroid_weighted():
     centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
                            )[0].centroid_weighted
+    target_centroid = (5.540540540540, 9.445945945945)
     centroid = tuple(float(c) for c in centroid)
-    assert_array_almost_equal(centroid, (5.540540540540, 9.445945945945))
+    assert_array_almost_equal(centroid, target_centroid)
+
+    # Verify test function
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    cY = float(Mpq(0, 1) / Mpq(0, 0))
+    cX = float(Mpq(1, 0) / Mpq(0, 0))
+    assert_almost_equal((cX, cY), centroid)
+
+    # Test spacing
+    spacing = (2, 2)
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    cY = float(Mpq(0, 1) / Mpq(0, 0))
+    cX = float(Mpq(1, 0) / Mpq(0, 0))
+    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    centroid = tuple(float(c) for c in centroid)
+    assert_almost_equal(centroid, (cX, cY))
+    assert_almost_equal(centroid, tuple(2 * c for c in target_centroid))
+
+    spacing = (1.3, 0.7)
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    cY = float(Mpq(0, 1) / Mpq(0, 0))
+    cX = float(Mpq(1, 0) / Mpq(0, 0))
+    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    centroid = tuple(float(c) for c in centroid)
+    assert_almost_equal(centroid, (cX, cY))
 
 
 def test_moments_weighted_hu():
@@ -463,6 +819,9 @@ def test_moments_weighted_hu():
     # fmt: on
     assert_array_almost_equal(whu, ref)
 
+    with pytest.raises(NotImplementedError):
+        regionprops(SAMPLE, spacing=(2, 1))[0].moments_weighted_hu
+
 
 def test_moments_weighted():
     wm = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
@@ -477,6 +836,47 @@ def test_moments_weighted():
     # fmt: on
     assert_array_almost_equal(wm, ref)
 
+    # Verify test function
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    assert_almost_equal(Mpq(0, 0), ref[0, 0])
+    assert_almost_equal(Mpq(0, 1), ref[0, 1])
+    assert_almost_equal(Mpq(0, 2), ref[0, 2])
+    assert_almost_equal(Mpq(0, 3), ref[0, 3])
+    assert_almost_equal(Mpq(1, 0), ref[1, 0])
+    assert_almost_equal(Mpq(1, 1), ref[1, 1])
+    assert_almost_equal(Mpq(1, 2), ref[1, 2])
+    assert_almost_equal(Mpq(1, 3), ref[1, 3])
+    assert_almost_equal(Mpq(2, 0), ref[2, 0])
+    assert_almost_equal(Mpq(2, 1), ref[2, 1])
+    assert_almost_equal(Mpq(2, 2), ref[2, 2])
+    assert_almost_equal(Mpq(2, 3), ref[2, 3])
+    assert_almost_equal(Mpq(3, 0), ref[3, 0])
+    assert_almost_equal(Mpq(3, 1), ref[3, 1])
+    assert_almost_equal(Mpq(3, 2), ref[3, 2])
+    assert_almost_equal(Mpq(3, 3), ref[3, 3])
+
+    # Test spacing
+    spacing = (3.2, 1.2)
+    wmu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE,
+                      spacing=spacing)[0].moments_weighted
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    assert_almost_equal(wmu[0, 0], Mpq(0, 0))
+    assert_almost_equal(wmu[0, 1], Mpq(0, 1))
+    assert_almost_equal(wmu[0, 2], Mpq(0, 2))
+    assert_almost_equal(wmu[0, 3], Mpq(0, 3))
+    assert_almost_equal(wmu[1, 0], Mpq(1, 0))
+    assert_almost_equal(wmu[1, 1], Mpq(1, 1))
+    assert_almost_equal(wmu[1, 2], Mpq(1, 2))
+    assert_almost_equal(wmu[1, 3], Mpq(1, 3))
+    assert_almost_equal(wmu[2, 0], Mpq(2, 0))
+    assert_almost_equal(wmu[2, 1], Mpq(2, 1))
+    assert_almost_equal(wmu[2, 2], Mpq(2, 2))
+    assert_almost_equal(wmu[2, 3], Mpq(2, 3))
+    assert_almost_equal(wmu[3, 0], Mpq(3, 0))
+    assert_almost_equal(wmu[3, 1], Mpq(3, 1))
+    assert_almost_equal(wmu[3, 2], Mpq(3, 2))
+    assert_almost_equal(wmu[3, 3], Mpq(3, 3), decimal=6)
+
 
 def test_moments_weighted_normalized():
     wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
@@ -490,6 +890,24 @@ def test_moments_weighted_normalized():
     )
     # fmt: on
     assert_array_almost_equal(wnu, ref)
+
+    spacing = (3, 3)
+    wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].moments_weighted_normalized
+
+    # Normalized moments are scale invariant
+    assert_almost_equal(wnu[0, 2], 0.2301467830)
+    assert_almost_equal(wnu[0, 3], -0.0162529732)
+    assert_almost_equal(wnu[1, 1], -0.0160405109)
+    assert_almost_equal(wnu[1, 2], 0.0457932622)
+    assert_almost_equal(wnu[1, 3], -0.0104598869)
+    assert_almost_equal(wnu[2, 0], 0.0873590903)
+    assert_almost_equal(wnu[2, 1], -0.0031421072)
+    assert_almost_equal(wnu[2, 2], 0.0165315478)
+    assert_almost_equal(wnu[2, 3], -0.0028544152)
+    assert_almost_equal(wnu[3, 0], -0.0161217406)
+    assert_almost_equal(wnu[3, 1], -0.0031376984)
+    assert_almost_equal(wnu[3, 2], 0.0043903193)
+    assert_almost_equal(wnu[3, 3], -0.0011057191)
 
 
 def test_label_sequence():
@@ -753,6 +1171,18 @@ def test_extra_properties_intensity():
                          extra_properties=(intensity_median,)
                          )[0]
     assert region.intensity_median == cp.median(INTENSITY_SAMPLE[SAMPLE == 1])
+
+
+@pytest.mark.parametrize('intensity_prop', _require_intensity_image)
+def test_intensity_image_required(intensity_prop):
+    region = regionprops(SAMPLE)[0]
+    with pytest.raises(AttributeError) as e:
+        getattr(region, intensity_prop)
+    expected_error = (
+        f"Attribute '{intensity_prop}' unavailable when `intensity_image` has "
+        f"not been specified."
+    )
+    assert expected_error == str(e.value)
 
 
 def test_extra_properties_no_intensity_provided():


### PR DESCRIPTION
related to #419

This PR ports features related to image moments and `regionprops` from scikit-image 0.20 to cuCIM

- Improve performance of ``cucim.skimage.measure.moments_central`` by ~2x by avoiding redundant computations (adaptation of scikit-image/scikit-image#6188 to the GPU)
- Support anisotropic images with different voxel spacings.  Spacings can be defined with the new parameter ``spacing`` of the following functions in ``skimage.measure``: ``regionprops``, ``regionprops_table``, ``moments``, ``moments_central``, ``moments_normalized``, ``centroid``, ``inertia_tensor``, and ``inertia_tensor_eigvals`` (scikit-image/scikit-image#6296)
- Voxel spacing is taken into account for the following existing properties in ``skimage.measure.regionprops``: ``area``, ``area_bbox``, ``centroid``, ``area_convex``, ``extent``, ``feret_diameter_max``, ``area_filled``, ``inertia_tensor``, ``moments``, ``moments_central``, ``moments_hu``, ``moments_normalized``, ``perimeter``, ``perimeter_crofton``, ``solidity``, ``moments_weighted_central``, and ``moments_weighted_hu``. (scikit-image/scikit-image#6296)
- Raise a specific error message when accessing region properties from skimage.measure.regionprops when the required intensity_image is unavailable (scikit-image/scikit-image#6584).

