### PR TITLE
add three segmentation metrics

### DIFF
--- a/benchmarks/skimage/cucim_segmentation_bench.py
+++ b/benchmarks/skimage/cucim_segmentation_bench.py
@@ -56,7 +56,7 @@ class LabelBench(ImageBench):
         return labels.astype(dtype, copy=False)
 
     def set_args(self, dtype):
-        labels_d = self._genereate_labels(dtype)
+        labels_d = self._generate_labels(dtype)
         labels = cp.asnumpy(labels_d)
         self.args_cpu = (labels,)
         self.args_gpu = (labels_d,)
@@ -65,7 +65,7 @@ class LabelBench(ImageBench):
 class LabelAndImageBench(LabelBench):
 
     def set_args(self, dtype):
-        labels_d = self._genereate_labels(dtype)
+        labels_d = self._generate_labels(dtype)
         labels = cp.asnumpy(labels_d)
         image_d = cp.random.standard_normal(labels.shape).astype(np.float32)
         image = cp.asnumpy(image_d)

--- a/benchmarks/skimage/run-nv-bench-metrics.sh
+++ b/benchmarks/skimage/run-nv-bench-metrics.sh
@@ -5,7 +5,19 @@ param_dt=(float32 uint8)
 for shape in "${param_shape[@]}"; do
     for filt in "${param_filt[@]}"; do
         for dt in "${param_dt[@]}"; do
-            python cucim_metrics_bench.py -f $filt -i $shape -d $dt -t 10
+            python cucim_metrics_bench.py -f $filt -i $shape -d $dt -t 4
+        done
+    done
+done
+
+# can only use integer dtypes and non-color images for the segmentation metrics
+param_shape=(512,512 3840,2160 192,192,192)
+param_filt=(adapted_rand_error contingency_table variation_of_information)
+param_dt=(uint8)
+for shape in "${param_shape[@]}"; do
+    for filt in "${param_filt[@]}"; do
+        for dt in "${param_dt[@]}"; do
+            python cucim_metrics_bench.py -f $filt -i $shape -d $dt -t 4
         done
     done
 done

--- a/python/cucim/src/cucim/skimage/metrics/__init__.py
+++ b/python/cucim/src/cucim/skimage/metrics/__init__.py
@@ -1,8 +1,14 @@
+from ._adapted_rand_error import adapted_rand_error
+from ._contingency_table import contingency_table
 from ._structural_similarity import structural_similarity
