### PR TITLE
pin to cmake <3.25 on CI to avoid bug with CUDA+conda during build

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18.0
+    - cmake >=3.23.1,<3.25
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.23.1,<3.25
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18.0
+    - cmake >=3.23.1,<3.25
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.23.1,<3.25
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}


### PR DESCRIPTION
CMake 3.25 was released today and seems to have broken the CI builds. Trying to pin the version here to see if it resolves the issue.

attn: @jakirkham 