### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18.0
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18.0
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.