### PR TITLE
Faster `hessian_matrix_*` and `structure_tensor_eigvals` via analytical eigenvalues for the 3D case

### DIFF
--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -407,7 +407,7 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
             # using ElementwiseKernels rather than reusing the eigenvalue ones.
             H = hessian_matrix(image, sigma)
             evs = hessian_matrix_eigvals(H)
-            return cp.prod(evs)
+            return cp.prod(evs, axis=0)
         hessian_mat_array = _symmetric_image(hessian_matrix(image, sigma))
         return cp.linalg.det(hessian_mat_array)
 

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -399,6 +399,15 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
         # integral = integral_image(image)
         # return cp.asarray(_hessian_matrix_det(integral, sigma))
     else:  # slower brute-force implementation for nD images
+        if image.ndim in [2, 3]:
+            # Compute determinant as the product of the eigenvalues.
+            # This avoids the huge memory overhead of forming
+            # `_symmetric_image` as in the code below.
+            # Could optimize further by computing the determinant directly
+            # using ElementwiseKernels rather than reusing the eigenvalue ones.
+            H = hessian_matrix(image, sigma)
+            evs = hessian_matrix_eigvals(H)
+            return cp.prod(evs)
         hessian_mat_array = _symmetric_image(hessian_matrix(image, sigma))
         return cp.linalg.det(hessian_mat_array)
 

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -485,7 +485,9 @@ def _image_orthogonal_matrix22_eigvals(
     """  # noqa
     if M00.dtype.kind != "f":
         raise ValueError("expected real-valued floating point matrices")
-    kernel = _get_real_symmetric_2x2_eigvals_kernel(sort=sort, abs_sort=abs_sort)
+    kernel = _get_real_symmetric_2x2_eigvals_kernel(
+        sort=sort, abs_sort=abs_sort
+    )
     eigs = cp.empty((2,) + M00.shape, dtype=M00.dtype)
     kernel(M00, M01, M11, eigs[0], eigs[1])
     return eigs
@@ -606,7 +608,9 @@ def _image_orthogonal_matrix33_eigvals(
     """  # noqa
     if a.dtype.kind != "f":
         raise ValueError("expected real-valued floating point matrices")
-    kernel = _get_real_symmetric_3x3_eigvals_kernel(sort=sort, abs_sort=abs_sort)
+    kernel = _get_real_symmetric_3x3_eigvals_kernel(
+        sort=sort, abs_sort=abs_sort
+    )
     eigs = cp.empty((3,) + a.shape, dtype=a.dtype)
     kernel(a, b, c, d, e, f, eigs[0], eigs[1], eigs[2])
     return eigs

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -506,13 +506,19 @@ def _image_orthogonal_matrix22_eigvals(
 def _get_real_symmetric_3x3_eigvals_kernel(sort='ascending', abs_sort=False):
 
     operation = """
-    F x1, x2, phi;
-    F d_sq = d * d;
-    F e_sq = e * e;
-    F f_sq = f * f;
-    F tmpa = (2*a - b - c);
-    F tmpb = (2*b - a - c);
-    F tmpc = (2*c - a - b);
+    double x1, x2, phi;
+    double a = static_cast<double>(aa);
+    double b = static_cast<double>(bb);
+    double c = static_cast<double>(cc);
+    double d = static_cast<double>(dd);
+    double e = static_cast<double>(ee);
+    double f = static_cast<double>(ff);
+    double d_sq = d * d;
+    double e_sq = e * e;
+    double f_sq = f * f;
+    double tmpa = (2*a - b - c);
+    double tmpb = (2*b - a - c);
+    double tmpc = (2*c - a - b);
     x2 = - tmpa * tmpb * tmpc;
     x2 += 9 * (tmpc*d_sq + tmpb*f_sq + tmpa*e_sq);
     x2 -= 54 * (d * e * f);
@@ -523,14 +529,14 @@ def _get_real_symmetric_3x3_eigvals_kernel(sort='ascending', abs_sort=False):
     } else {
         // grlee77: added max() here for numerical stability
         // (avoid NaN values in test_hessian_matrix_eigvals_3d)
-        F arg = max(4*x1*x1*x1 - x2*x2, static_cast<F>(0.0));
+        double arg = max(4*x1*x1*x1 - x2*x2, 0.0);
         phi = atan(sqrt(arg)/x2);
         if (x2 < 0) {
             phi += M_PI;
         }
     }
-    F x1_term = (2.0 / 3.0) * sqrt(x1);
-    F abc = (a + b + c) / 3.0;
+    double x1_term = (2.0 / 3.0) * sqrt(x1);
+    double abc = (a + b + c) / 3.0;
     lam1 = abc - x1_term * cos(phi / 3.0);
     lam2 = abc + x1_term * cos((phi - M_PI) / 3.0);
     lam3 = abc + x1_term * cos((phi + M_PI) / 3.0);
@@ -570,7 +576,7 @@ def _get_real_symmetric_3x3_eigvals_kernel(sort='ascending', abs_sort=False):
         prefix=prefix, var1=var1, var2="lam2", var3=var3
     )
     return cp.ElementwiseKernel(
-        in_params="F a, F b, F c, F d, F e, F f",
+        in_params="F aa, F bb, F cc, F dd, F ee, F ff",
         out_params="F lam1, F lam2, F lam3",
         operation=operation,
         name="cucim_skimage_symmetric_eig33_kernel")

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -417,16 +417,19 @@ def _get_real_symmetric_2x2_eigvals_kernel(sort='ascending', abs_sort=False):
 
     operation = """
     F tmp1, tmp2;
-    tmp1 = M01 * M01;
+    double m00 = static_cast<double>(M00);
+    double m01 = static_cast<double>(M01);
+    double m11 = static_cast<double>(M11);
+    tmp1 = m01 * m01;
     tmp1 *= 4;
 
-    tmp2 = M00 - M11;
+    tmp2 = m00 - m11;
     tmp2 *= tmp2;
     tmp2 += tmp1;
     tmp2 = sqrt(tmp2);
     tmp2 /= 2;
 
-    tmp1 = M00 + M11;
+    tmp1 = m00 + m11;
     tmp1 /= 2;
     """
     if sort == 'ascending':

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -252,15 +252,6 @@ def test_hessian_matrix_eigvals_3d(im3d, dtype):
     assert np.min(response2) < 0
     assert np.max(response0) > 0
 
-
-def test_hessian_matrix_det():
-    image = cp.zeros((5, 5))
-    image[2, 2] = 1
-    # TODO: approximate=True case not implemented
-    det = hessian_matrix_det(image, 5, approximate=False)
-    assert_array_almost_equal(det, 0, decimal=3)
-
-
 def _reference_eigvals_computation(S_elems):
     """Legacy eigenvalue implementation based on cp.linalg.eigvalsh."""
     matrices = _symmetric_image(S_elems)
@@ -284,6 +275,14 @@ def test_custom_eigvals_kernels_vs_linalg_eigvalsh(shape, dtype):
     evs2 = hessian_matrix_eigvals(H)
     atol = 1e-10
     cp.testing.assert_allclose(evs1, evs2, atol=atol)
+
+
+def test_hessian_matrix_det():
+    image = cp.zeros((5, 5))
+    image[2, 2] = 1
+    # TODO: approximate=True case not implemented
+    det = hessian_matrix_det(image, 5, approximate=False)
+    assert_array_almost_equal(det, 0, decimal=3)
 
 
 @pytest.mark.parametrize('dtype', [cp.float16, cp.float32, cp.float64])

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -252,6 +252,7 @@ def test_hessian_matrix_eigvals_3d(im3d, dtype):
     assert np.min(response2) < 0
     assert np.max(response0) > 0
 
+
 def _reference_eigvals_computation(S_elems):
     """Legacy eigenvalue implementation based on cp.linalg.eigvalsh."""
     matrices = _symmetric_image(S_elems)

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -481,8 +481,8 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
         H = hessian_matrix(image, sigma, mode=mode, cval=cval,
                            use_gaussian_derivatives=True)
 
-        # using _symmetric_compute_eigenvalues rather than hessian_matrix_eigvals
-        # so we can directly sort by ascending magnitude
+        # Use _symmetric_compute_eigenvalues rather than
+        # hessian_matrix_eigvals so we can directly sort by ascending magnitude
         eigvals = _symmetric_compute_eigenvalues(
             H, sort='ascending', abs_sort=True
         )

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -15,7 +15,8 @@ import cupy as cp
 import numpy as np
 
 from .._shared.utils import _supported_float_type, check_nD, deprecated
-from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
+from ..feature.corner import (_symmetric_compute_eigenvalues, hessian_matrix,
+                              hessian_matrix_eigvals)
 from ..util import img_as_float
 
 
@@ -479,12 +480,12 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     for i, sigma in enumerate(sigmas):  # Filter for all sigmas.
         H = hessian_matrix(image, sigma, mode=mode, cval=cval,
                            use_gaussian_derivatives=True)
-        eigvals = hessian_matrix_eigvals(H)
 
-        # Sort eigenvalues by ascending magnitude
-        # (hessian_matrix_eigvals are sorted in descending order, but not by
-        #  magnitude)
-        eigvals = cp.take_along_axis(eigvals, cp.abs(eigvals).argsort(0), 0)
+        # using _symmetric_compute_eigenvalues rather than hessian_matrix_eigvals
+        # so we can directly sort by ascending magnitude
+        eigvals = _symmetric_compute_eigenvalues(
+            H, sort='ascending', abs_sort=True
+        )
 
         # compute squared sum of the eigenvalues
         if ndim == 2:

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -178,8 +178,9 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     # from different (sigma) scales
     filtered_max = cp.zeros_like(image)
     for sigma in sigmas:  # Filter for all sigmas.
-        eigvals = hessian_matrix_eigvals(hessian_matrix(
-            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        H = hessian_matrix(image, sigma, mode=mode, cval=cval,
+                           use_gaussian_derivatives=True)
+        eigvals = hessian_matrix_eigvals(H)
 
         # cucim's hessian_matrix differs numerically from the one in skimage.
         # Sometimes where skimage returns 0, it returns very small values
@@ -261,8 +262,9 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     # from different (sigma) scales
     filtered_max = cp.zeros_like(image)
     for sigma in sigmas:  # Filter for all sigmas.
-        eigvals = hessian_matrix_eigvals(hessian_matrix(
-            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        H = hessian_matrix(image, sigma, mode=mode, cval=cval,
+                           use_gaussian_derivatives=True)
+        eigvals = hessian_matrix_eigvals(H)
 
         # cucim's hessian_matrix differs numerically from the one in skimage.
         # Sometimes where skimage returns 0, it returns very small values
@@ -475,8 +477,9 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     vals = cp.empty(image.shape, dtype=image.dtype)
     ev_sq_sum = cp.empty_like(vals)
     for i, sigma in enumerate(sigmas):  # Filter for all sigmas.
-        eigvals = hessian_matrix_eigvals(hessian_matrix(
-            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        H = hessian_matrix(image, sigma, mode=mode, cval=cval,
+                           use_gaussian_derivatives=True)
+        eigvals = hessian_matrix_eigvals(H)
 
         # Sort eigenvalues by ascending magnitude
         # (hessian_matrix_eigvals are sorted in descending order, but not by

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -633,7 +633,7 @@ def inertia_tensor(image, mu=None, *, spacing=None):
             mu_index[list(dims)] = 1
             result[dims] = -mu[tuple(mu_index)] / mu0
             result.T[dims] = -mu[tuple(mu_index)] / mu0
-        result = xp.asarray(result)
+        result = cp.asarray(result)
     return result
 
 

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -4,6 +4,8 @@ import cupy as cp
 import numpy as np
 
 from .._shared.utils import _supported_float_type, check_nD
+from ..feature.corner import (_image_orthogonal_matrix22_eigvals,
+                              _image_orthogonal_matrix33_eigvals)
 
 
 def moments_coords(coords, order=3):
@@ -531,9 +533,9 @@ def inertia_tensor(image, mu=None, *, xp=cp):
         # ([2, 0, 0], [0, 2, 0], [0, 0, 2]) (3D), etc.
         corners2 = tuple(2 * np.eye(image.ndim, dtype=int))
         # See https://ocw.mit.edu/courses/aeronautics-and-astronautics/
-        #             16-07-dynamics-fall-2009/lecture-notes/MIT16_07F09_Lec26.pdf
-        # Iii is the sum of second-order moments of every axis *except* i, not the
-        # second order moment of axis i.
+        #          16-07-dynamics-fall-2009/lecture-notes/MIT16_07F09_Lec26.pdf
+        # Iii is the sum of second-order moments of every axis *except* i, not
+        # the second order moment of axis i.
         # See also https://github.com/scikit-image/scikit-image/issues/3229
         result = np.diag((np.sum(mu[corners2]) - mu[corners2]) / mu0)
 
@@ -589,13 +591,15 @@ def inertia_tensor_eigvals(image, mu=None, T=None, *, xp=cp):
     if image.ndim == 2:
         eigvals = _image_orthogonal_matrix22_eigvals(
             T[0, 0], T[0, 1], T[1, 1], sort='descending', abs_sort=False
-        );
+        )
         cp.maximum(eigvals, 0.0, out=eigvals)
     elif image.ndim == 3:
+        # fmt: off
         eigvals = _image_orthogonal_matrix33_eigvals(
             T[0, 0], T[0, 1], T[0, 2], T[1, 1], T[1, 2], T[2, 2],
             sort='descending', abs_sort=False
-        );
+        )
+        # fmt: on
         cp.maximum(eigvals, 0.0, out=eigvals)
     else:
         # sort in descending order


### PR DESCRIPTION
closes #354

This MR implements faster 2D and 3D pixelwise eigenvalue computations for `hessian_matrix_eigvals`, `structure_tensor_eigvals` and `hessian_matrix_det`. The 2D case already had a fairly fast code path, but it is further improved here by switching from a fused kernel to an elementwise kernel that removed the need for a separate call to `cupy.stack`. In 3D runtime is reduced by ~30x for float32 and >100x for float64. The 3D case also uses MUCH less RAM than previously (>20x reduction). For example computing the eigenvalues for size (128, 128, 128) float32 arrays would run out of memory even on an A6000 (40GB). With the changes here, it works even for 16x larger data of shape (512, 512, 512).

Functions that benefit from this are:
	
- `cucim.skimage.feature.hessian_matrix_det`
- `cucim.skimage.feature.hessian_matrix_eigvals`	
- `cucim.skimage.feature.structure_tensor_eigenvalues`
- `cucim.skimage.feature.shape_index`
- `cucim.skimage.feature.multiscale_basic_features`
- `cucim.skimage.filters.meijering`
- `cucim.skimage.filters.sato`
- `cucim.skimage.filters.frangi`
- `cucim.skimage.filters.hessian`

Independently of the above, the function `cucim.skimage.measure.inertia_tensor_eigvals` was updated with custom kernels so it can operate purely on the GPU for the 2D and 3D cases (formly these used copies to/from the host). These operate on tiny arrays, so they use only a single GPU thread. Despite the lack of paralellism, this is lower overhead than round trip host/device transfer. This will also improve region properties making use of these eigenvalues (e.g. the `axis_major_length` and `axis_minor_length` properties for `regionprops_table`) 