### PR TITLE
add whole-slide tiled read/write demos for measuring GPUDirect Storage (GDS) I/O performance

### DIFF
--- a/examples/python/gds_whole_slide/README.md
+++ b/examples/python/gds_whole_slide/README.md
@@ -1,0 +1,107 @@
+Example scripts used for benchmarking reads of uncompressed TIFF images using
+existing CPU-based tools (openslide-python, tifffile) as well as reads
+accelerated using `kvikio` with GPUDirect Storage enabled or disabled.
+
+### GPUDirect setup/install
+
+GPUDirect Storage (GDS) is only supported on certain linux systems
+
+(e.g. at the time of writing:
+ Ubuntu 18.04, Ubuntu 20.04, RHEL 8.3, RHEL 8.4, DGX workstations)
+
+Also, not all CUDA-capable hardware supports GDS. For example, gaming-focused
+GPUs are currently not GDS-enabled. GDS is supported on T4, V100, A100 and
+RTX A6000 GPUs, for example:
+https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html#api-error-2
+
+GPUDirect must be installed as described in
+https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html
+
+As part of this, the Mellanox OFED drivers (MLNX_OFED) must be installed:
+https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html#mofed-req-install
+https://network.nvidia.com/support/mlnx-ofed-matrix/
+
+
+### Obtaining test data
+
+Due to the large data size needed for benchmarking, no data is included in this
+repository. Many suitable images are publicly available. Assume we download a single image named `TUPAC-TR-467.svs` which is available in the training data from this challenge:
+
+https://tupac.grand-challenge.org/Dataset/
+
+which corresponds to the following publication:
+
+Veta, Mitko, et al. "Predicting breast tumor proliferation from whole-slide images: the TUPAC16 challenge." Medical image analysis 54 (2019): 111-121.
+
+Because the demo only supports uncompressed data, it is necessary to first convert the data a raw (uncompressed) TIFF image. This can be done using cuCIM >= 2022.12.00 via the following command line call:
+```sh
+cucim convert --tile-size 512 --overlap 0 --num-workers 12  --output-filename resize.tiff --compression RAW TUPAC-TR-467.svs
+```
+
+The scripts have the filename `resize.tiff` hardcoded, so you will have to modify the file name in near the top of the scripts if a different image is to be used.
+
+
+### Summary of demo files
+
+- **benchmark_read.py** : Benchmark reads of a full image at the specified
+resolution level from an uncompressed multi-resolution TIFF image.
+
+- **benchmark_round_trip.py** : Read from uncompressed TIFF while writing to an
+uncompressed Zarr file with a tile size matching the TIFF image.
+
+- **benchmark_zarr_write.py** : Benchmark writing of a CuPy array to an
+uncompressed Zarr file of the specified chunk size. 
+
+- **benchmark_zarr_write_lz4_via_dask.py** : Use Dask and
+`kvikio.zarr.GDSStore` to write LZ4 lossless compressed Zarr array with the
+specified storage level.
+
+- **lz4_nvcomp.py** : this is a LZ4 compressor for use with
+`kvikio.zarr.GDSStore`
+
+- **demo_implementation.py** : Implementations of tiled read/write that are
+used by the benchmarking scripts described above.
+
+
+### some commands from GDSDirect guide for checking system status
+
+Below are some useful diagnostic commands extracted from the
+[GPUDirect Storage docs](https://docs.nvidia.com/gpudirect-storage/index.html).
+
+To check MLNX_OFED version
+```sh
+ofed_info -s
+```
+
+To check GDS status run:
+```sh
+/usr/local/cuda/gds/tools/gdscheck -p
+```
+want to see at least NVMe supported in the driver configuration, e.g.
+```
+ =====================
+ DRIVER CONFIGURATION:
+ =====================
+ NVMe               : Supported
+```
+and under the GPU INFO, the device should be listed as "supports GDS", e.g.
+```
+ =========
+ GPU INFO:
+ =========
+ GPU index 0 NVIDIA RTX A6000 bar:1 bar size (MiB):256 supports GDS, IOMMU State: Disable
+ ```
+
+Check nvidia-fs
+```sh
+cat /proc/driver/nvidia-fs/stats
+```
+e.g.
+```
+GDS Version: 1.4.0.29 
+NVFS statistics(ver: 4.0)
+NVFS Driver(version: 2.13.5)
+Mellanox PeerDirect Supported: False
+IO stats: Disabled, peer IO stats: Disabled
+Logging level: info
+```

--- a/examples/python/gds_whole_slide/README.md
+++ b/examples/python/gds_whole_slide/README.md
@@ -63,7 +63,7 @@ specified storage level.
 used by the benchmarking scripts described above.
 
 
-### some commands from GDSDirect guide for checking system status
+### Some commands from GDSDirect guide for checking system status
 
 Below are some useful diagnostic commands extracted from the
 [GPUDirect Storage docs](https://docs.nvidia.com/gpudirect-storage/index.html).

--- a/examples/python/gds_whole_slide/benchmark_read.py
+++ b/examples/python/gds_whole_slide/benchmark_read.py
@@ -1,0 +1,240 @@
+import math
+import os
+
+import kvikio
+import kvikio.defaults
+import numpy as np
+from cupyx.profiler import benchmark
+from tifffile import TiffFile
+
+from demo_implementation import read_openslide, read_tifffile, read_tiled, get_n_tiles, get_tile_buffers
+
+data_dir = os.environ.get('WHOLE_SLIDE_DATA_DIR', os.path.dirname('__file__'))
+fname = os.path.join(data_dir, 'resize.tiff')
+if not os.path.exists(fname):
+    raise RuntimeError(f"Could not find data file: {fname}")
+
+level = 0
+max_duration = 8
+
+with TiffFile(fname) as tif:
+    page = tif.pages[level]
+    page_shape = page.shape
+    tile_shape = (page.tilelength, page.tilewidth, page.samplesperpixel)
+    total_tiles = math.prod(get_n_tiles(page))
+print(f"Resolution level {level}\n")
+print(f"\tshape: {page_shape}")
+print(f"\tstored as {total_tiles} tiles of shape {tile_shape}")
+
+# make sure we are not in compatibility mode to ensure cuFile is being used
+# (when compat_mode() is True, POSIX will be used instead of libcufile.so)
+kvikio.defaults.compat_mode_reset(False)
+assert not kvikio.defaults.compat_mode()
+
+# set the number of threads to use
+kvikio.defaults.num_threads_reset(16)
+
+
+print(f"\t{kvikio.defaults.compat_mode() = }")
+print(f"\t{kvikio.defaults.get_num_threads() = }")
+
+preregister_buffers = False
+if preregister_buffers:
+    tile_buffers = get_tile_buffers(fname, level, n_buffer=256)
+    for b in tile_buffers:
+        kvikio.memory_register(b)
+else:
+    tile_buffers = None
+
+# print(f"\tkvikio task size = {kvikio.defaults.task_size()/1024**2} MB")
+
+times = []
+labels = []
+perf_openslide = benchmark(
+    read_openslide,
+    (fname, level),
+    n_warmup=0,
+    n_repeat=100,
+    max_duration=max_duration
+)
+times.append(perf_openslide.gpu_times.mean())
+labels.append('openslide')
+print(f"duration ({labels[-1]}) = {times[-1]}")
+
+perf_tifffile = benchmark(
+    read_tifffile,
+    (fname, level),
+    n_warmup=0,
+    n_repeat=100,
+    max_duration=max_duration
+)
+times.append(perf_tifffile.gpu_times.mean())
+labels.append('tifffile')
+print(f"duration ({labels[-1]}) = {times[-1]}")
+
+for gds_enabled in [False, True]:
+    kvikio.defaults.compat_mode_reset(not gds_enabled)
+    assert kvikio.defaults.compat_mode() == (not gds_enabled)
+
+    p = benchmark(
+        read_tiled,
+        (fname, [level]),
+        kwargs=dict(backend='kvikio-raw_read', tile_buffers=tile_buffers),
+        n_warmup=1,
+        n_repeat=100,
+        max_duration=max_duration,
+    )
+    if gds_enabled:
+        perf_kvikio_raw = p
+    else:
+        perf_kvikio_raw_nogds = p
+    times.append(p.gpu_times.mean())
+    labels.append(f"kvikio-read_raw ({gds_enabled=})")
+    print(f"duration ({labels[-1]}) = {times[-1]}")
+
+    for mm in [8, 16, 32, 64]:
+        kvikio.defaults.task_size_reset(4096 * mm)
+
+        p = benchmark(
+            read_tiled,
+            (fname, [level]),
+            kwargs=dict(backend='kvikio-read', tile_buffers=tile_buffers),
+            n_warmup=1,
+            n_repeat=100,
+            max_duration=max_duration,
+        )
+        if gds_enabled:
+            perf_kvikio_read = p
+        else:
+            perf_kvikio_read_nogds = p
+        times.append(p.gpu_times.mean())
+        labels.append(
+            f"kvikio-read (task size={kvikio.defaults.task_size() // 1024} kB)"
+            f" ({gds_enabled=})"
+        )
+        print(f"duration ({labels[-1]}) = {times[-1]}")
+
+    # Go back to 4MB task size in pread case
+    kvikio.defaults.task_size_reset(512 * 1024)
+    if gds_enabled:
+        perf_kvikio_pread = []
+    else:
+        perf_kvikio_pread_nogds = []
+    n_buffers = [1, 4, 16, 64, 256]
+    for n_buffer in n_buffers:
+        p = benchmark(
+            read_tiled,
+            (fname, [level]),
+            kwargs=dict(backend='kvikio-pread',
+                        n_buffer=n_buffer,
+                        tile_buffers=tile_buffers),
+            n_warmup=1,
+            n_repeat=100,
+            max_duration=max_duration
+        )
+        if gds_enabled:
+            perf_kvikio_pread.append(p)
+        else:
+            perf_kvikio_pread_nogds.append(p)
+        times.append(p.gpu_times.mean())
+        labels.append(f"kvikio-pread ({n_buffer=}) ({gds_enabled=})")
+        print(f"duration ({labels[-1]}) = {times[-1]}")
+
+if preregister_buffers:
+    for b in tile_buffers:
+        kvikio.memory_deregister(b)
+
+kvikio.defaults.compat_mode_reset(False)
+
+out_name = 'read_times.npz'
+# auto-increment filename to avoid overwriting old results
+cnt = 1
+while os.path.exists(out_name):
+    out_name = f'read_times{cnt}.npz'
+    cnt += 1
+np.savez(out_name, times=np.asarray(times), labels=np.asarray(labels))
+
+
+"""
+Resolution level 0 with Cache clearing, but reads are not 4096-byte aligned
+
+    shape: (26420, 19920, 3)
+    stored as 2028 tiles of shape (512, 512, 3)
+    kvikio.defaults.compat_mode() = False
+    kvikio.defaults.get_num_threads() = 18
+    kvikio task size = 4.0 MB
+duration (openslide) = 28.921716796875
+duration (tifffile) = 3.818202718098958
+duration (tiled-tifffile) = 3.885939778645833
+duration (kvikio-read_raw (gds_enabled=False)) = 3.4184929199218748
+duration (kvikio-read (gds_enabled=False)) = 3.813303955078125
+duration (kvikio-pread (n_buffer=1) (gds_enabled=False)) = 3.9369333496093746
+duration (kvikio-pread (n_buffer=2) (gds_enabled=False)) = 4.028409342447917
+duration (kvikio-pread (n_buffer=4) (gds_enabled=False)) = 2.785054626464844
+duration (kvikio-pread (n_buffer=8) (gds_enabled=False)) = 1.7379150390625
+duration (kvikio-pread (n_buffer=16) (gds_enabled=False)) = 1.2908187103271485
+duration (kvikio-pread (n_buffer=32) (gds_enabled=False)) = 1.0635023193359374
+duration (kvikio-pread (n_buffer=64) (gds_enabled=False)) = 0.9369119762073862
+duration (kvikio-pread (n_buffer=128) (gds_enabled=False)) = 0.8773154449462891
+duration (kvikio-read_raw (gds_enabled=True)) = 3.4003018391927085
+duration (kvikio-read (gds_enabled=True)) = 3.763134847005208
+duration (kvikio-pread (n_buffer=1) (gds_enabled=True)) = 3.7581602376302086
+duration (kvikio-pread (n_buffer=2) (gds_enabled=True)) = 4.107709065755208
+duration (kvikio-pread (n_buffer=4) (gds_enabled=True)) = 2.609207336425781
+duration (kvikio-pread (n_buffer=8) (gds_enabled=True)) = 1.744682902018229
+duration (kvikio-pread (n_buffer=16) (gds_enabled=True)) = 1.2838030700683594
+duration (kvikio-pread (n_buffer=32) (gds_enabled=True)) = 1.05522587890625
+duration (kvikio-pread (n_buffer=64) (gds_enabled=True)) = 0.9214399691495029
+duration (kvikio-pread (n_buffer=128) (gds_enabled=True)) = 0.8695069885253907
+
+
+Resolution level 0 with 4096-byte aligned reads
+
+    shape: (26420, 19920, 3)
+    stored as 2028 tiles of shape (512, 512, 3)
+    kvikio.defaults.compat_mode() = False
+    kvikio.defaults.get_num_threads() = 18
+    kvikio task size = 4.0 MB
+duration (kvikio-read_raw (gds_enabled=False)) = 3.4100815429687494
+duration (kvikio-read (gds_enabled=False)) = 3.8238279622395837
+duration (kvikio-pread (n_buffer=1) (gds_enabled=False)) = 3.740669270833333
+duration (kvikio-pread (n_buffer=4) (gds_enabled=False)) = 2.672812255859375
+duration (kvikio-pread (n_buffer=16) (gds_enabled=False)) = 1.3131573791503905
+duration (kvikio-pread (n_buffer=64) (gds_enabled=False)) = 0.9273524225408379
+duration (kvikio-pread (n_buffer=256) (gds_enabled=False)) = 0.8461123250325521
+duration (kvikio-read_raw (gds_enabled=True)) = 4.179492513020834
+duration (kvikio-read (gds_enabled=True)) = 4.889711263020834
+duration (kvikio-pread (n_buffer=1) (gds_enabled=True)) = 4.816523600260417
+duration (kvikio-pread (n_buffer=4) (gds_enabled=True)) = 2.2351694824218753
+duration (kvikio-pread (n_buffer=16) (gds_enabled=True)) = 1.1082978149414064
+duration (kvikio-pread (n_buffer=64) (gds_enabled=True)) = 0.670870166015625
+duration (kvikio-pread (n_buffer=256) (gds_enabled=True)) = 0.5998859683766086
+
+
+    pread with default 4MB "task size"
+        Resolution level 0
+            shape: (26420, 19920, 3)
+            stored as 2028 tiles of shape (512, 512, 3)
+            kvikio.defaults.compat_mode() = False
+            kvikio.defaults.get_num_threads() = 18
+            kvikio task size = 4 MB
+        duration (kvikio-pread (n_buffer=1) (gds_enabled=True)) = 4.8583107096354174
+        duration (kvikio-pread (n_buffer=4) (gds_enabled=True)) = 2.1224323242187504
+        duration (kvikio-pread (n_buffer=16) (gds_enabled=True)) = 1.1164629991319446
+        duration (kvikio-pread (n_buffer=64) (gds_enabled=True)) = 0.6734547526041668
+        duration (kvikio-pread (n_buffer=256) (gds_enabled=True)) = 0.601566697064568
+        (cucim) grelee@grelee-dt:~/Dropbox/NVIDIA/demos/gds/gds-cucim-demo$ python benchmark_read.py
+        Resolution level 0
+
+    pread with 64kB "task size"
+            shape: (26420, 19920, 3)
+            stored as 2028 tiles of shape (512, 512, 3)
+            kvikio.defaults.compat_mode() = False
+            kvikio.defaults.get_num_threads() = 18
+            kvikio task size = 0.064 MB
+        duration (kvikio-pread (n_buffer=1) (gds_enabled=True)) = 3.0912179565429687
+        duration (kvikio-pread (n_buffer=4) (gds_enabled=True)) = 1.3932305145263673
+        duration (kvikio-pread (n_buffer=16) (gds_enabled=True)) = 0.9027577819824221
+        duration (kvikio-pread (n_buffer=64) (gds_enabled=True)) = 0.7827104492187501
+        duration (kvikio-pread (n_buffer=256) (gds_enabled=True)) = 0.756464599609375
+"""

--- a/examples/python/gds_whole_slide/benchmark_round_trip.py
+++ b/examples/python/gds_whole_slide/benchmark_round_trip.py
@@ -1,0 +1,241 @@
+import os
+from time import time
+
+import cucim.skimage.filters
+import cupy as cp
+import numpy as np
+import kvikio
+import kvikio.defaults
+from cucim.core.operations.color import image_to_absorbance
+from cupyx.profiler import benchmark
+
+from demo_implementation import cupy_to_zarr, read_tiled
+
+
+data_dir = os.environ.get('WHOLE_SLIDE_DATA_DIR', os.path.dirname('__file__'))
+fname = os.path.join(data_dir, 'resize.tiff')
+if not os.path.exists(fname):
+    raise RuntimeError(f"Could not find data file: {fname}")
+
+level = 0
+max_duration = 8
+compressor = None
+
+# set the number of threads to use
+kvikio.defaults.num_threads_reset(16)
+
+# Go back to 4MB task size in pread case
+kvikio.defaults.task_size_reset(4 * 1024 * 1024)
+
+
+def round_trip(
+    fname,
+    level=0,
+    n_buffer=64,
+    kernel_func=None,
+    kernel_func_kwargs={},
+    apply_kernel_tilewise=True,
+    out_dtype=cp.uint8,
+    zarr_chunk_shape=(2048, 2048, 3),
+    output_path=None,
+    zarr_kwargs=dict(overwrite=True, compressor=None),
+    verbose_times=False,
+):
+
+    if output_path is None:
+        output_path = f'./image-{cp.dtype(out_dtype).name}.zarr'
+
+    if apply_kernel_tilewise:
+        tile_func = kernel_func
+        tile_func_kwargs = kernel_func_kwargs
+    else:
+        tile_func = None
+        tile_func_kwargs = {}
+
+    if verbose_times:
+        tstart = time()
+    data_gpu = read_tiled(
+        fname,
+        levels=[level],
+        backend='kvikio-pread',
+        n_buffer=n_buffer,
+        tile_func=tile_func,
+        tile_func_kwargs=tile_func_kwargs,
+        out_dtype=out_dtype
+    )[0]
+    if verbose_times:
+        dur_read = time() - tstart
+        if not apply_kernel_tilewise:
+            dur_read = time() - tstart
+            print(f"{dur_read=}")
+        else:
+            dur_read_and_comp = time() - tstart
+            print(f"{dur_read_and_comp=}")
+
+    if not apply_kernel_tilewise:
+        if verbose_times:
+            tstart = time()
+        data_gpu = kernel_func(data_gpu, **kernel_func_kwargs)
+        if verbose_times:
+            dur_comp = time() - tstart
+            print(f"{dur_comp=}")
+
+    if verbose_times:
+        tstart = time()
+    cupy_to_zarr(
+        data_gpu,
+        backend='dask',  # 'kvikio-pwrite',
+        output_path=output_path,
+        chunk_shape=zarr_chunk_shape,
+        zarr_kwargs=zarr_kwargs,
+    )
+    if verbose_times:
+        dur_write = time() - tstart
+        print(f"{dur_write=}")
+
+    return output_path
+
+
+gds_enabled = True
+apply_kernel_tilewise = True
+times = []
+labels = []
+n_buffer = 32
+for zarr_chunk_shape in [(512, 512, 3), (1024, 1024, 3), (2048, 2048, 3), (4096, 4096, 3)]:
+    for computation in ['absorbance', 'median', 'gaussian', 'sobel']:
+
+        if computation is None:
+            kernel_func = None
+            kernel_func_kwargs = {}
+            out_dtype = cp.uint8
+        elif computation == 'absorbance':
+            kernel_func = image_to_absorbance
+            kernel_func_kwargs = {}
+            out_dtype = cp.float32
+        elif computation == 'median':
+            kernel_func = cucim.skimage.filters.median
+            kernel_func_kwargs = dict(footprint=cp.ones((5, 5, 1), dtype=bool))
+            out_dtype = cp.uint8
+        elif computation == 'gaussian':
+            kernel_func = cucim.skimage.filters.gaussian
+            kernel_func_kwargs = dict(sigma=2.5, channel_axis=-1)
+            out_dtype = cp.uint8
+        elif computation == 'sobel':
+            kernel_func = cucim.skimage.filters.sobel
+            kernel_func_kwargs = dict(axis=(0, 1))
+            out_dtype = cp.float32
+
+        for apply_kernel_tilewise in [False, True]:
+            for gds_enabled in [False, True]:
+                kvikio.defaults.compat_mode_reset(not gds_enabled)
+                assert kvikio.defaults.compat_mode() == (not gds_enabled)
+
+                kwargs = dict(
+                    level=0,
+                    n_buffer=n_buffer,
+                    kernel_func=kernel_func,
+                    kernel_func_kwargs=kernel_func_kwargs,
+                    out_dtype=out_dtype,
+                    apply_kernel_tilewise=apply_kernel_tilewise,
+                    zarr_chunk_shape=zarr_chunk_shape,
+                    zarr_kwargs=dict(overwrite=True, compressor=compressor),
+                    verbose_times=False,
+                )
+
+                perf = benchmark(
+                    round_trip,
+                    (fname,),
+                    kwargs=kwargs,
+                    n_warmup=1,
+                    n_repeat=100,
+                    max_duration=max_duration,
+                )
+                t = perf.gpu_times
+
+                kernel_description = 'tiled' if apply_kernel_tilewise else 'global'
+                gds_description = 'with GDS' if gds_enabled else 'without GDS'
+                label = f"{computation=}, {kernel_description}, chunk_shape={zarr_chunk_shape}, {gds_description}"
+                print(f"Duration ({label}): {t.mean()} s +/- {t.std()} s")
+
+                times.append(t.mean())
+                labels.append(label)
+
+out_name = 'round_trip_times.npz'
+# auto-increment filename to avoid overwriting old results
+cnt = 1
+while os.path.exists(out_name):
+    out_name = f'round_trip_times{cnt}.npz'
+    cnt += 1
+np.savez(out_name, times=np.asarray(times), labels=np.asarray(labels))
+
+
+"""
+on dgx-02
+
+(gds_demo) apollo@dgx-02:/mnt/nvme0/cucim/gds-cucim-demo$ python benchmark_round_trip.py
+    Duration (computation='absorbance', global, chunk_shape=(512, 512, 3), without GDS): 3.1191054687500004 s +/- 0.225595815853941 s
+    Duration (computation='absorbance', global, chunk_shape=(512, 512, 3), with GDS): 2.1042802734375003 s +/- 0.027930034537340144 s
+    Duration (computation='absorbance', tiled, chunk_shape=(512, 512, 3), without GDS): 3.141532592773437 s +/- 0.04939690170558264 s
+    Duration (computation='absorbance', tiled, chunk_shape=(512, 512, 3), with GDS): 2.231423193359375 s +/- 0.16606144818711904 s
+    Duration (computation='median', global, chunk_shape=(512, 512, 3), without GDS): 2.0818441894531245 s +/- 0.021839879963544123 s
+    Duration (computation='median', global, chunk_shape=(512, 512, 3), with GDS): 2.035376928710938 s +/- 0.029007739628238723 s
+    Duration (computation='median', tiled, chunk_shape=(512, 512, 3), without GDS): 2.567677185058594 s +/- 0.1512259361762735 s
+    Duration (computation='median', tiled, chunk_shape=(512, 512, 3), with GDS): 2.258326318359375 s +/- 0.03280750045711541 s
+    Duration (computation='gaussian', global, chunk_shape=(512, 512, 3), without GDS): 3.1225366821289064 s +/- 0.03711702097752233 s
+    Duration (computation='gaussian', global, chunk_shape=(512, 512, 3), with GDS): 2.2253964843750005 s +/- 0.2325274037827292 s
+    Duration (computation='gaussian', tiled, chunk_shape=(512, 512, 3), without GDS): 2.4777058593750003 s +/- 0.009240477773701704 s
+    Duration (computation='gaussian', tiled, chunk_shape=(512, 512, 3), with GDS): 2.3227379394531256 s +/- 0.009206045295060663 s
+    Duration (computation='sobel', global, chunk_shape=(512, 512, 3), without GDS): 3.2487342529296876 s +/- 0.27136693727180555 s
+    Duration (computation='sobel', global, chunk_shape=(512, 512, 3), with GDS): 2.10892294921875 s +/- 0.02097221308256493 s
+    Duration (computation='sobel', tiled, chunk_shape=(512, 512, 3), without GDS): 4.1089834798177085 s +/- 0.01915263510603932 s
+    Duration (computation='sobel', tiled, chunk_shape=(512, 512, 3), with GDS): 2.938178039550781 s +/- 0.014859342085037834 s
+    Duration (computation='absorbance', global, chunk_shape=(1024, 1024, 3), without GDS): 2.7858702392578127 s +/- 0.019651934337578617 s
+    Duration (computation='absorbance', global, chunk_shape=(1024, 1024, 3), with GDS): 1.9969252726236981 s +/- 0.027131826130877872 s
+    Duration (computation='absorbance', tiled, chunk_shape=(1024, 1024, 3), without GDS): 2.805119934082031 s +/- 0.04126104227305295 s
+    Duration (computation='absorbance', tiled, chunk_shape=(1024, 1024, 3), with GDS): 2.000840478515625 s +/- 0.018744582209408268 s
+    Duration (computation='median', global, chunk_shape=(1024, 1024, 3), without GDS): 1.1235912679036462 s +/- 0.017105640884020744 s
+    Duration (computation='median', global, chunk_shape=(1024, 1024, 3), with GDS): 0.797370131272536 s +/- 0.15744958452772662 s
+    Duration (computation='median', tiled, chunk_shape=(1024, 1024, 3), without GDS): 1.437654331752232 s +/- 0.021581864835220975 s
+    Duration (computation='median', tiled, chunk_shape=(1024, 1024, 3), with GDS): 0.9701279130415483 s +/- 0.02103963138394191 s
+    Duration (computation='gaussian', global, chunk_shape=(1024, 1024, 3), without GDS): 2.8036607666015625 s +/- 0.012992702272646189 s
+    Duration (computation='gaussian', global, chunk_shape=(1024, 1024, 3), with GDS): 2.0812043945312504 s +/- 0.11895250430711447 s
+    Duration (computation='gaussian', tiled, chunk_shape=(1024, 1024, 3), without GDS): 1.5445246407645088 s +/- 0.015315103050140895 s
+    Duration (computation='gaussian', tiled, chunk_shape=(1024, 1024, 3), with GDS): 1.0669870971679687 s +/- 0.02188820345886527 s
+    Duration (computation='sobel', global, chunk_shape=(1024, 1024, 3), without GDS): 2.9324288330078128 s +/- 0.22276139967810918 s
+    Duration (computation='sobel', global, chunk_shape=(1024, 1024, 3), with GDS): 2.0065390625000004 s +/- 0.013617705944694957 s
+    Duration (computation='sobel', tiled, chunk_shape=(1024, 1024, 3), without GDS): 3.6309766438802087 s +/- 0.05874521968221261 s
+    Duration (computation='sobel', tiled, chunk_shape=(1024, 1024, 3), with GDS): 2.984893737792969 s +/- 0.25415558271992245 s
+    Duration (computation='absorbance', global, chunk_shape=(2048, 2048, 3), without GDS): 2.9885695800781247 s +/- 0.026795940572500634 s
+    Duration (computation='absorbance', global, chunk_shape=(2048, 2048, 3), with GDS): 1.965831502278646 s +/- 0.0168025999020846 s
+    Duration (computation='absorbance', tiled, chunk_shape=(2048, 2048, 3), without GDS): 3.1813931884765627 s +/- 0.2428613856732194 s
+    Duration (computation='absorbance', tiled, chunk_shape=(2048, 2048, 3), with GDS): 1.9277428181966145 s +/- 0.04373333981541544 s
+    Duration (computation='median', global, chunk_shape=(2048, 2048, 3), without GDS): 1.0377198669433594 s +/- 0.012093431782665117 s
+    Duration (computation='median', global, chunk_shape=(2048, 2048, 3), with GDS): 0.707420703125 s +/- 0.01371743462230204 s
+    Duration (computation='median', tiled, chunk_shape=(2048, 2048, 3), without GDS): 1.4118775634765626 s +/- 0.18244415183128557 s
+    Duration (computation='median', tiled, chunk_shape=(2048, 2048, 3), with GDS): 0.9218176491477272 s +/- 0.01591385754055359 s
+    Duration (computation='gaussian', global, chunk_shape=(2048, 2048, 3), without GDS): 2.9058739013671877 s +/- 0.016099121671779952 s
+    Duration (computation='gaussian', global, chunk_shape=(2048, 2048, 3), with GDS): 2.0523116210937498 s +/- 0.18981050500282015 s
+    Duration (computation='gaussian', tiled, chunk_shape=(2048, 2048, 3), without GDS): 1.4494330357142857 s +/- 0.014561240480290236 s
+    Duration (computation='gaussian', tiled, chunk_shape=(2048, 2048, 3), with GDS): 1.0200827880859376 s +/- 0.019787969209851694 s
+    Duration (computation='sobel', global, chunk_shape=(2048, 2048, 3), without GDS): 3.119711364746094 s +/- 0.22031551398713953 s
+    Duration (computation='sobel', global, chunk_shape=(2048, 2048, 3), with GDS): 1.958296569824219 s +/- 0.02411710745257342 s
+    Duration (computation='sobel', tiled, chunk_shape=(2048, 2048, 3), without GDS): 3.8941464843749998 s +/- 0.049486723671958784 s
+    Duration (computation='sobel', tiled, chunk_shape=(2048, 2048, 3), with GDS): 2.9164300537109376 s +/- 0.1746352677421199 s
+    Duration (computation='absorbance', global, chunk_shape=(4096, 4096, 3), without GDS): 4.78259814453125 s +/- 0.08003375317781046 s
+    Duration (computation='absorbance', global, chunk_shape=(4096, 4096, 3), with GDS): 2.1372686035156248 s +/- 0.043582537001700936 s
+    Duration (computation='absorbance', tiled, chunk_shape=(4096, 4096, 3), without GDS): 4.702880371093751 s +/- 0.036472302464017906 s
+    Duration (computation='absorbance', tiled, chunk_shape=(4096, 4096, 3), with GDS): 2.1466302734375 s +/- 0.04854747600437549 s
+    Duration (computation='median', global, chunk_shape=(4096, 4096, 3), without GDS): 1.2019552951388888 s +/- 0.041718545478099486 s
+    Duration (computation='median', global, chunk_shape=(4096, 4096, 3), with GDS): 0.7432061026436942 s +/- 0.024861430042890365 s
+    Duration (computation='median', tiled, chunk_shape=(4096, 4096, 3), without GDS): 1.5174084472656253 s +/- 0.19087705973449015 s
+    Duration (computation='median', tiled, chunk_shape=(4096, 4096, 3), with GDS): 0.9612706076882103 s +/- 0.047138270409090556 s
+    Duration (computation='gaussian', global, chunk_shape=(4096, 4096, 3), without GDS): 4.438681803385417 s +/- 0.07821072441047229 s
+    Duration (computation='gaussian', global, chunk_shape=(4096, 4096, 3), with GDS): 2.292842724609375 s +/- 0.17273283392695543 s
+    Duration (computation='gaussian', tiled, chunk_shape=(4096, 4096, 3), without GDS): 1.5610232805524553 s +/- 0.04472800111712806 s
+    Duration (computation='gaussian', tiled, chunk_shape=(4096, 4096, 3), with GDS): 1.053441522216797 s +/- 0.047010837833830116 s
+    Duration (computation='sobel', global, chunk_shape=(4096, 4096, 3), without GDS): 4.608963867187501 s +/- 0.27347076419226174 s
+    Duration (computation='sobel', global, chunk_shape=(4096, 4096, 3), with GDS): 2.2000548339843746 s +/- 0.07589894027639234 s
+    Duration (computation='sobel', tiled, chunk_shape=(4096, 4096, 3), without GDS): 5.430656982421875 s +/- 0.01277270507812478 s
+    Duration (computation='sobel', tiled, chunk_shape=(4096, 4096, 3), with GDS): 3.1940713500976563 s +/- 0.19852391299904837 s
+
+"""

--- a/examples/python/gds_whole_slide/benchmark_zarr_write.py
+++ b/examples/python/gds_whole_slide/benchmark_zarr_write.py
@@ -1,0 +1,105 @@
+import math
+import os
+
+import cupy as cp
+import kvikio.defaults
+import numpy as np
+from cucim.core.operations.color import image_to_absorbance
+from cupyx.profiler import benchmark
+from tifffile import TiffFile
+
+from demo_implementation import read_tiled, get_n_tiles, cupy_to_zarr
+
+
+data_dir = os.environ.get('WHOLE_SLIDE_DATA_DIR', os.path.dirname('__file__'))
+fname = os.path.join(data_dir, 'resize.tiff')
+if not os.path.exists(fname):
+    raise RuntimeError(f"Could not find data file: {fname}")
+
+# make sure we are not in compatibility mode to ensure cuFile is being used
+# (when compat_mode() is True, POSIX will be used instead of libcufile.so)
+kvikio.defaults.compat_mode_reset(False)
+assert not kvikio.defaults.compat_mode()
+
+# set the number of threads to use
+kvikio.defaults.num_threads_reset(16)
+
+print(f"\t{kvikio.defaults.compat_mode() = }")
+print(f"\t{kvikio.defaults.get_num_threads() = }")
+print(f"\tkvikio task size = {kvikio.defaults.task_size()/1024**2} MB")
+
+
+n_buffer = 128
+max_duration = 4
+level = 0
+compressor = None
+
+with TiffFile(fname) as tif:
+    page = tif.pages[level]
+    page_shape = page.shape
+    tile_shape = (page.tilelength, page.tilewidth, page.samplesperpixel)
+    total_tiles = math.prod(get_n_tiles(page))
+print(f"Resolution level {level}\n")
+print(f"\tshape: {page_shape}")
+print(f"\tstored as {total_tiles} tiles of shape {tile_shape}")
+
+
+# read the uint8 TIFF
+kwargs = dict(levels=[level], backend='kvikio-pread', n_buffer=n_buffer)
+image_gpu = read_tiled(fname, **kwargs)[0]
+
+# read the uint8 TIFF applying tile-wise processing to give a float32 array
+kwargs = dict(levels=[level], backend='kvikio-pread', n_buffer=n_buffer,
+              tile_func=image_to_absorbance, out_dtype=cp.float32)
+preprocessed_gpu = read_tiled(fname, **kwargs)[0]
+
+# benchmark writing these CuPy outputs to Zarr with various chunk sizes
+dtypes = ['uint8', 'float32']
+chunk_shapes = [(512, 512, 3), (1024, 1024, 3), (2048, 2048, 3)]
+backends = ['dask', 'kvikio-raw_write', 'kvikio-pwrite']
+kvikio.defaults.num_threads_reset(16)
+write_time_means = np.zeros(
+    ((len(dtypes), len(chunk_shapes), len(backends), 2)), dtype=float
+)
+write_time_stds = np.zeros_like(write_time_means)
+for i, dtype in enumerate(dtypes):
+    if dtype == 'uint8':
+        img = image_gpu
+        assert img.dtype == cp.uint8
+    elif dtype == 'float32':
+        img = preprocessed_gpu
+        assert img.dtype == cp.float32
+    else:
+        raise NotImplementedError("only testing for uint8 and float32")
+    for j, chunk_shape in enumerate(chunk_shapes):
+        for k, backend in enumerate(backends):
+            kwargs = dict(
+                output_path=f'./image-{dtype}.zarr',
+                chunk_shape=chunk_shape,
+                zarr_kwargs=dict(overwrite=True, compressor=compressor),
+                n_buffer=64,
+                backend=backend,
+            )
+            for m, gds_enabled in enumerate([False, True]):
+                kvikio.defaults.compat_mode_reset(not gds_enabled)
+                perf_write_float32 = benchmark(cupy_to_zarr, (img,), kwargs=kwargs, n_warmup=1, n_repeat=7, max_duration=15)
+                t = perf_write_float32.gpu_times
+                write_time_means[i, j, k, m] = t.mean()
+                write_time_stds[i, j, k, m] = t.std()
+                print(f"Duration ({cp.dtype(dtype).name} write, {chunk_shape=}, {backend=}, {gds_enabled=}): "
+                      f"{t.mean()} s +/- {t.std()} s")
+out_name = 'write_times.npz'
+# auto-increment filename to avoid overwriting old results
+cnt = 1
+while os.path.exists(out_name):
+    out_name = f'write_times{cnt}.npz'
+    cnt += 1
+
+np.savez(out_name, write_time_means=write_time_means, write_time_stds=write_time_stds)
+
+
+"""
+Output on local system:
+
+
+"""

--- a/examples/python/gds_whole_slide/benchmark_zarr_write_lz4_via_dask.py
+++ b/examples/python/gds_whole_slide/benchmark_zarr_write_lz4_via_dask.py
@@ -1,0 +1,152 @@
+"""
+TODO: Currently LZ4-compressed images are a tiny bit larger than uncompressed.
+Need to look into why this is!
+
+"""
+
+import math
+import os
+
+import cupy as cp
+import kvikio.defaults
+import numpy as np
+from cucim.core.operations.color import image_to_absorbance
+from cupyx.profiler import benchmark
+from tifffile import TiffFile
+
+from demo_implementation import read_tiled, get_n_tiles, cupy_to_zarr
+from lz4_nvcomp import LZ4NVCOMP
+
+
+data_dir = os.environ.get('WHOLE_SLIDE_DATA_DIR', os.path.dirname('__file__'))
+fname = os.path.join(data_dir, 'resize.tiff')
+if not os.path.exists(fname):
+    raise RuntimeError(f"Could not find data file: {fname}")
+
+# make sure we are not in compatibility mode to ensure cuFile is being used
+# (when compat_mode() is True, POSIX will be used instead of libcufile.so)
+kvikio.defaults.compat_mode_reset(False)
+assert not kvikio.defaults.compat_mode()
+
+# set the number of threads to use
+kvikio.defaults.num_threads_reset(16)
+
+print(f"\t{kvikio.defaults.compat_mode() = }")
+print(f"\t{kvikio.defaults.get_num_threads() = }")
+print(f"\tkvikio task size = {kvikio.defaults.task_size()/1024**2} MB")
+
+
+n_buffer = 128
+max_duration = 8
+level = 1
+
+with TiffFile(fname) as tif:
+    page = tif.pages[level]
+    page_shape = page.shape
+    tile_shape = (page.tilelength, page.tilewidth, page.samplesperpixel)
+    total_tiles = math.prod(get_n_tiles(page))
+print(f"Resolution level {level}\n")
+print(f"\tshape: {page_shape}")
+print(f"\tstored as {total_tiles} tiles of shape {tile_shape}")
+
+
+# read the uint8 TIFF
+kwargs = dict(levels=[level], backend='kvikio-pread', n_buffer=n_buffer)
+image_gpu = read_tiled(fname, **kwargs)[0]
+
+# benchmark writing these CuPy outputs to Zarr with various chunk sizes
+# Note: nvcomp only supports integer and unsigned dtypes.
+# https://github.com/rapidsai/kvikio/blob/b0c6cedf43d1bc240c3ef1b38ebb9d89574a08ee/python/kvikio/nvcomp.py#L12-L21  # noqa
+
+dtypes = ['uint16']
+chunk_shapes = [(512, 512, 3), (1024, 1024, 3), (2048, 2048, 3), (4096, 4096, 3)]
+backend = 'dask'
+compressors = [None, LZ4NVCOMP()]
+kvikio.defaults.num_threads_reset(16)
+write_time_means = np.zeros(((len(dtypes), len(chunk_shapes), len(compressors), 2)), dtype=float)
+write_time_stds = np.zeros_like(write_time_means)
+for i, dtype in enumerate(dtypes):
+    if dtype == 'uint8':
+        img = image_gpu
+        assert img.dtype == cp.uint8
+    else:
+        img = image_gpu.astype(dtype)
+    else:
+        raise NotImplementedError("only testing for uint8 and uint16")
+    for j, chunk_shape in enumerate(chunk_shapes):
+        for k, compressor in enumerate(compressors):
+            kwargs = dict(
+                output_path=f'./image-{dtype}-chunk{chunk_shape[0]}.zarr' if compressor is None else f'./image-{dtype}-chunk{chunk_shape[0]}-lz4.zarr',
+                chunk_shape=chunk_shape,
+                zarr_kwargs=dict(overwrite=True, compressor=compressor),
+                n_buffer=64,
+                backend=backend,
+            )
+            for m, gds_enabled in enumerate([False, True]):
+                kvikio.defaults.compat_mode_reset(not gds_enabled)
+                perf_write_float32 = benchmark(cupy_to_zarr, (img,), kwargs=kwargs, n_warmup=1, n_repeat=7, max_duration=max_duration)
+                t = perf_write_float32.gpu_times
+                write_time_means[i, j, k, m] = t.mean()
+                write_time_stds[i, j, k, m] = t.std()
+                print(f"Duration ({cp.dtype(dtype).name} write, {chunk_shape=}, {compressor=}, {gds_enabled=}): "
+                   f"{t.mean()} s +/- {t.std()} s")
+
+out_name = 'write_times_lz4.npz'
+# auto-increment filename to avoid overwriting old results
+cnt = 1
+while os.path.exists(out_name):
+    out_name = f'write_times_lz4{cnt}.npz'
+    cnt += 1
+
+np.savez(out_name, write_time_means=write_time_means, write_time_stds=write_time_stds)
+
+
+"""
+
+421M    image-uint8-chunk2048.zarr/
+295M    image-uint8-chunk2048-lz4.zarr/
+
+Output on local system:
+
+    kvikio.defaults.compat_mode() = False
+    kvikio.defaults.get_num_threads() = 16
+    kvikio task size = 4.0 MB
+Resolution level 1
+
+Duration (uint8 write, chunk_shape=(512, 512, 3), compressor=None, gds_enabled=False): 0.9078736816406249 s +/- 0.014021576325619447 s
+Duration (uint8 write, chunk_shape=(512, 512, 3), compressor=None, gds_enabled=True): 0.7154334309895835 s +/- 0.012911493047009337 s
+Duration (uint8 write, chunk_shape=(512, 512, 3), compressor=LZ4NVCOMP, gds_enabled=False): 4.5858623046875 s +/- 0.0 s
+Duration (uint8 write, chunk_shape=(512, 512, 3), compressor=LZ4NVCOMP, gds_enabled=True): 4.7737607421875 s +/- 0.0 s
+Duration (uint8 write, chunk_shape=(1024, 1024, 3), compressor=None, gds_enabled=False): 0.33250243268694196 s +/- 0.033499521893803265 s
+Duration (uint8 write, chunk_shape=(1024, 1024, 3), compressor=None, gds_enabled=True): 0.1679712175641741 s +/- 0.00943557539273183 s
+Duration (uint8 write, chunk_shape=(1024, 1024, 3), compressor=LZ4NVCOMP, gds_enabled=False): 1.308169403076172 s +/- 0.009489436283604222 s
+Duration (uint8 write, chunk_shape=(1024, 1024, 3), compressor=LZ4NVCOMP, gds_enabled=True): 1.3726735026041668 s +/- 0.0047038287720149695 s
+Duration (uint8 write, chunk_shape=(2048, 2048, 3), compressor=None, gds_enabled=False): 0.25327674865722655 s +/- 0.06120098715153658 s
+Duration (uint8 write, chunk_shape=(2048, 2048, 3), compressor=None, gds_enabled=True): 0.17847256687709265 s +/- 0.008324480608522849 s
+Duration (uint8 write, chunk_shape=(2048, 2048, 3), compressor=LZ4NVCOMP, gds_enabled=False): 0.5187601710728237 s +/- 0.007874048300727562 s
+Duration (uint8 write, chunk_shape=(2048, 2048, 3), compressor=LZ4NVCOMP, gds_enabled=True): 0.45903962925502234 s +/- 0.019780733967690416 s
+Duration (uint8 write, chunk_shape=(4096, 4096, 3), compressor=None, gds_enabled=False): 0.2989522748674665 s +/- 0.01275530846360682 s
+Duration (uint8 write, chunk_shape=(4096, 4096, 3), compressor=None, gds_enabled=True): 0.3445836966378349 s +/- 0.010775083201675684 s
+Duration (uint8 write, chunk_shape=(4096, 4096, 3), compressor=LZ4NVCOMP, gds_enabled=False): 0.3000637948172433 s +/- 0.04060511008994888 s
+Duration (uint8 write, chunk_shape=(4096, 4096, 3), compressor=LZ4NVCOMP, gds_enabled=True): 0.2680468902587891 s +/- 0.023300006446218775 s
+
+    shape: (13210, 9960, 3)
+    stored as 520 tiles of shape (512, 512, 3)
+Duration (uint16 write, chunk_shape=(512, 512, 3), compressor=None, gds_enabled=False): 1.0883130187988281 s +/- 0.029807589266119452 s
+Duration (uint16 write, chunk_shape=(512, 512, 3), compressor=None, gds_enabled=True): 0.7361140238444012 s +/- 0.02239347882169216 s
+Duration (uint16 write, chunk_shape=(512, 512, 3), compressor=LZ4NVCOMP, gds_enabled=False): 4.56396484375 s +/- 0.0 s
+Duration (uint16 write, chunk_shape=(512, 512, 3), compressor=LZ4NVCOMP, gds_enabled=True): 4.76813818359375 s +/- 0.0 s
+Duration (uint16 write, chunk_shape=(1024, 1024, 3), compressor=None, gds_enabled=False): 0.45565206037248884 s +/- 0.14820532739770373 s
+Duration (uint16 write, chunk_shape=(1024, 1024, 3), compressor=None, gds_enabled=True): 0.31185867309570314 s +/- 0.013444509106645106 s
+Duration (uint16 write, chunk_shape=(1024, 1024, 3), compressor=LZ4NVCOMP, gds_enabled=False): 1.5407437337239582 s +/- 0.12621846871213385 s
+Duration (uint16 write, chunk_shape=(1024, 1024, 3), compressor=LZ4NVCOMP, gds_enabled=True): 1.298984100341797 s +/- 0.025558385966707807 s
+Duration (uint16 write, chunk_shape=(2048, 2048, 3), compressor=None, gds_enabled=False): 0.5751916896275112 s +/- 0.1870959869706265 s
+Duration (uint16 write, chunk_shape=(2048, 2048, 3), compressor=None, gds_enabled=True): 0.36480389404296876 s +/- 0.008747247240530139 s
+Duration (uint16 write, chunk_shape=(2048, 2048, 3), compressor=LZ4NVCOMP, gds_enabled=False): 0.7505391642252603 s +/- 0.19527720554541175 s
+Duration (uint16 write, chunk_shape=(2048, 2048, 3), compressor=LZ4NVCOMP, gds_enabled=True): 0.5359197431291852 s +/- 0.08704735860133013 s
+Duration (uint16 write, chunk_shape=(4096, 4096, 3), compressor=None, gds_enabled=False): 1.5224884440104167 s +/- 0.16454276798775797 s
+Duration (uint16 write, chunk_shape=(4096, 4096, 3), compressor=None, gds_enabled=True): 1.2984992370605468 s +/- 0.028939276482940306 s
+Duration (uint16 write, chunk_shape=(4096, 4096, 3), compressor=LZ4NVCOMP, gds_enabled=False): 0.8166022583007813 s +/- 0.19712617258152443 s
+Duration (uint16 write, chunk_shape=(4096, 4096, 3), compressor=LZ4NVCOMP, gds_enabled=True): 0.7342889607747396 s +/- 0.025796103217999546 s
+
+"""

--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -1,0 +1,722 @@
+import os
+
+import cupy as cp
+import dask.array as da
+import kvikio
+import kvikio.defaults
+import numpy as np
+import openslide
+import tifffile
+from tifffile import TiffFile
+from kvikio.cufile import IOFuture
+from kvikio.zarr import GDSStore
+from zarr import DirectoryStore
+from zarr.creation import init_array
+
+from cucim.clara import filesystem
+
+"""
+Developed with Dask 2022.05.2
+zarr >= 2.13.2
+kvikio >= 2022.10.00  (but had to use a recent development branch on my system to properly find libcufile.so)
+"""
+
+
+def get_n_tiles(page):
+    """Create a tuple containing the number of tiles along each axis
+
+    Parameters
+    ----------
+    page : tifffile.tifffile.TiffPage
+        The TIFF page.
+    """
+
+    tdepth, tlength, twidth = (page.tiledepth, page.tilelength, page.tilewidth)
+    assert page.shaped[-1] == page.samplesperpixel
+    imdepth, imlength, imwidth, samples = page.shaped[-4:]
+
+    n_width = (imwidth + twidth - 1) // twidth
+    n_length = (imlength + tlength - 1) // tlength
+    n_depth = (imdepth + tdepth - 1) // tdepth
+    return (n_depth, n_length, n_width)
+
+
+def _get_tile_multiindex(page, index, n_tiles):
+    """Position offsets into the output array for the current tile.
+
+    Parameters
+    ----------
+    page : tifffile.tifffile.TiffPage
+        The TIFF page.
+    index : int
+        The linear index in page.dataoffsets (or page.databytecounts)
+        corresponding to the current tile.
+    n_tiles : int
+        The total number of tiles as returned by ``get_n_tiles(page)``
+
+    Returns
+    -------
+    multi_index : tuple of int
+        Starting index for the tile along each axis in the output array.
+    """
+    d, l, w = n_tiles
+    wl = w * l
+    wld = wl * d
+    multi_index = (
+        index // wld,
+        (index // wl) % d * page.tiledepth,
+        (index // w) % l * page.tilelength,
+        index % w * page.tilewidth,
+        0,
+    )
+    return multi_index
+
+
+def _decode(data, tile_shape, truncation_slices):
+    """Reshape data from a 1d buffer to the destination tile's shape.
+
+    Parameters
+    ----------
+    data : buffer or ndarray
+        Data array (1d raveled tile data).
+    tile_shape : tuple of int
+        The shape of the tile
+    truncation_slices : tuple of slice
+        Slice objects used to truncate the reshaped data. Needed to trim the
+        last tile along a given dimension when the page size is not an even
+        multiple of the tile width.
+    """
+    if not hasattr(data, '__cuda_array_interface__'):
+        data = np.frombuffer(data, np.uint8)
+    data.shape = tile_shape
+    # truncate any tiles that extend past the image boundary
+    if truncation_slices:
+        data = data[truncation_slices]
+    return data
+
+
+def _truncation_slices(check_needed, page_shape, offsets, tile_shape, n_tiles):
+    """Determine any necessary truncation of boundary tiles.
+
+    This is essentially generating a tuple of slices for doing:
+
+    tile = tile[
+        : page_shape[0] - offsets[0],
+        : page_shape[1] - offsets[1],
+        : page_shape[2] - offsets[2],
+    ]
+
+    but has additional logic to return None in cases where truncation is not
+    needed.
+
+    Parameters
+    ----------
+    check_needed : 3-tuple of bool
+        Any axis whos page size is not evenly divisible by the tile size will
+        have a True entry in this tuple.
+    page_shape : tuple of int
+        The shape of the current TIFF page (depth, length, width[, channels])
+    offsets : 3-tuple of int
+        Starting corner indices for the current tile (depth, length, width).
+    tile_shape : tuple of int
+        Shape of a single tile (depth, length, width[, channels]).
+    n_tiles : 3-tuple of int
+        The number of tiles along each axis (depth, length, width)
+
+    Returns
+    -------
+    tile_slice : 3-tuple of slice or None
+        Slices needed to generate a truncated tile via
+        ``tile = tile[tile_slice]``. Returns None of no truncation is needed
+        at the current tile.
+    """
+    any_truncated = False
+    slices = []
+    for ax in range(len(offsets)):
+        if (
+            check_needed[ax]
+            # don't need to truncate unless this is the last tile along an axis
+            and (offsets[ax] // tile_shape[ax] == n_tiles[ax] - 1)
+        ):
+            any_truncated = True
+            slices.append(slice(0, page_shape[ax] - offsets[ax]))
+        else:
+            slices.append(slice(None))
+    if any_truncated:
+        return tuple(slices)
+    return None
+
+
+def read_openslide(fname, level, clear_cache=True):
+    """CPU-based reader using openslide followed by cupy.array."""
+
+    if clear_cache:
+        assert filesystem.discard_page_cache(fname)
+
+    slide = openslide.OpenSlide(fname)
+    out = slide.read_region(
+        location=(0, 0),
+        level=level,
+        size=slide.level_dimensions[level]
+    )
+    # convert from PIL image to NumPy array
+    out = np.asarray(out)
+    # transfer to GPU, omitting the alpha channel
+    return cp.array(out[..., :3])
+
+
+def read_tifffile(fname, level, clear_cache=True):
+    """CPU-based reader using tifffile followed by cupy.array."""
+
+    if clear_cache:
+        assert filesystem.discard_page_cache(fname)
+
+    return cp.array(tifffile.imread(fname, level=level))
+
+
+def _get_aligned_read_props(offsets, bytecounts, alignment=4096):
+    """Adjust offsets and bytecounts to get reads of the desired alignment.
+
+    Parameters
+    ----------
+    offsets : sequence of int
+        The bytes offsets of each tile in the TIFF page.
+        (i.e. tifffile's ``page.dataoffsets``).
+    bytecounts : sequence of int
+        The size in bytes of each tile in the TIFF page.
+        (i.e. tifffile's ``page.databytecounts``).
+    alignment : int, optional
+        The desired alignment for the read operation. For GPUDirect Storage,
+        this should be 4096.
+
+    Notes
+    -----
+    For GPUDirect Storage, it is important that reads occur width 4096-byte
+    alignment and have a size that is a multiple of 4096-bytes. So, in this
+    function we offset the read from the tile's start position back to the
+    previous byte-aligned position. We then round up the total bytes to be read
+    so that it is a multiple of `alignment`.
+    """
+    offsets = np.asarray(offsets, dtype=int)
+    bytecounts = np.asarray(bytecounts, dtype=int)
+    rounded_offsets = (offsets // alignment) * alignment
+    buffer_offsets = offsets - rounded_offsets
+    rounded_bytecounts = buffer_offsets + bytecounts
+    rounded_bytecounts = np.ceil(rounded_bytecounts / alignment).astype(int) * alignment
+
+    # truncate last bytecounts entry to avoid possibly exceeding file extent
+    last = offsets[-1] + bytecounts[-1]
+    rounded_last = rounded_offsets[-1] + rounded_bytecounts[-1]
+    rounded_bytecounts[-1] += last - rounded_last
+
+    return rounded_offsets, rounded_bytecounts, buffer_offsets
+
+
+def _bulk_read_is_possible(offsets, bytecounts):
+    """Check that all of the page's tile data is contiguous in memory."""
+    contiguous_offsets = np.array(offsets)[:-1] + np.array(bytecounts)[:-1]
+    return np.all(contiguous_offsets == np.array(offsets)[1:])
+
+
+def _get_bulk_offset_and_size(offsets, bytecounts, align=4096):
+    """Determine offsets and bytecounts for a single bulk read of the desired
+    alignment.
+
+    Notes
+    -----
+    See documentation of `_get_aligned_read_props` for explanation of the
+    alignment requirements of GPUDirect Storage.
+    """
+    if not _bulk_read_is_possible(offsets, bytecounts):
+        raise RuntimeError("Tiles are not stored contiguously!")
+    total_size = offsets[-1] - offsets[0] + bytecounts[-1]
+    # reduce offset to closest value that is aligned to 4096 bytes
+    offset_aligned = (offsets[0] // align) * align
+    padded_bytes = offsets[0] - offset_aligned
+    # increase size to keep the same final byte
+    total_size += padded_bytes
+    return offset_aligned, total_size, padded_bytes
+
+
+def read_alltiles_bulk(fname, level, clear_cache=True):
+    """Read all tiles from a page in a single, bulk read operation.
+
+    Can be used to compare to the performance of tile-based reads.
+    """
+    if clear_cache:
+        assert filesystem.discard_page_cache(fname)
+
+    with TiffFile(fname) as tif:
+        fh = kvikio.CuFile(fname, "r")
+        page = tif.pages[level]
+        offset, total_size, padded_bytes = _get_bulk_offset_and_size(
+            page.dataoffsets, page.databytecounts
+        )
+        output = cp.empty(total_size, dtype=cp.uint8)
+        size = fh.read(output, file_offset=offset)
+        if size != total_size:
+            raise ValueError("failed to read the expected number of bytes")
+    return output[padded_bytes:]
+
+
+def get_tile_buffers(fname, level, n_buffer):
+    with TiffFile(fname) as tif:
+        page = tif.pages[level]
+        n_chan = page.shaped[-1]
+
+        rounded_offsets, rounded_bytecounts, buffer_offsets = _get_aligned_read_props(
+            offsets=page.dataoffsets,
+            bytecounts=page.databytecounts,
+            alignment=4096
+        )
+        # Allocate buffer based on size of the largest tile after rounding
+        # up to the nearest multiple of 4096.
+        # (in the uncompressed TIFF case, all tiles have an equal number of
+        #  bytes)
+        buffer_bytecount = rounded_bytecounts.max()
+        assert buffer_bytecount % 4096 == 0
+
+        # note: tile_buffer is C-contiguous so tile_buffer[i] is contiguous
+        tile_buffers = tuple(
+            cp.empty(buffer_bytecount, dtype=cp.uint8) for n in range(n_buffer)
+        )
+    return tile_buffers
+
+
+def read_tiled(fname, levels=[0], backend='kvikio-pread', n_buffer=100,
+               tile_func=None, tile_func_kwargs={}, out_dtype=None,
+               clear_cache=True, preregister_memory_buffers=False,
+               tile_buffers=None):
+    """Read an uncompressed, tiled multiresolution TIFF image to GPU memory.
+
+    Parameters
+    ----------
+    fname : str, optional
+        File name.
+    levels : sequence of int or 'all', optional
+        The resolution levels to read. If 'all' then all levels in the file
+        will be read. Level 0 corresponds to the highest resolution in the
+        file.
+    backend : {'kvikio-pread', 'kvikio-read', 'kvikio-raw_read'}, optional
+        The approach to use when reading the file. The kvikio options can make
+        use of GPUDirect Storage. Best performance was observed with the
+        default 'kvikio-pread', which does asynchronous, multithreaded tile
+        reads.
+    n_buffer : int, optional
+        Scratch space equal to `n_buffer` TIFF tiles will be allocated.
+        Providing scratch space for multiple tiles helps the peformance in the
+        recommended asynchronous 'kvikio-pread' mode.
+    tile_func : function, optional
+        A CuPy-based function to apply to each tile after it is read. Must
+        take as input a single CuPy array and return a CuPy array of the same
+        shape (with possibly different dtype). The default of None does not
+        apply any processing to each tile.
+    tile_func_kwargs : dict, optional
+        Keyword arguments to pass into `tile_func`.
+    out_dtype : cp.dtype, optional
+        The output dtype of the output array. If unspecified, it will be equal
+        to the dtype of the input TIFF data.
+    clear_cache : bool, optional
+        If True, clear the file system's page cache prior to starting any
+        read operations. This is necessary to avoid caching so that one gets
+        accurate benchmark results if running this function repeatedly on the
+        same input data.
+    preregister_memory_buffers : bool, optional
+        If True, explicitly preregister the memory buffers with kvikio via
+        `kvikio.memory_register`.
+    tile_buffers : tuple or list of ndarray
+        If provided, use this preallocated set of tile buffers instead of
+        allocating tile buffers within this function. Will also override
+        n_buffer, setting it to ``n_buffer = len(tile_buffers)``. If the
+        provided buffers are too small, a warning will be printed and new
+        buffers will be allocated instead.
+
+    Returns
+    -------
+    out : list of cupy.ndarray
+        One CuPy array per requested level in `levels`.
+
+    """
+    if not os.path.isfile(fname):
+        raise ValueError(f"file not found: {fname}")
+
+    if clear_cache:
+        assert filesystem.discard_page_cache(fname)
+
+    if tile_buffers is not None:
+        if not (
+            isinstance(tile_buffers, (tuple, list))
+            and all(isinstance(b, cp.ndarray) for b in tile_buffers)
+        ):
+            raise ValueError("tile_buffers must be a list of ndarray")
+        # override user-provided n_buffer
+        if len(tile_buffers) != n_buffer:
+            n_buffer = len(tile_buffers)
+
+    with TiffFile(fname) as tif:
+
+        if isinstance(levels, int):
+            levels = (levels,)
+        if levels == 'all':
+            pages = tuple(tif.pages[n] for n in range(len(tif.pages)))
+        elif isinstance(levels, (tuple, list)):
+            pages = tuple(tif.pages[n] for n in levels)
+        else:
+            raise ValueError("pages must be a tuple or list of int or the "
+                             "string 'all'")
+
+        # sanity check: identical tile size for all TIFF pages
+        #               todo: is this always true?
+        assert len(set(p.tilelength for p in pages)) == 1
+        assert len(set(p.tilewidth for p in pages)) == 1
+
+        outputs = []
+
+        fh = kvikio.CuFile(fname, "r")
+        page = pages[0]
+        n_chan = page.shaped[-1]
+
+        for page in pages:
+            if out_dtype is None:
+                out_dtype = page.dtype
+            out_array = cp.ndarray(shape=page.shape, dtype=out_dtype)
+
+            rounded_offsets, rounded_bytecounts, buffer_offsets = _get_aligned_read_props(
+                offsets=page.dataoffsets,
+                bytecounts=page.databytecounts,
+                alignment=4096
+            )
+            # Allocate buffer based on size of the largest tile after rounding
+            # up to the nearest multiple of 4096.
+            # (in the uncompressed TIFF case, all tiles have an equal number of
+            #  bytes)
+            buffer_bytecount = rounded_bytecounts.max()
+            assert buffer_bytecount % 4096 == 0
+
+            tile_shape = (page.tilelength, page.tilewidth, n_chan)
+            # note: tile_buffer is C-contiguous so tile_buffer[i] is contiguous
+            if tile_buffers is None:
+                tile_buffers = tuple(
+                    cp.empty(buffer_bytecount, dtype=cp.uint8) for n in range(n_buffer)
+                )
+            elif tile_buffers[0].size < buffer_bytecount:
+                warning.warn("reallocating tile buffers to accomodate data size")
+                tile_buffers = tuple(
+                    cp.empty(buffer_bytecount, dtype=cp.uint8) for n in range(n_buffer)
+                )
+            else:
+                buffer_bytecount = tile_buffers[0].size
+
+            if preregister_memory_buffers:
+                for n in range(n_buffer):
+                    kvikio.memory_register(tile_buffers[n])
+
+            # compute number of tiles up-front to make _decode more efficient
+            n_tiles = get_n_tiles(page)
+
+            tile_shape = (
+                page.tiledepth,
+                page.tilelength,
+                page.tilewidth,
+                page.samplesperpixel
+            )
+            keyframe = page.keyframe
+            truncation_check_needed = (
+                (keyframe.imagedepth % page.tiledepth != 0),
+                (keyframe.imagelength % page.tilelength != 0),
+                (keyframe.imagewidth % page.tilewidth != 0)
+            )
+            any_truncated = any(truncation_check_needed)
+            page_shape = page.shaped[1:]  # # Any reason to prefer page.keyframe.imagedepth, etc. here as opposed to page.shape or page.shaped?
+
+            if backend == 'kvikio-raw_read':
+
+                def read_tile_raw(fh, tile_buffer, bytecount, offset):
+                    """returns the # of bytes read"""
+                    size = fh.raw_read(tile_buffer[:bytecount], file_offset=offset)
+                    if size != bytecount:
+                        raise ValueError(
+                            "failed to read the expected number of bytes"
+                        )
+                    return size
+
+                kv_read = read_tile_raw
+
+            elif backend == 'kvikio-read':
+
+                def read_tile(fh, tile_buffer, bytecount, offset):
+                    """returns the # of bytes read"""
+                    size = fh.read(tile_buffer[:bytecount], file_offset=offset)
+                    if size != bytecount:
+                        raise ValueError(
+                            "failed to read the expected number of bytes"
+                        )
+                    return size
+
+                kv_read = read_tile
+
+            elif backend == 'kvikio-pread':
+
+                def read_tile_async(fh, tile_buffer, bytecount, offset):
+                    """returns a future"""
+                    future = fh.pread(tile_buffer[:bytecount], file_offset=offset)
+                    # future.get()
+                    return future
+
+                kv_read = read_tile_async
+            else:
+                raise ValueError(f"unrecognized backend: {backend}")
+
+            # note: page.databytecounts contains the size of all tiles in
+            #       bytes. It will only vary in the case of compressed data
+            for index, (offset, tile_bytecount, rounded_bytecount, buffer_offset) in enumerate(
+                zip(rounded_offsets, page.databytecounts, rounded_bytecounts, buffer_offsets)
+            ):
+                index_mod = index % n_buffer
+                if index == 0:
+                    # intialize lists for storage of future results
+                    all_futures = []
+                    all_tiles = []
+                    all_slices = []
+                elif index_mod == 0:
+                    # process the prior group of n_buffer futures
+                    for tile, sl, future in zip(all_tiles, all_slices, all_futures):
+                        if isinstance(future, IOFuture):
+                            size = future.get()
+                            if size != rounded_bytecount:
+                                raise ValueError(
+                                    "failed to read the expected number of bytes"
+                                )
+                        tile = tile[0]  # omit depth axis
+                        if tile_func is None:
+                            out_array[sl] = tile
+                        else:
+                            out_array[sl] = tile_func(tile, **tile_func_kwargs)
+                    # reset the lists to prepare for the next n_buffer tiles
+                    all_futures = []
+                    all_tiles = []
+                    all_slices = []
+
+                # read a multiple of 4096 bytes into the current buffer at an
+                # offset that is aligned to 4096 bytes
+                read_output = kv_read(
+                    fh,
+                    tile_buffers[index_mod],
+                    rounded_bytecount,
+                    offset,
+                )
+
+                # Determine offsets into `out_array` for the current tile
+                # and determine slices to truncate the tile if needed.
+                offset_indices = _get_tile_multiindex(page, index, n_tiles)
+                (s, d, l, w, _) = offset_indices
+                if any_truncated:
+                    trunc_sl = _truncation_slices(
+                        truncation_check_needed,
+                        page_shape,
+                        offset_indices[1:4],
+                        tile_shape,
+                        n_tiles
+                    )
+                else:
+                    trunc_sl = None
+
+                # Reads are aligned to 4096-byte boundaries, so buffer_offset
+                # is needed to discard any initial bytes prior to the actual
+                # tile start.
+                buffer_start = buffer_offset
+                buffer_end = buffer_start + tile_bytecount
+                tile = _decode(tile_buffers[index_mod][buffer_start:buffer_end], tile_shape, trunc_sl)
+                all_futures.append(read_output)
+                all_tiles.append(tile)
+                all_slices.append((slice(l, l + tile_shape[1]), slice(w, w + tile_shape[2])))
+
+            for tile, sl, future in zip(all_tiles, all_slices, all_futures):
+                if isinstance(future, IOFuture):
+                    # make sure the buffer is filled with data
+                    future.get()
+                tile = tile[0]  # omit depth axis
+                if tile_func is None:
+                    out_array[sl] = tile
+                else:
+                    out_array[sl] = tile_func(tile, **tile_func_kwargs)
+            outputs.append(out_array)
+
+            if preregister_memory_buffers:
+                for n in range(n_buffer):
+                    kvikio.memory_deregister(tile_buffers[n])
+
+    return outputs
+
+
+def _cupy_to_zarr_via_dask(
+    image,
+    output_path='./example-output.zarr',
+    chunk_shape=(2048, 2048, 3),
+    zarr_kwargs=dict(overwrite=False, compressor=None)
+):
+    """Write output to Zarr via GDSStore"""
+    store = GDSStore(output_path)
+
+    dask_image = da.from_array(image, chunks=chunk_shape)
+    dask_image.to_zarr(store, meta_array=cp.empty(()), **zarr_kwargs)
+    return dask_image
+
+
+def _cupy_to_zarr_kvikio_write_sync(
+    image,
+    output_path='./example-output.zarr',
+    chunk_shape=(2048, 2048, 3),
+    zarr_kwargs=dict(overwrite=False, compressor=None),
+    backend='kvikio-raw_write',
+):
+    """Write output to Zarr via GDSStore"""
+
+    # 1.) create a zarr store
+    # 2.) call init_array to initialize Zarr .zarry metadata
+    #     this will also remove any existing files in output_path when
+    #     overwrite = True.
+
+    output_path = os.path.realpath(output_path)
+    store = DirectoryStore(output_path)
+    init_array(store, shape=image.shape, chunks=chunk_shape, dtype=image.dtype,
+               **zarr_kwargs)
+
+    c0, c1, c2 = chunk_shape
+    s0, s1, s2 = image.shape
+    for i0, start0 in enumerate(range(0, s0, c0)):
+        for i1, start1 in enumerate(range(0, s1, c1)):
+            for i2, start2 in enumerate(range(0, s2, c2)):
+                tile = image[start0:start0 + c0,
+                             start1:start1 + c1,
+                             start2:start2 + c2]
+                if tile.shape == chunk_shape:
+                    # copy so the tile is contiguous in memory
+                    tile = tile.copy()
+                else:
+                    pad_width = (
+                        (0, c0 - tile.shape[0]),
+                        (0, c1 - tile.shape[1]),
+                        (0, c2 - tile.shape[2]),
+                    )
+                    tile = cp.pad(
+                        tile, pad_width, mode='constant', constant_values=0
+                    )
+
+                chunk_key = '.'.join(map(str, (i0, i1, i2)))
+                fname = os.path.join(output_path, chunk_key)
+                with kvikio.CuFile(fname, "w") as fh:
+                    if backend == 'kvikio-raw_write':
+                        size = fh.raw_write(tile)
+                    elif backend == 'kvikio-write':
+                        size = fh.write(tile)
+                    else:
+                        raise ValueError(f"unknown backend {backend}")
+                    assert size == tile.nbytes
+    return
+
+
+def cupy_to_zarr(
+    image,
+    output_path='./example-output.zarr',
+    chunk_shape=(512, 512, 3),
+    n_buffer=16,
+    zarr_kwargs=dict(overwrite=False, compressor=None),
+    backend='kvikio-pwrite',
+):
+    """Write output to Zarr via GDSStore
+
+
+    """
+    if backend == 'dask':
+        return _cupy_to_zarr_via_dask(
+            image,
+            output_path=output_path,
+            chunk_shape=chunk_shape,
+            zarr_kwargs=zarr_kwargs,
+        )
+
+    elif backend in ['kvikio-write', 'kvikio-raw_write']:
+        return _cupy_to_zarr_kvikio_write_sync(
+            image,
+            output_path=output_path,
+            chunk_shape=chunk_shape,
+            zarr_kwargs=zarr_kwargs,
+            backend=backend,
+        )
+    elif backend != 'kvikio-pwrite':
+        raise ValueError(f"unrecognized backend: {backend}")
+
+    # 1.) create a zarr store
+    # 2.) call init_array to initialize Zarr .zarry metadata
+    #     this will also remove any existing files in output_path when
+    #     overwrite = True.
+    output_path = os.path.realpath(output_path)
+    store = DirectoryStore(output_path)
+    init_array(store, shape=image.shape, chunks=chunk_shape, dtype=image.dtype,
+               **zarr_kwargs)
+
+    # asynchronous write using pwrite
+    index = 0
+    c0, c1, c2 = chunk_shape
+    s0, s1, s2 = image.shape
+    tile_cache = cp.zeros((n_buffer,) + chunk_shape, dtype=image.dtype)
+    for i0, start0 in enumerate(range(0, s0, c0)):
+        for i1, start1 in enumerate(range(0, s1, c1)):
+            for i2, start2 in enumerate(range(0, s2, c2)):
+
+                index_mod = index % n_buffer
+                if index == 0:
+                    # intialize lists for storage of future results
+                    all_tiles = []
+                    all_handles = []
+                    all_futures = []
+                elif index_mod == 0:
+                    for fh, future in zip(all_handles, all_futures):
+                        if isinstance(future, IOFuture):
+                            size = future.get()
+                            if size != tile_cache[0].nbytes:
+                                raise ValueError(
+                                    "failed to write the expected number of "
+                                    "bytes"
+                                )
+                        fh.close()
+                        # reset the lists to prepare for the next n_buffer tiles
+                        all_futures = []
+                        all_handles = []
+                        all_tiles = []
+
+                tile = image[start0:start0 + c0,
+                             start1:start1 + c1,
+                             start2:start2 + c2]
+                if tile.shape == chunk_shape:
+                    # copy so the tile is contiguous in memory
+                    tile_cache[index_mod] = tile
+                else:
+                    pad_width = (
+                        (0, c0 - tile.shape[0]),
+                        (0, c1 - tile.shape[1]),
+                        (0, c2 - tile.shape[2]),
+                    )
+                    tile_cache[index_mod] = cp.pad(
+                        tile, pad_width, mode='constant', constant_values=0
+                    )
+
+                chunk_key = '.'.join(map(str, (i0, i1, i2)))
+                fname = os.path.join(output_path, chunk_key)
+
+                fh = kvikio.CuFile(fname, "w")
+                future = fh.pwrite(tile_cache[index_mod])
+                all_futures.append(future)
+                all_handles.append(fh)
+                # assert written == a.nbytes
+                index += 1
+    for fh, future in zip(all_handles, all_futures):
+        if isinstance(future, IOFuture):
+            size = future.get()
+            if size != tile_cache[0].nbytes:
+                raise ValueError(
+                    "failed to write the expected number of bytes"
+                )
+        fh.close()
+    return

--- a/examples/python/gds_whole_slide/lz4_nvcomp.py
+++ b/examples/python/gds_whole_slide/lz4_nvcomp.py
@@ -1,0 +1,161 @@
+import cupy as cp
+import numpy as np
+from kvikio.nvcomp import LZ4Manager
+from numcodecs import registry
+from numcodecs.abc import Codec
+
+
+def ensure_ndarray(buf):
+    if isinstance(buf, cp.ndarray):
+        arr = buf
+    elif hasattr(buf, '__cuda_array_interface__'):
+        arr = cp.asarray(buf, copy=False)
+    elif hasattr(buf, '__array_interface__'):
+        arr = cp.asarray(np.asarray(buf))
+    else:
+        raise ValueError("expected a cupy.ndarray")
+    return arr
+
+
+def ensure_contiguous_ndarray(
+    buf, max_buffer_size=None, flatten=True
+):
+    """Convenience function to coerce `buf` to ndarray-like array.
+    Also ensures that the returned value exports fully contiguous memory,
+    and supports the new-style buffer interface. If the optional max_buffer_size is
+    provided, raise a ValueError if the number of bytes consumed by the returned
+    array exceeds this value.
+
+    Parameters
+    ----------
+    buf : ndarray-like, array-like, or bytes-like
+        A numpy array like object such as numpy.ndarray, cupy.ndarray, or
+        any object exporting a buffer interface.
+    max_buffer_size : int
+        If specified, the largest allowable value of arr.nbytes, where arr
+        is the returned array.
+    flatten : bool
+        If True, the array are flatten.
+
+    Returns
+    -------
+    arr : cupy.ndarray
+        A cupy.ndarray, sharing memory with `buf`.
+
+    Notes
+    -----
+    This function will not create a copy under any circumstances, it is guaranteed to
+    return a view on memory exported by `buf`.
+    """
+    arr = ensure_ndarray(buf)
+
+    # check for object arrays, these are just memory pointers, actual memory holding
+    # item data is scattered elsewhere
+    if arr.dtype == object:
+        raise TypeError("object arrays are not supported")
+
+    # check for datetime or timedelta ndarray, the buffer interface doesn't support those
+    if arr.dtype.kind in "Mm":
+        arr = arr.view(np.int64)
+
+    # check memory is contiguous, if so flatten
+    if arr.flags.c_contiguous or arr.flags.f_contiguous:
+        if flatten:
+            # can flatten without copy
+            arr = arr.reshape(-1, order="A")
+    else:
+        raise ValueError("an array with contiguous memory is required")
+
+    if max_buffer_size is not None and arr.nbytes > max_buffer_size:
+        msg = "Codec does not support buffers of > {} bytes".format(max_buffer_size)
+        raise ValueError(msg)
+
+    return arr
+
+
+def ndarray_copy(src, dst):
+    """Copy the contents of the array from `src` to `dst`."""
+
+    if dst is None:
+        # no-op
+        return src
+
+    # ensure ndarray like
+    src = ensure_ndarray(src)
+    dst = ensure_ndarray(dst)
+
+    # flatten source array
+    src = src.reshape(-1, order="A")
+
+    # ensure same data type
+    if dst.dtype != object:
+        src = src.view(dst.dtype)
+
+    # reshape source to match destination
+    if src.shape != dst.shape:
+        if dst.flags.f_contiguous:
+            order = "F"
+        else:
+            order = "C"
+        src = src.reshape(dst.shape, order=order)
+
+    # copy via numpy
+    cp.copyto(dst, src)
+
+    return dst
+
+
+class LZ4NVCOMP(Codec):
+    """Codec providing compression using LZ4 on the GPU via nvCOMP.
+
+    Parameters
+    ----------
+    acceleration : int
+        Acceleration level. The larger the acceleration value, the faster the
+        algorithm, but also the lesser the compression.
+
+    See Also
+    --------
+    numcodecs.zstd.Zstd, numcodecs.blosc.Blosc
+
+    """
+
+    codec_id = 'lz4nvcomp'
+    max_buffer_size = 0x7E000000
+
+    def __init__(self, compressor=None):  # , acceleration=1  (nvcomp lz4 doesn't take an acceleration argument)
+        # self.acceleration = acceleration
+        self._compressor = None
+
+    def encode(self, buf):
+        buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)
+        if self._compressor is None: # or self._compressor.data_type != buf.dtype:
+            self._compressor = LZ4Manager(data_type=buf.dtype)
+        return self._compressor.compress(buf)  # , self.acceleration)
+
+    def decode(self, buf, out=None):
+        buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)
+        if self._compressor is None: # or self._compressor.data_type != buf.dtype:
+            self._compressor = LZ4Manager(data_type=buf.dtype)
+        decompressed = self._compressor.decompress(buf)
+        return ndarray_copy(decompressed, out)
+
+    # def get_config(self):
+    #     # cc_config = self.compressor.get_config() if self.compressor else None
+    #     return {
+    #         "id": self.codec_id,
+    #         "compressor_config": None,  # cc_config,
+    #     }
+
+    # @classmethod
+    # def from_config(cls, config):
+    #     # cc_config = config.get("compressor_config", None)
+    #     # compressor = get_codec(cc_config) if cc_config else None
+    #     return cls()  # compressor=compressor)
+
+    def __repr__(self):
+        r = '%s' % type(self).__name__
+        return r
+
+
+registry.register_codec(LZ4NVCOMP)

--- a/examples/python/gds_whole_slide/lz4_nvcomp.py
+++ b/examples/python/gds_whole_slide/lz4_nvcomp.py
@@ -140,19 +140,6 @@ class LZ4NVCOMP(Codec):
         decompressed = self._compressor.decompress(buf)
         return ndarray_copy(decompressed, out)
 
-    # def get_config(self):
-    #     # cc_config = self.compressor.get_config() if self.compressor else None
-    #     return {
-    #         "id": self.codec_id,
-    #         "compressor_config": None,  # cc_config,
-    #     }
-
-    # @classmethod
-    # def from_config(cls, config):
-    #     # cc_config = config.get("compressor_config", None)
-    #     # compressor = get_codec(cc_config) if cc_config else None
-    #     return cls()  # compressor=compressor)
-
     def __repr__(self):
         r = '%s' % type(self).__name__
         return r


### PR DESCRIPTION
These demos are intended to accompany a blog post describing tiled read and write operations of whole slide images.