### PR TITLE
improved implementation of ridge filters (bug fixes and reduced memory footprint)

### DIFF
--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -1,7 +1,6 @@
 import functools
 import math
 from itertools import combinations_with_replacement
-from warnings import warn
 
 import cupy as cp
 import numpy as np
@@ -12,7 +11,6 @@ from cucim.skimage.util import img_as_float
 
 # from ..transform import integral_image
 from .._shared._gradient import gradient
-from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, warn
 from .peak import peak_local_max
 from .util import _prepare_grayscale_input_nD
@@ -231,7 +229,7 @@ def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
     # orders in 2D = ([1, 0], [0, 1])
     #        in 3D = ([1, 0, 0], [0, 1, 0], [0, 0, 1])
     #        etc.
-    orders = tuple([0] * d + [1] + [0]*(ndim - d - 1) for d in range(ndim))
+    orders = tuple([0] * d + [1] + [0] * (ndim - d - 1) for d in range(ndim))
     gradients = [gaussian_(image, order=orders[d]) for d in range(ndim)]
 
     # 2.) apply the derivative along another axis as well
@@ -337,7 +335,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
 
     # Autodetection as done internally to Gaussian, but set it here to silence
     # a warning.
-	# TODO: eventually remove this as this behavior of gaussian is deprecated
+    # TODO: eventually remove this as this behavior of gaussian is deprecated
     channel_axis = -1 if (image.ndim == 3 and image.shape[-1] == 3) else None
 
     gaussian_filtered = gaussian(image, sigma=sigma, mode=mode, cval=cval,

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -1,3 +1,5 @@
+import functools
+import math
 from itertools import combinations_with_replacement
 from warnings import warn
 
@@ -10,7 +12,8 @@ from cucim.skimage.util import img_as_float
 
 # from ..transform import integral_image
 from .._shared._gradient import gradient
-from .._shared.utils import _supported_float_type
+from .._shared.filters import gaussian
+from .._shared.utils import _supported_float_type, warn
 from .peak import peak_local_max
 from .util import _prepare_grayscale_input_nD
 
@@ -153,8 +156,96 @@ def structure_tensor(image, sigma=1, mode="constant", cval=0, order=None):
     return A_elems
 
 
-def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
-    """Compute the Hessian matrix.
+def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
+                                  order='rc'):
+    """Compute the Hessian via convolutions with Gaussian derivatives.
+
+    In 2D, the Hessian matrix is defined as:
+        H = [Hrr Hrc]
+            [Hrc Hcc]
+
+    which is computed by convolving the image with the second derivatives
+    of the Gaussian kernel in the respective r- and c-directions.
+
+    The implementation here also supports n-dimensional data.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    sigma : float or sequence of float, optional
+        Standard deviation used for the Gaussian kernel, which sets the
+        amount of smoothing in terms of pixel-distances. It is
+        advised to not choose a sigma much less than 1.0, otherwise
+        aliasing artifacts may occur.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
+    order : {'rc', 'xy'}, optional
+        This parameter allows for the use of reverse or forward order of
+        the image axes in gradient computation. 'rc' indicates the use of
+        the first axis initially (Hrr, Hrc, Hcc), whilst 'xy' indicates the
+        usage of the last axis initially (Hxx, Hxy, Hyy)
+
+    Returns
+    -------
+    H_elems : list of ndarray
+        Upper-diagonal elements of the hessian matrix for each pixel in the
+        input image. In 2D, this will be a three element list containing [Hrr,
+        Hrc, Hcc]. In nD, the list will contain ``(n**2 + n) / 2`` arrays.
+
+    """
+    image = img_as_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
+
+    if np.isscalar(sigma):
+        sigma = (sigma,) * image.ndim
+
+    # This function uses `scipy.ndimage.gaussian_filter` with the order
+    # argument to compute convolutions. For example, specifying
+    # ``order=[1, 0]`` would apply convolution with a first-order derivative of
+    # the Gaussian along the first axis and simple Gaussian smoothing along the
+    # second.
+
+    # For small sigma, the SciPy Gaussian filter suffers from aliasing and edge
+    # artifacts, given that the filter will approximate a sinc or sinc
+    # derivative which only goes to 0 very slowly (order 1/n**2). Thus, we use
+    # a much larger truncate value to reduce any edge artifacts.
+    truncate = 8 if all(s > 1 for s in sigma) else 100
+    sq1_2 = 1 / math.sqrt(2)
+    sigma_scaled = tuple(sq1_2 * s for s in sigma)
+    common_kwargs = dict(sigma=sigma_scaled, mode=mode, cval=cval,
+                         truncate=truncate)
+    gaussian_ = functools.partial(ndi.gaussian_filter, **common_kwargs)
+
+    # Apply two successive first order Gaussian derivative operations, as
+    # detailed in:
+    # https://dsp.stackexchange.com/questions/78280/are-scipy-second-order-gaussian-derivatives-correct  # noqa
+
+    # 1.) First order along one axis while smoothing (order=0) along the other
+    ndim = image.ndim
+
+    # orders in 2D = ([1, 0], [0, 1])
+    #        in 3D = ([1, 0, 0], [0, 1, 0], [0, 0, 1])
+    #        etc.
+    orders = tuple([0] * d + [1] + [0]*(ndim - d - 1) for d in range(ndim))
+    gradients = [gaussian_(image, order=orders[d]) for d in range(ndim)]
+
+    # 2.) apply the derivative along another axis as well
+    axes = range(ndim)
+    if order == 'rc':
+        axes = reversed(axes)
+    H_elems = [gaussian_(gradients[ax0], order=orders[ax1])
+               for ax0, ax1 in combinations_with_replacement(axes, 2)]
+    return H_elems
+
+
+def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
+                   use_gaussian_derivatives=None):
+    r"""Compute the Hessian matrix.
 
     In 2D, the Hessian matrix is defined as::
 
@@ -183,6 +274,9 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
         the image axes in gradient computation. 'rc' indicates the use of
         the first axis initially (Hrr, Hrc, Hcc), whilst 'xy' indicates the
         usage of the last axis initially (Hxx, Hxy, Hyy)
+    use_gaussian_derivatives : boolean, optional
+        Indicates whether the Hessian is computed by convolving with Gaussian
+        derivatives, or by a simple finite-difference operation.
 
     Returns
     -------
@@ -191,13 +285,32 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
         input image. In 2D, this will be a three element list containing [Hrr,
         Hrc, Hcc]. In nD, the list will contain ``(n**2 + n) / 2`` arrays.
 
+
+    Notes
+    -----
+    The distributive property of derivatives and convolutions allows us to
+    restate the derivative of an image, I, smoothed with a Gaussian kernel, G,
+    as the convolution of the image with the derivative of G.
+
+    .. math::
+
+        \frac{\partial }{\partial x_i}(I * G) =
+        I * \left( \frac{\partial }{\partial x_i} G \right)
+
+    When ``use_gaussian_derivatives`` is ``True``, this property is used to
+    compute the second order derivatives that make up the Hessian matrix.
+
+    When ``use_gaussian_derivatives`` is ``False``, simple finite differences
+    on a Gaussian-smoothed image are used instead.
+
     Examples
     --------
     >>> import cupy as cp
     >>> from cucim.skimage.feature import hessian_matrix
     >>> square = cp.zeros((5, 5))
     >>> square[2, 2] = 4
-    >>> Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='rc')
+    >>> Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='rc',
+    ...                                use_gaussian_derivatives=False)
     >>> Hrc
     array([[ 0.,  0.,  0.,  0.,  0.],
            [ 0.,  1.,  0., -1.,  0.],
@@ -211,8 +324,20 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 
+    if use_gaussian_derivatives is None:
+        use_gaussian_derivatives = False
+        warn("use_gaussian_derivatives currently defaults to False, but will "
+             "change to True in a future version. Please specify this "
+             "argument explicitly to maintain the current behavior",
+             category=FutureWarning, stacklevel=2)
+
+    if use_gaussian_derivatives:
+        return _hessian_matrix_with_gaussian(image, sigma=sigma, mode=mode,
+                                             cval=cval, order=order)
+
     # Autodetection as done internally to Gaussian, but set it here to silence
     # a warning.
+	# TODO: eventually remove this as this behavior of gaussian is deprecated
     channel_axis = -1 if (image.ndim == 3 and image.shape[-1] == 3) else None
 
     gaussian_filtered = gaussian(image, sigma=sigma, mode=mode, cval=cval,
@@ -433,7 +558,8 @@ def hessian_matrix_eigvals(H_elems):
     ...                                      hessian_matrix_eigvals)
     >>> square = cp.zeros((5, 5))
     >>> square[2, 2] = 4
-    >>> H_elems = hessian_matrix(square, sigma=0.1, order='rc')
+    >>> H_elems = hessian_matrix(square, sigma=0.1, order='rc',
+    ...                          use_gaussian_derivatives=False)
     >>> hessian_matrix_eigvals(H_elems)[0]
     array([[ 0.,  0.,  2.,  0.,  0.],
            [ 0.,  1.,  0.,  1.,  0.],
@@ -510,7 +636,8 @@ def shape_index(image, sigma=1, mode="constant", cval=0):
            [ nan,  nan, -0.5,  nan,  nan]])
     """
 
-    H = hessian_matrix(image, sigma=sigma, mode=mode, cval=cval, order="rc")
+    H = hessian_matrix(image, sigma=sigma, mode=mode, cval=cval, order="rc",
+                       use_gaussian_derivatives=False)
     l1, l2 = hessian_matrix_eigvals(H)
 
     # don't warn on divide by 0 as occurs in the docstring example

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -124,7 +124,8 @@ def test_structure_tensor_sigma(ndim):
 def test_hessian_matrix(dtype):
     square = cp.zeros((5, 5), dtype=dtype)
     square[2, 2] = 4
-    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order="rc")
+    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order="rc",
+                                   use_gaussian_derivatives=False)
     out_dtype = _supported_float_type(dtype)
     assert all(a.dtype == out_dtype for a in (Hrr, Hrc, Hcc))
     # fmt: off
@@ -147,11 +148,17 @@ def test_hessian_matrix(dtype):
                                                [0, 0,  2, 0, 0]]))  # noqa
     # fmt: on
 
+    with expected_warnings(["use_gaussian_derivatives currently defaults"]):
+        # FutureWarning warning when use_gaussian_derivatives is not
+        # specified.
+        hessian_matrix(square, sigma=0.1, order="rc")
+
 
 def test_hessian_matrix_3d():
     cube = cp.zeros((5, 5, 5))
     cube[2, 2, 2] = 4
-    Hs = hessian_matrix(cube, sigma=0.1, order='rc')
+    Hs = hessian_matrix(cube, sigma=0.1, order='rc',
+                        use_gaussian_derivatives=False)
     assert len(Hs) == 6, "incorrect number of Hessian images (%i) for 3D" % len(
         Hs
     )
@@ -199,7 +206,8 @@ def test_structure_tensor_eigenvalues_3d():
 def test_hessian_matrix_eigvals(dtype):
     square = cp.zeros((5, 5), dtype=dtype)
     square[2, 2] = 4
-    H = hessian_matrix(square, sigma=0.1, order='rc')
+    H = hessian_matrix(square, sigma=0.1, order='rc',
+                       use_gaussian_derivatives=False)
     l1, l2 = hessian_matrix_eigvals(H)
     out_dtype = _supported_float_type(dtype)
     assert all(a.dtype == out_dtype for a in (l1, l2))
@@ -220,7 +228,7 @@ def test_hessian_matrix_eigvals(dtype):
 @pytest.mark.parametrize('dtype', [cp.float16, cp.float32, cp.float64])
 def test_hessian_matrix_eigvals_3d(im3d, dtype):
     im3d = im3d.astype(dtype, copy=False)
-    H = hessian_matrix(im3d)
+    H = hessian_matrix(im3d, use_gaussian_derivatives=False)
     E = hessian_matrix_eigvals(H)
     E = cp.asnumpy(E)
     out_dtype = _supported_float_type(dtype)

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -269,7 +269,6 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
         # the same behavior.
         eigvals[eigvals < 1e-12] = 0.0
 
-
         # Compute normalized tubeness (eqs. (9) and (22), ref. [1]_) as the
         # geometric mean of eigvals other than the lowest one
         # (hessian_matrix_eigvals returns eigvals in decreasing order), clipped

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -8,107 +8,20 @@ image intensities to detect tube-like structures where the intensity changes
 perpendicular but not along the structure.
 """
 
-from functools import reduce
 from warnings import warn
 
 import cupy as cp
 import numpy as np
 
-from .._shared.utils import _supported_float_type, check_nD
-from ..util import img_as_float, invert
+from .._shared.utils import _supported_float_type, check_nD, deprecated
+from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
+from ..util import img_as_float
 
 
-def _divide_nonzero(array1, array2, cval=1e-10):
-    """
-    Divides two arrays.
-
-    Denominator is set to small value where zero to avoid ZeroDivisionError and
-    return finite float array.
-
-    Parameters
-    ----------
-    array1 : (N, ..., M) ndarray
-        Array 1 in the enumerator.
-    array2 : (N, ..., M) ndarray
-        Array 2 in the denominator.
-    cval : float, optional
-        Value used to replace zero entries in the denominator.
-
-    Returns
-    -------
-    array : (N, ..., M) ndarray
-        Quotient of the array division.
-    """
-
-    # Copy denominator
-    denominator = cp.copy(array2)
-
-    # Set zero entries of denominator to small value
-    denominator[denominator == 0] = cval
-
-    # Return quotient
-    return cp.divide(array1, denominator)
-
-
-def _sortbyabs(array, axis=0):
-    """
-    Sort array along a given axis by absolute values.
-
-    Parameters
-    ----------
-    array : (N, ..., M) ndarray
-        Array with input image data.
-    axis : int
-        Axis along which to sort.
-
-    Returns
-    -------
-    array : (N, ..., M) ndarray
-        Array sorted along a given axis by absolute values.
-
-    Notes
-    -----
-    Modified from: http://stackoverflow.com/a/11253931/4067734
-    """
-
-    # Create auxiliary array for indexing
-    index = list(cp.ix_(*[cp.arange(i) for i in array.shape]))
-
-    # Get indices of abs sorted array
-    index[axis] = cp.abs(array).argsort(axis)
-
-    # Return abs sorted array
-    return array[tuple(index)]
-
-
-def _check_sigmas(sigmas):
-    """Check sigma values for ridges filters.
-
-    Parameters
-    ----------
-    sigmas : iterable of floats
-        Sigmas argument to be checked
-
-    Returns
-    -------
-    sigmas : ndarray
-        input iterable converted to ndarray
-
-    Raises
-    ------
-    ValueError if any input value is negative
-
-    """
-    if np.isscalar(sigmas):
-        sigmas = (sigmas,)
-    if any(s < 0.0 for s in sigmas):
-        raise ValueError('Sigma values should be equal to or greater '
-                         'than zero.')
-    return np.asarray(sigmas)
-
-
+@deprecated(removed_version="2023.06.01")
 def compute_hessian_eigenvalues(image, sigma, sorting='none',
-                                mode='constant', cval=0):
+                                mode='constant', cval=0,
+                                use_gaussian_derivatives=False):
     """
     Compute Hessian eigenvalues of nD images.
 
@@ -130,6 +43,9 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
+    use_gaussian_derivatives : boolean, optional
+        Indicates whether the Hessian is computed by convolving with Gaussian
+        derivatives, or by a simple finite-difference operation.
 
     Returns
     -------
@@ -137,9 +53,6 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
         Array with (sorted) eigenvalues of Hessian eigenvalues for each pixel
         of the input image.
     """
-
-    # Import moved here to avoid circular import error
-    from ..feature import hessian_matrix, hessian_matrix_eigvals
 
     # Convert image to float
     float_dtype = _supported_float_type(image.dtype)
@@ -149,21 +62,25 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     image = image.astype(float_dtype, copy=False)
 
     # Make nD hessian
-    hessian_elements = hessian_matrix(image, sigma=sigma, order='rc',
-                                      mode=mode, cval=cval)
+    hessian_matrix_kwargs = dict(
+        sigma=sigma, order='rc', mode=mode, cval=cval,
+        use_gaussian_derivatives=use_gaussian_derivatives
+    )
+    hessian_elements = hessian_matrix(image, **hessian_matrix_kwargs)
 
-    # Correct for scale
-    var = sigma * sigma
-    hessian_elements = [var * e for e in hessian_elements]
+    if not use_gaussian_derivatives:
+        # Kept to preserve legacy behavior
+        var = sigma * sigma
+        hessian_elements = [var * e for e in hessian_elements]
 
     # Compute Hessian eigenvalues
-    # hessian_eigenvalues = np.array(hessian_matrix_eigvals(hessian_elements))
     hessian_eigenvalues = hessian_matrix_eigvals(hessian_elements)
 
     if sorting == 'abs':
 
         # Sort eigenvalues by absolute values in ascending order
-        hessian_eigenvalues = _sortbyabs(hessian_eigenvalues, axis=0)
+        hessian_eigenvalues = cp.take_along_axis(
+            hessian_eigenvalues, abs(hessian_eigenvalues).argsort(0), 0)
 
     elif sorting == 'val':
 
@@ -172,6 +89,26 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
 
     # Return Hessian eigenvalues
     return hessian_eigenvalues
+
+
+@cp.memoize()
+def _get_circulant_init_kernel(ndim, alpha):
+    operation = f"""
+    for (int x=0; x < {ndim}; x++) {{
+        for (int y=0; y < {ndim}; y++) {{
+            if (x == y) {{
+               out[y + x*{ndim}] = 1.0;
+            }} else {{
+               out[y + x*{ndim}] = {alpha};
+            }}
+        }}
+    }}
+    """
+    return cp.ElementwiseKernel(
+        "",
+        "raw F out",
+        operation=operation,
+        name=f"cucim_circulant_init_{ndim}d_alpha{int(1000*alpha)}")
 
 
 def meijering(image, sigmas=range(1, 10, 2), alpha=None,
@@ -193,8 +130,8 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     sigmas : iterable of floats, optional
         Sigmas used as scales of filter
     alpha : float, optional
-        Frangi correction constant that adjusts the filter's
-        sensitivity to deviation from a plate-like structure.
+        Shaping filter constant, that selects maximally flat elongated
+        features.  The default, None, selects the optimal value -1/(ndim+1).
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
@@ -224,63 +161,46 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
         :DOI:`10.1002/cyto.a.20022`
     """
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Get image dimensions
-    ndim = image.ndim
-
-    # Set parameters
     if alpha is None:
-        alpha = 1.0 / ndim
+        alpha = 1 / (image.ndim + 1)
 
-    # Invert image to detect dark ridges on bright background
-    if black_ridges:
-        image = invert(image)
+    # tiny matrix, so just use a single threaded kernel to assign the values
+    circulant_init_kernel = _get_circulant_init_kernel(image.ndim, alpha)
+    mtx = cp.empty((image.ndim, image.ndim), dtype=image.dtype)
+    circulant_init_kernel(mtx, size=1)
 
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    # Generate empty array for storing maximum value
+    # from different (sigma) scales
+    filtered_max = cp.zeros_like(image)
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
 
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered at
-    # different (sigma) scales
-    filtered_array = cp.empty(sigmas.shape + image.shape, dtype=float_dtype)
+        # cucim's hessian_matrix differs numerically from the one in skimage.
+        # Sometimes where skimage returns 0, it returns very small values
+        # (1e-15-1e-14). Here we set values < 1e-12 to 0 to better replicate
+        # the same behavior.
+        eigvals[eigvals < 1e-12] = 0.0
 
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
+        # Compute normalized eigenvalues l_i = e_i + sum_{j!=i} alpha * e_j.
+        vals = cp.tensordot(mtx, eigvals, 1)
+        # Get largest normalized eigenvalue (by magnitude) at each pixel.
+        vals = cp.take_along_axis(
+            vals, abs(vals).argmax(0)[None], 0).squeeze(0)
+        # Remove negative values.
+        vals = cp.maximum(vals, 0)
+        # Normalize to max = 1 (unless everything is already zero).
+        max_val = vals.max()
+        if max_val > 0:
+            vals /= max_val
+        filtered_max = cp.maximum(filtered_max, vals)
+        # print(f"{black_ridges=}, {image.max()=}, {sigma=}, {filtered_max=}")
 
-        # Calculate (sorted) eigenvalues
-        eigenvalues = compute_hessian_eigenvalues(image, sigma, sorting='abs',
-                                                  mode=mode, cval=cval)
-        # CuPy Backend: do intermediate computations with tiny arrays on the
-        #               CPU
-        # TODO: refactor to avoid host-device transfer
-        eigenvalues = cp.asnumpy(eigenvalues)
-
-        if ndim > 1:
-
-            # Set coefficients for scaling eigenvalues
-            coefficients = [alpha] * ndim
-            coefficients[0] = 1
-
-            # Compute normalized eigenvalues l_i = e_i + sum_{j!=i} alpha * e_j
-            auxiliary = [np.sum([eigenvalues[i] * np.roll(coefficients, j)[i]
-                         for j in range(ndim)], axis=0) for i in range(ndim)]
-
-            # Get maximum eigenvalues by magnitude
-            auxiliary = auxiliary[-1]
-            auxiliary = cp.asarray(auxiliary)
-
-            # Rescale image intensity and avoid ZeroDivisionError
-            filtered = _divide_nonzero(auxiliary, cp.min(auxiliary))
-
-            # Remove background
-            filtered = cp.where(auxiliary < 0, filtered, 0)
-
-            # Store results in (n+1)D matrices
-            filtered_array[i] = filtered
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return cp.max(filtered_array, axis=0)
+    return filtered_max  # Return pixel-wise max over all sigmas.
 
 
 def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
@@ -331,46 +251,38 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
         :DOI:`10.1016/S1361-8415(98)80009-1`
     """
 
-    # Check image dimensions
-    check_nD(image, [2, 3])
+    check_nD(image, [2, 3])  # Check image dimensions.
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
+    # Generate empty array for storing maximum value
+    # from different (sigma) scales
+    filtered_max = cp.zeros_like(image)
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
 
-    # Invert image to detect bright ridges on dark background
-    if not black_ridges:
-        image = invert(image)
+        # cucim's hessian_matrix differs numerically from the one in skimage.
+        # Sometimes where skimage returns 0, it returns very small values
+        # (1e-15-1e-14). Here we set values < 1e-12 to 0 to better replicate
+        # the same behavior.
+        eigvals[eigvals < 1e-12] = 0.0
 
-    float_dtype = _supported_float_type(image.dtype)
 
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered
-    # at different (sigma) scales
-    filtered_array = cp.empty(sigmas.shape + image.shape, dtype=float_dtype)
-
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
-
-        # Calculate (sorted) eigenvalues
-        lamba1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                       sorting='val',
-                                                       mode=mode, cval=cval)
-
-        # Compute tubeness, see  equation (9) in reference [1]_.
-        # cp.abs(lambda2) in 2D, cp.sqrt(cp.abs(lambda2 * lambda3)) in 3D
-
-        # CuPy Backend: cp.multiply does not have a reduce method
-        # filtered = cp.abs(cp.multiply.reduce(lambdas)) ** (1 / len(lambdas))
-        filtered = cp.abs(reduce(cp.multiply, lambdas)) ** (1 / len(lambdas))
-
-        # Remove background and store results in (n+1)D matrices
-        filtered_array[i] = cp.where(lambdas[-1] > 0, filtered, 0)
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return cp.max(filtered_array, axis=0)
+        # Compute normalized tubeness (eqs. (9) and (22), ref. [1]_) as the
+        # geometric mean of eigvals other than the lowest one
+        # (hessian_matrix_eigvals returns eigvals in decreasing order), clipped
+        # to 0, multiplied by sigma^2.
+        eigvals = eigvals[:-1]
+        vals = cp.prod(cp.maximum(eigvals, 0), 0) ** (1 / len(eigvals))
+        vals *= sigma ** 2
+        filtered_max = cp.maximum(filtered_max, vals)
+    return filtered_max  # Return pixel-wise max over all sigmas.
 
 
 def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
-           scale_step=None, alpha=0.5, beta=0.5, gamma=15,
+           scale_step=None, alpha=0.5, beta=0.5, gamma=None,
            black_ridges=True, mode='reflect', cval=0):
     """
     Filter an image with the Frangi vesselness filter.
@@ -403,6 +315,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     gamma : float, optional
         Frangi correction constant that adjusts the filter's
         sensitivity to areas of high variance/texture/structure.
+        The default, None, uses half of the maximum Hessian norm.
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
@@ -419,9 +332,9 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
 
     Notes
     -----
-    Written by Marc Schrijver, November 2001
-    Re-Written by D. J. Kroon, University of Twente, May 2009, [2]_
-    Adoption of 3D version from D. G. Ellis, Januar 20017, [3]_
+    Earlier versions of this filter were implemented by Marc Schrijver,
+    (November 2001), D. J. Kroon, University of Twente (May 2009) [2]_, and
+    D. G. Ellis (January 2017) [3]_.
 
     See also
     --------
@@ -445,72 +358,52 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
              stacklevel=2)
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)
 
-    # Check image dimensions
-    check_nD(image, [2, 3])
+    check_nD(image, [2, 3])  # Check image dimensions.
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
+    # Generate empty array for storing maximum value
+    # from different (sigma) scales
+    filtered_max = cp.zeros_like(image)
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
 
-    # Rescale filter parameters
-    alpha_sq = 2 * alpha ** 2
-    beta_sq = 2 * beta ** 2
-    gamma_sq = 2 * gamma ** 2
+        # cucim's hessian_matrix differs numerically from the one in skimage.
+        # Sometimes where skimage returns 0, it returns very small values
+        # (1e-15-1e-14). Here we set values < 1e-12 to 0 to better replicate
+        # the same behavior.
+        eigvals[eigvals < 1e-12] = 0.0
 
-    # Get image dimensions
-    ndim = image.ndim
-
-    # Invert image to detect dark ridges on light background
-    if black_ridges:
-        image = invert(image)
-
-    float_dtype = _supported_float_type(image.dtype)
-
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered
-    # at different (sigma) scales
-    filtered_array = cp.empty(sigmas.shape + image.shape, dtype=float_dtype)
-    lambdas_array = cp.empty_like(filtered_array)
-
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
-
-        # Calculate (abs sorted) eigenvalues
-        lambda1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                        sorting='abs',
-                                                        mode=mode, cval=cval)
-
-        # Compute sensitivity to deviation from a plate-like
-        # structure see equations (11) and (15) in reference [1]_
-        r_a = np.inf if ndim == 2 else _divide_nonzero(*lambdas) ** 2
-
-        # Compute sensitivity to deviation from a blob-like structure,
-        # see equations (10) and (15) in reference [1]_,
-        # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D
-        # CuPy Backend: cp.multiply does not have a reduce method
-        # filtered_raw = np.abs(np.multiply.reduce(lambdas))**(1/len(lambdas))
-        filtered_raw = cp.abs(reduce(cp.multiply, lambdas)) ** (
-            1 / len(lambdas)
-        )
-        r_b = _divide_nonzero(lambda1, filtered_raw)
-        r_b *= r_b
-
-        # Compute sensitivity to areas of high variance/texture/structure,
-        # see equation (12)in reference [1]_
-        r_g = sum([lambda1 * lambda1] +
-                  [lambdai * lambdai for lambdai in lambdas])
-
-        # Compute output image for given (sigma) scale and store results in
-        # (n+1)D matrices, see equations (13) and (15) in reference [1]_
-        filtered_array[i] = ((1 - cp.exp(-r_a / alpha_sq))
-                             * cp.exp(-r_b / beta_sq)
-                             * (1 - cp.exp(-r_g / gamma_sq)))
-
-        lambdas_array[i] = cp.max(cp.asarray(lambdas), axis=0)
-
-    # Remove background
-    filtered_array[lambdas_array > 0] = 0
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return cp.max(filtered_array, axis=0)
+        # Sort eigenvalues by magnitude.
+        eigvals = cp.take_along_axis(eigvals, abs(eigvals).argsort(0), 0)
+        lambda1 = eigvals[0]
+        if image.ndim == 2:
+            lambda2, = cp.maximum(eigvals[1:], 1e-10)
+            r_a = cp.inf  # implied by eq. (15).
+            r_b = cp.abs(lambda1) / lambda2  # eq. (15).
+        else:  # ndim == 3
+            lambda2, lambda3 = cp.maximum(eigvals[1:], 1e-10)
+            r_a = lambda2 / lambda3  # eq. (11).
+            r_b = cp.abs(lambda1) / cp.sqrt(lambda2 * lambda3)  # eq. (10).
+        s = cp.sqrt((eigvals ** 2).sum(0))  # eq. (12).
+        if gamma is None:
+            gamma = s.max() / 2
+            if gamma == 0:
+                gamma = 1  # If s == 0 everywhere, gamma doesn't matter.
+        # Filtered image, eq. (13) and (15).  Our implementation relies on the
+        # blobness exponential factor underflowing to zero whenever the second
+        # or third eigenvalues are negative (we clip them to 1e-10, to make r_b
+        # very large).
+        vals = 1.0 - cp.exp(-r_a**2 / (2 * alpha**2))  # plate sensitivity
+        vals = vals.astype(image.dtype, copy=False)
+        vals = vals * cp.exp(-r_b**2 / (2 * beta**2))  # blobness
+        vals *= 1.0 - cp.exp(-s**2 / (2 * gamma**2))  # structuredness
+        filtered_max = cp.maximum(filtered_max, vals)
+    if filtered_max.dtype != image.dtype:
+        1 / 0
+    return filtered_max  # Return pixel-wise max over all sigmas.
 
 
 def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,

--- a/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
@@ -189,14 +189,16 @@ def test_2d_cropped_camera_image(dtype):
     zeros = cp.zeros((100, 100))
     ones = cp.ones((100, 100))
 
+    tol = 1e-7 if dtype == 'float64' else 1e-5
+
     assert_allclose(meijering(a_black, black_ridges=True),
-                    meijering(a_white, black_ridges=False))
+                    meijering(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
-                    sato(a_white, black_ridges=False, mode='reflect'))
+                    sato(a_white, black_ridges=False, mode='reflect'), atol=tol, rtol=tol)
 
-    assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
-    assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
+    assert_allclose(frangi(a_black, black_ridges=True),
+                    frangi(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
                     ones, atol=1 - 1e-7)
@@ -223,16 +225,17 @@ def test_3d_cropped_camera_image(dtype):
 
     zeros = cp.zeros((100, 100, 3))
     ones = cp.ones((100, 100, 3))
+    tol = 1e-7 if dtype == 'float64' else 4e-4
 
     # TODO: determine why the following allclose checks occassionally fail
     assert_allclose(meijering(a_black, black_ridges=True),
-                    meijering(a_white, black_ridges=False))
+                    meijering(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
-                    sato(a_white, black_ridges=False, mode='reflect'))
+                    sato(a_white, black_ridges=False, mode='reflect'), atol=tol, rtol=tol)
 
-    assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
-    assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
+    assert_allclose(frangi(a_black, black_ridges=True),
+                    frangi(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
                     ones, atol=1 - 1e-7)
@@ -240,9 +243,9 @@ def test_3d_cropped_camera_image(dtype):
                     ones, atol=1 - 1e-7)
 
 
-@pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
-                                       (meijering, 2e-2),
-                                       (sato, 1e-3),
+@pytest.mark.parametrize('func, tol', [(frangi, 1e-2),
+                                       (meijering, 1e-2),
+                                       (sato, 2e-3),
                                        (hessian, 2e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(cp.array(retina()[300:500, 700:900]))

--- a/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
@@ -186,7 +186,6 @@ def test_2d_cropped_camera_image(dtype):
         a_black = img_as_float64(a_black)
     a_white = invert(a_black)
 
-    zeros = cp.zeros((100, 100))
     ones = cp.ones((100, 100))
 
     tol = 1e-7 if dtype == 'float64' else 1e-5
@@ -195,7 +194,8 @@ def test_2d_cropped_camera_image(dtype):
                     meijering(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
-                    sato(a_white, black_ridges=False, mode='reflect'), atol=tol, rtol=tol)
+                    sato(a_white, black_ridges=False, mode='reflect'),
+                    atol=tol, rtol=tol)
 
     assert_allclose(frangi(a_black, black_ridges=True),
                     frangi(a_white, black_ridges=False), atol=tol, rtol=tol)
@@ -223,7 +223,6 @@ def test_3d_cropped_camera_image(dtype):
     a_black = cp.dstack([a_black, a_black, a_black])
     a_white = invert(a_black)
 
-    zeros = cp.zeros((100, 100, 3))
     ones = cp.ones((100, 100, 3))
     tol = 1e-7 if dtype == 'float64' else 4e-4
 
@@ -232,7 +231,8 @@ def test_3d_cropped_camera_image(dtype):
                     meijering(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
-                    sato(a_white, black_ridges=False, mode='reflect'), atol=tol, rtol=tol)
+                    sato(a_white, black_ridges=False, mode='reflect'),
+                    atol=tol, rtol=tol)
 
     assert_allclose(frangi(a_black, black_ridges=True),
                     frangi(a_white, black_ridges=False), atol=tol, rtol=tol)

--- a/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_ridges.py
@@ -224,7 +224,7 @@ def test_3d_cropped_camera_image(dtype):
     a_white = invert(a_black)
 
     ones = cp.ones((100, 100, 3))
-    tol = 1e-7 if dtype == 'float64' else 4e-4
+    tol = 1e-7 if dtype == 'float64' else 8e-3
 
     # TODO: determine why the following allclose checks occassionally fail
     assert_allclose(meijering(a_black, black_ridges=True),
@@ -246,7 +246,7 @@ def test_3d_cropped_camera_image(dtype):
 @pytest.mark.parametrize('func, tol', [(frangi, 1e-2),
                                        (meijering, 1e-2),
                                        (sato, 2e-3),
-                                       (hessian, 2e-2)])
+                                       (hessian, 1e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(cp.array(retina()[300:500, 700:900]))
     out = func(img, sigmas=[1], mode='mirror')
@@ -264,5 +264,5 @@ def test_border_management(func, tol):
     assert abs(full_std - border_std) < tol
     assert abs(inside_std - border_std) < tol
     assert abs(full_mean - inside_mean) < tol
-    assert abs(full_mean - border_mean) < tol
-    assert abs(inside_mean - border_mean) < tol
+    assert abs(full_mean - border_mean) < 8 * tol
+    assert abs(inside_mean - border_mean) < 8 * tol


### PR DESCRIPTION
related to #419

A large overhaul of the ridge filters, addressing inaccuracies and errors has been implemented for scikit-image 0.20. This PR ports the same changes to these functions to cuCIM.

upstream PRs: 
 - scikit-image/scikit-image#6149
 - scikit-image/scikit-image#6440 
 - scikit-image/scikit-image#6446
 - scikit-image/scikit-image#6509

These fix various bugs, simplify the implementation and reduce the memory footprint
