### PR TITLE
Fix rotate behavior for ndim > 2

### DIFF
--- a/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
@@ -259,6 +259,19 @@ def test_rotate_resize_90():
     assert x90.shape == (230, 470)
 
 
+@pytest.mark.parametrize('dtype', [cp.float16, cp.float32, cp.float64])
+@pytest.mark.parametrize('resize', [False, True])
+@pytest.mark.parametrize('ndim', [2, 3, 4])
+def test_rotate_nd(dtype, resize, ndim):
+    # verify fix for issue: https://github.com/rapidsai/cucim/issues/431
+    x = cp.zeros((5, 5) + (4,) * (ndim - 2), dtype=dtype)
+    x[1, 1] = 1
+    x_out = rotate(x, 15, resize=resize)
+    assert x_out.ndim == x.ndim
+    assert x_out.shape[2:] == x.shape[2:]
+    assert x_out.dtype == _supported_float_type(dtype)
+
+
 def test_rescale():
     # same scale factor
     x = cp.zeros((5, 5), dtype=cp.double)


### PR DESCRIPTION
closes #431

Fixes the `resize=True` code path to take additional dimensions into account. `rotate` will now rotate the first two axes, preserving any additional ones. 

New test cases were added to confirm that no dimensions are lost.