+from ._variation_of_information import variation_of_information
 from .simple_metrics import (mean_squared_error, normalized_mutual_information,
                              normalized_root_mse, peak_signal_noise_ratio)
 
 __all__ = [
+    "adapted_rand_error",
+    "variation_of_information",
+    "contingency_table",
     "mean_squared_error",
     "normalized_mutual_information",
     "normalized_root_mse",

--- a/python/cucim/src/cucim/skimage/metrics/_adapted_rand_error.py
+++ b/python/cucim/src/cucim/skimage/metrics/_adapted_rand_error.py
@@ -1,0 +1,96 @@
+from .._shared.utils import check_shape_equality
+from ._contingency_table import contingency_table
+
+__all__ = ['adapted_rand_error']
+
+
+def adapted_rand_error(image_true=None, image_test=None, *, table=None,
+                       ignore_labels=(0,), alpha=0.5):
+    r"""Compute Adapted Rand error as defined by the SNEMI3D contest. [1]_
+
+    Parameters
+    ----------
+    image_true : cp.ndarray of int
+        Ground-truth label image, same shape as im_test.
+    image_test : cp.ndarray of int
+        Test image.
+    table : cupyx.scipy.sparse array in csr format, optional
+        A contingency table built with skimage.evaluate.contingency_table.
+        If None, it will be computed on the fly.
+    ignore_labels : sequence of int, optional
+        Labels to ignore. Any part of the true image labeled with any of these
+        values will not be counted in the score.
+    alpha : float, optional
+        Relative weight given to precision and recall in the adapted Rand error
+        calculation.
+
+    Returns
+    -------
+    are : float
+        The adapted Rand error.
+    prec : float
+        The adapted Rand precision: this is the number of pairs of pixels that
+        have the same label in the test label image *and* in the true image,
+        divided by the number in the test image.
+    rec : float
+        The adapted Rand recall: this is the number of pairs of pixels that
+        have the same label in the test label image *and* in the true image,
+        divided by the number in the true image.
+
+    Notes
+    -----
+    Pixels with label 0 in the true segmentation are ignored in the score.
+
+    The adapted Rand error is calculated as follows:
+
+    :math:`1 - \frac{\sum_{ij} p_{ij}^{2}}{\alpha \sum_{k} s_{k}^{2} +
+    (1-\alpha)\sum_{k} t_{k}^{2}}`,
+    where :math:`p_{ij}` is the probability that a pixel has the same label
+    in the test image *and* in the true image, :math:`t_{k}` is the
+    probability that a pixel has label :math:`k` in the true image,
+    and :math:`s_{k}` is the probability that a pixel has label :math:`k`
+    in the test image.
+
+    Default behavior is to weight precision and recall equally in the
+    adapted Rand error calculation.
+    When alpha = 0, adapted Rand error = recall.
+    When alpha = 1, adapted Rand error = precision.
+
+    References
+    ----------
+    .. [1] Arganda-Carreras I, Turaga SC, Berger DR, et al. (2015)
+           Crowdsourcing the creation of image segmentation algorithms
+           for connectomics. Front. Neuroanat. 9:142.
+           :DOI:`10.3389/fnana.2015.00142`
+    """
+    if image_test is not None and image_true is not None:
+        check_shape_equality(image_true, image_test)
+
+    if table is None:
+        p_ij = contingency_table(image_true, image_test,
+                                 ignore_labels=ignore_labels, normalize=False)
+    else:
+        p_ij = table
+
+    if alpha < 0.0 or alpha > 1.0:
+        raise ValueError('alpha must be between 0 and 1')
+
+    # Sum of the joint distribution squared
+    sum_p_ij2 = p_ij.data @ p_ij.data - p_ij.sum()
+
+    a_i = p_ij.sum(axis=1).ravel()
+    b_i = p_ij.sum(axis=0).ravel()
+
+    # Sum of squares of the test segment sizes (this is 2x the number of pairs
+    # of pixels with the same label in im_test)
+    sum_a2 = a_i @ a_i - a_i.sum()
+    # Same for im_true
+    sum_b2 = b_i @ b_i - b_i.sum()
+
+    precision = sum_p_ij2 / sum_a2
+    recall = sum_p_ij2 / sum_b2
+
+    fscore = sum_p_ij2 / (alpha * sum_a2 + (1 - alpha) * sum_b2)
+    are = 1. - fscore
+
+    return are, precision, recall

--- a/python/cucim/src/cucim/skimage/metrics/_contingency_table.py
+++ b/python/cucim/src/cucim/skimage/metrics/_contingency_table.py
@@ -1,0 +1,44 @@
+import cupyx.scipy.sparse as sparse
+import cupy as cp
+
+__all__ = ['contingency_table']
+
+
+def contingency_table(im_true, im_test, *, ignore_labels=None,
+                      normalize=False):
+    """
+    Return the contingency table for all regions in matched segmentations.
+
+    Parameters
+    ----------
+    im_true : ndarray of int
+        Ground-truth label image, same shape as im_test.
+    im_test : ndarray of int
+        Test image.
+    ignore_labels : sequence of int, optional
+        Labels to ignore. Any part of the true image labeled with any of these
+        values will not be counted in the score.
+    normalize : bool
+        Determines if the contingency table is normalized by pixel count.
+
+    Returns
+    -------
+    cont : scipy.sparse.csr_matrix
+        A contingency table. `cont[i, j]` will equal the number of voxels
+        labeled `i` in `im_true` and `j` in `im_test`.
+    """
+
+    im_test_r = im_test.reshape(-1)
+    im_true_r = im_true.reshape(-1)
+    if ignore_labels is not None:
+        ignore_labels = cp.asarray(ignore_labels)
+        data = cp.isin(im_true_r, ignore_labels, invert=True).astype(float)
+        if normalize:
+            data /= cp.count_nonzero(data)
+    else:
+        if normalize:
+            data = cp.full((im_test_r.size,), 1 / im_test_r.size, dtype=float)
+        else:
+            data = cp.ones((im_test_r.size,), dtype=float)
+    cont = sparse.coo_matrix((data, (im_true_r, im_test_r))).tocsr()
+    return cont

--- a/python/cucim/src/cucim/skimage/metrics/_variation_of_information.py
+++ b/python/cucim/src/cucim/skimage/metrics/_variation_of_information.py
@@ -1,0 +1,136 @@
+import cupy as cp
+import cupyx.scipy.sparse as sparse
+from ._contingency_table import contingency_table
+from .._shared.utils import check_shape_equality
+
+__all__ = ['variation_of_information']
+
+
+def variation_of_information(image0=None, image1=None, *, table=None,
+                             ignore_labels=()):
+    """Return symmetric conditional entropies associated with the VI. [1]_
+
+    The variation of information is defined as VI(X,Y) = H(X|Y) + H(Y|X).
+    If X is the ground-truth segmentation, then H(X|Y) can be interpreted
+    as the amount of under-segmentation and H(X|Y) as the amount
+    of over-segmentation. In other words, a perfect over-segmentation
+    will have H(X|Y)=0 and a perfect under-segmentation will have H(Y|X)=0.
+
+    Parameters
+    ----------
+    image0, image1 : cp.ndarray of int
+        Label images / segmentations, must have same shape.
+    table : cupyx.scipy.sparse array in csr format, optional
+        A contingency table built with skimage.evaluate.contingency_table.
+        If None, it will be computed with skimage.evaluate.contingency_table.
+        If given, the entropies will be computed from this table and any images
+        will be ignored.
+    ignore_labels : sequence of int, optional
+        Labels to ignore. Any part of the true image labeled with any of these
+        values will not be counted in the score.
+
+    Returns
+    -------
+    vi : cp.ndarray of float, shape (2,)
+        The conditional entropies of image1|image0 and image0|image1.
+
+    References
+    ----------
+    .. [1] Marina Meilă (2007), Comparing clusterings—an information based
+        distance, Journal of Multivariate Analysis, Volume 98, Issue 5,
+        Pages 873-895, ISSN 0047-259X, :DOI:`10.1016/j.jmva.2006.11.013`.
+    """
+    h0g1, h1g0 = _vi_tables(image0, image1, table=table,
+                            ignore_labels=ignore_labels)
+    # false splits, false merges
+    return cp.array([h1g0.sum(), h0g1.sum()])
+
+
+def _xlogx(x):
+    """Compute x * log_2(x).
+
+    We define 0 * log_2(0) = 0
+
+    Parameters
+    ----------
+    x : cp.ndarray or scipy.sparse.csc_matrix or csr_matrix
+        The input array.
+
+    Returns
+    -------
+    y : same type as x
+        Result of x * log_2(x).
+    """
+    y = x.copy()
+    if isinstance(y, sparse.csc_matrix) or isinstance(y, sparse.csr_matrix):
+        z = y.data
+    else:
+        z = cp.asarray(y)  # ensure np.matrix converted to np.array
+    nz = z.nonzero()
+    z[nz] *= cp.log2(z[nz])
+    return y
+
+
+def _vi_tables(im_true, im_test, table=None, ignore_labels=()):
+    """Compute probability tables used for calculating VI.
+
+    Parameters
+    ----------
+    im_true, im_test : cp.ndarray of int
+        Input label images, any dimensionality.
+    table : csr matrix, optional
+        Pre-computed contingency table.
+    ignore_labels : sequence of int, optional
+        Labels to ignore when computing scores.
+
+    Returns
+    -------
+    hxgy, hygx : cp.ndarray of float
+        Per-segment conditional entropies of ``im_true`` given ``im_test`` and
+        vice-versa.
+    """
+    check_shape_equality(im_true, im_test)
+
+    if table is None:
+        # normalize, since it is an identity op if already done
+        pxy = contingency_table(
+            im_true, im_test,
+            ignore_labels=ignore_labels, normalize=True
+        )
+
+    else:
+        pxy = table
+
+    # compute marginal probabilities, converting to 1D array
+    px = cp.ravel(pxy.sum(axis=1))
+    py = cp.ravel(pxy.sum(axis=0))
+
+    # use sparse matrix linear algebra to compute VI
+    # first, compute the inverse diagonal matrices
+    px_inv = sparse.diags(_invert_nonzero(px))
+    py_inv = sparse.diags(_invert_nonzero(py))
+
+    # then, compute the entropies
+    hygx = -px @ _xlogx(px_inv @ pxy).sum(axis=1)
+    hxgy = -_xlogx(pxy @ py_inv).sum(axis=0) @ py
+
+    return list(map(cp.asarray, [hxgy, hygx]))
+
+
+def _invert_nonzero(arr):
+    """Compute the inverse of the non-zero elements of arr, not changing 0.
+
+    Parameters
+    ----------
+    arr : cp.ndarray
+
+    Returns
+    -------
+    arr_inv : cp.cp.ndarray
+        Array containing the inverse of the non-zero elements of arr, and
+        zero elsewhere.
+    """
+    arr_inv = arr.copy()
+    nz = cp.nonzero(arr)
+    arr_inv[nz] = 1 / arr[nz]
+    return arr_inv

--- a/python/cucim/src/cucim/skimage/metrics/tests/test_segmentation_metrics.py
+++ b/python/cucim/src/cucim/skimage/metrics/tests/test_segmentation_metrics.py
@@ -1,0 +1,65 @@
+import cupy as cp
+import pytest
+from numpy.testing import assert_almost_equal, assert_equal
+
+from cucim.skimage.metrics import (adapted_rand_error,
+                                   variation_of_information,
+                                   contingency_table)
+
+from cupy.testing import assert_array_equal
+
+
+def test_contingency_table():
+    im_true = cp.array([1, 2, 3, 4])
+    im_test = cp.array([1, 1, 8, 8])
+
+    # fmt: off
+    table1 = cp.array([[0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                       [0., 0.25, 0., 0., 0., 0., 0., 0., 0.],
+                       [0., 0.25, 0., 0., 0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0., 0., 0., 0., 0.25],
+                       [0., 0., 0., 0., 0., 0., 0., 0., 0.25]])
+    # fmt: on
+
+    sparse_table2 = contingency_table(im_true, im_test, normalize=True)
+    table2 = sparse_table2.toarray()
+    assert_array_equal(table1, table2)
+
+
+def test_vi():
+    im_true = cp.array([1, 2, 3, 4])
+    im_test = cp.array([1, 1, 8, 8])
+    assert_equal(float(cp.sum(variation_of_information(im_true, im_test))), 1)
+
+
+def test_vi_ignore_labels():
+    im1 = cp.array([[1, 0],
+                    [2, 3]], dtype='uint8')
+    im2 = cp.array([[1, 1],
+                    [1, 0]], dtype='uint8')
+
+    false_splits, false_merges = variation_of_information(im1, im2,
+                                                          ignore_labels=[0])
+    assert (false_splits, false_merges) == (0, 2 / 3)
+
+
+def test_are():
+    im_true = cp.array([[2, 1], [1, 2]])
+    im_test = cp.array([[1, 2], [3, 1]])
+    assert_almost_equal(
+        tuple(map(float, adapted_rand_error(im_true, im_test))),
+        (0.3333333, 0.5, 1.0)
+    )
+    assert_almost_equal(
+        tuple(map(float, adapted_rand_error(im_true, im_test, alpha=0))),
+        (0, 0.5, 1.0)
+    )
+    assert_almost_equal(
+        tuple(map(float, adapted_rand_error(im_true, im_test, alpha=1))),
+        (0.5, 0.5, 1.0)
+    )
+
+    with pytest.raises(ValueError):
+        adapted_rand_error(im_true, im_test, alpha=1.01)
+    with pytest.raises(ValueError):
+        adapted_rand_error(im_true, im_test, alpha=-0.01)


### PR DESCRIPTION
This PR adds a few missing metrics that operate on segmentation label images. These are straightforward numpy/scipy -> cupy ports of the scikit-image code.
