### PR TITLE
additional minor updates (skimage 0.20)

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/__init__.py
+++ b/python/cucim/src/cucim/core/operations/color/__init__.py
@@ -1,7 +1,6 @@
 from .jitter import color_jitter, rand_color_jitter
 from .stain_normalizer import (absorbance_to_image, image_to_absorbance,
-                               normalize_colors_pca,
-                               stain_extraction_pca)
+                               normalize_colors_pca, stain_extraction_pca)
 
 __all__ = [
     "color_jitter",

--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -18,7 +18,6 @@ from typing import Union
 import cupy as cp
 import numpy as np
 
-
 __all__ = [
     "absorbance_to_image",
     "image_to_absorbance",

--- a/python/cucim/src/cucim/core/operations/morphology/_pba_2d.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_pba_2d.py
@@ -3,7 +3,6 @@ import math
 import numbers
 import os
 
-
 import cupy
 
 try:

--- a/python/cucim/src/cucim/core/operations/morphology/_pba_3d.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_pba_3d.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from ._pba_2d import _get_block_size, lcm
 
-
 pba3d_defines_template = """
 
 #define MARKER     {marker}

--- a/python/cucim/src/cucim/skimage/_shared/filters.py
+++ b/python/cucim/src/cucim/skimage/_shared/filters.py
@@ -7,8 +7,8 @@ The unit tests remain under skimage/filters/tests/
 from collections.abc import Iterable
 
 import cupy as cp
-import cucim.skimage._vendored.ndimage as ndi
 
+import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared import utils
 from .._shared.utils import _supported_float_type, convert_to_float

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -7,9 +7,9 @@ import numpy
 from cucim.skimage._vendored import _internal as internal
 from cucim.skimage._vendored import _ndimage_filters_core as _filters_core
 from cucim.skimage._vendored import _ndimage_util as _util
-
 from cucim.skimage.filters._separable_filtering import (ResourceLimitError,
                                                         _shmem_convolve1d)
+
 try:
     from cupy.cuda.compiler import CompileException
     compile_errors = (ResourceLimitError, CompileException)

--- a/python/cucim/src/cucim/skimage/color/colorconv.py
+++ b/python/cucim/src/cucim/skimage/color/colorconv.py
@@ -1259,7 +1259,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     nwarn = int(cp.count_nonzero(warnings))
     if nwarn > 0:  # synchronize!
         warn(f'Color data out of range: Z < 0 in {nwarn} pixels',
-             stacklevel=2)
+             stacklevel=3)
     return xyz
 
 

--- a/python/cucim/src/cucim/skimage/feature/__init__.py
+++ b/python/cucim/src/cucim/skimage/feature/__init__.py
@@ -2,15 +2,14 @@ from .._shared.utils import deprecated
 from ._basic_features import multiscale_basic_features
 from ._canny import canny
 from ._daisy import daisy
+from .blob import blob_dog, blob_doh, blob_log
 from .corner import (corner_foerstner, corner_harris, corner_kitchen_rosenfeld,
                      corner_peaks, corner_shi_tomasi, hessian_matrix,
                      hessian_matrix_det, hessian_matrix_eigvals, shape_index,
                      structure_tensor, structure_tensor_eigenvalues)
 from .match import match_descriptors
 from .peak import peak_local_max
-from .blob import blob_dog, blob_log, blob_doh
 from .template import match_template
-
 
 __all__ = ['canny',
            'daisy',

--- a/python/cucim/src/cucim/skimage/feature/_basic_features.py
+++ b/python/cucim/src/cucim/skimage/feature/_basic_features.py
@@ -6,10 +6,11 @@ from itertools import combinations_with_replacement
 import cupy as cp
 import numpy as np
 
-from .._shared._gradient import gradient
 from cucim.skimage import feature, filters
 from cucim.skimage._shared import utils
 from cucim.skimage.util import img_as_float32
+
+from .._shared._gradient import gradient
 
 
 def _texture_filter(gaussian_filtered):

--- a/python/cucim/src/cucim/skimage/feature/_canny.py
+++ b/python/cucim/src/cucim/skimage/feature/_canny.py
@@ -12,8 +12,8 @@ All rights reserved.
 Original author: Lee Kamentsky
 """
 import cupy as cp
-import cucim.skimage._vendored.ndimage as ndi
 
+import cucim.skimage._vendored.ndimage as ndi
 from cucim.skimage.util import dtype_limits
 
 from .._shared.filters import gaussian

--- a/python/cucim/src/cucim/skimage/feature/_hessian_det_appx.py
+++ b/python/cucim/src/cucim/skimage/feature/_hessian_det_appx.py
@@ -29,7 +29,7 @@ def _dtype_to_cuda_float_type(dtype):
     return cpp_float_types[dtype.type]
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_hessian_det_appx_kernel(dtype, large_int) -> cp.RawModule:
     """Loads all kernels in cuda/_hessian_det_appx.cu.
     Returns a cupy RawModule.

--- a/python/cucim/src/cucim/skimage/feature/blob.py
+++ b/python/cucim/src/cucim/skimage/feature/blob.py
@@ -42,7 +42,7 @@ def _dtype_to_cuda_float_type(dtype):
     return cpp_float_types[dtype.type]
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_prune_blob_rawmodule(dtype, large_int) -> cp.RawModule:
     """Loads the kernel according to dtype /cuda/blob.cu
     Returns a cupy RawModule.

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -171,10 +171,11 @@ def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     order : {'rc', 'xy'}, optional
-        This parameter allows for the use of reverse or forward order of
-        the image axes in gradient computation. 'rc' indicates the use of
-        the first axis initially (Hrr, Hrc, Hcc), whilst 'xy' indicates the
-        usage of the last axis initially (Hxx, Hxy, Hyy)
+        NOTE: 'xy' is only an option for 2D images, higher dimensions must
+        always use 'rc' order. This parameter allows for the use of reverse or
+        forward order of the image axes in gradient computation. 'rc' indicates
+        the use of the first axis initially (Hrr, Hrc, Hcc), whilst 'xy'
+        indicates the usage of the last axis initially (Hxx, Hxy, Hyy).
 
     Returns
     -------
@@ -187,6 +188,10 @@ def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
     image = img_as_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
+    if image.ndim > 2 and order == "xy":
+        raise ValueError("Order 'xy' is only supported for 2D images.")
+    if order not in ["rc", "xy"]:
+        raise ValueError(f"unrecognized order: {order}")
 
     if np.isscalar(sigma):
         sigma = (sigma,) * image.ndim
@@ -223,7 +228,7 @@ def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
 
     # 2.) apply the derivative along another axis as well
     axes = range(ndim)
-    if order == 'rc':
+    if order == 'xy':
         axes = reversed(axes)
     H_elems = [gaussian_(gradients[ax0], order=orders[ax1])
                for ax0, ax1 in combinations_with_replacement(axes, 2)]
@@ -257,10 +262,11 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     order : {'rc', 'xy'}, optional
-        This parameter allows for the use of reverse or forward order of
-        the image axes in gradient computation. 'rc' indicates the use of
-        the first axis initially (Hrr, Hrc, Hcc), whilst 'xy' indicates the
-        usage of the last axis initially (Hxx, Hxy, Hyy)
+        NOTE: 'xy' is only an option for 2D images, higher dimensions must
+        always use 'rc' order. This parameter allows for the use of reverse or
+        forward order of the image axes in gradient computation. 'rc' indicates
+        the use of the first axis initially (Hrr, Hrc, Hcc), whilst 'xy'
+        indicates the usage of the last axis initially (Hxx, Hxy, Hyy).
     use_gaussian_derivatives : boolean, optional
         Indicates whether the Hessian is computed by convolving with Gaussian
         derivatives, or by a simple finite-difference operation.
@@ -310,6 +316,10 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
     image = img_as_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
+    if image.ndim > 2 and order == "xy":
+        raise ValueError("Order 'xy' is only supported for 2D images.")
+    if order not in ["rc", "xy"]:
+        raise ValueError(f"unrecognized order: {order}")
 
     if use_gaussian_derivatives is None:
         use_gaussian_derivatives = False
@@ -333,7 +343,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
     gradients = gradient(gaussian_filtered)
     axes = range(image.ndim)
 
-    if order == "rc":
+    if order == "xy":
         axes = reversed(axes)
 
     H_elems = [

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -354,7 +354,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
     return H_elems
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_real_symmetric_2x2_det_kernel():
     return cp.ElementwiseKernel(
         in_params="F M00, F M01, F M11",
@@ -363,15 +363,13 @@ def _get_real_symmetric_2x2_det_kernel():
         name="cucim_skimage_symmetric_det22_kernel")
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_real_symmetric_3x3_det_kernel():
-
     operation = """
     det = M00 * (M11 * M22 - M12 * M12);
     det -= M01 * (M01 * M22 - M12 * M02);
     det += M02 * (M01 * M12 - M11 * M02);
     """
-
     return cp.ElementwiseKernel(
         in_params="F M00, F M01, F M02, F M11, F M12, F M22",
         out_params="F det",
@@ -447,7 +445,7 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
         return det
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_real_symmetric_2x2_eigvals_kernel(sort='ascending', abs_sort=False):
 
     operation = """
@@ -540,7 +538,7 @@ def _image_orthogonal_matrix22_eigvals(
     return eigs
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_real_symmetric_3x3_eigvals_kernel(sort='ascending', abs_sort=False):
 
     operation = """
@@ -889,9 +887,8 @@ def shape_index(image, sigma=1, mode="constant", cval=0):
         return (2.0 / np.pi) * np.arctan((l2 + l1) / (l2 - l1))
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_kitchen_rosenfeld_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F imx, F imy, F imxx, F imxy, F imyy',
         out_params='F response',
@@ -957,9 +954,8 @@ def corner_kitchen_rosenfeld(image, mode="constant", cval=0):
     return kernel(imx, imy, imxx, imxy, imyy, response)
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_corner_harris_k_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F Arr, F Acc, F Arc, float64 k',
         out_params='F response',
@@ -975,9 +971,8 @@ def _get_corner_harris_k_kernel():
     )
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_corner_harris_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F Arr, F Acc, F Arc, float64 eps',
         out_params='F response',
@@ -1068,9 +1063,8 @@ def corner_harris(image, method="k", k=0.05, eps=1e-6, sigma=1):
     return response
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_shi_tomasi_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F Arr, F Acc, F Arc',
         out_params='F response',
@@ -1145,9 +1139,8 @@ def corner_shi_tomasi(image, sigma=1):
     return kernel(Arr, Acc, Arc, response)
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_foerstner_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F Arr, F Acc, F Arc',
         out_params='F w, F q',

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -432,14 +432,7 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
             H = hessian_matrix(image, sigma)
             kernel(*H, det)
         else:
-            # # Compute determinant as the product of the eigenvalues.
-            # # This avoids the huge memory overhead of forming
-            # # `_symmetric_image` as in the code below.
-            # # Could optimize further by computing the determinant directly
-            # # using ElementwiseKernels rather than reusing the eigenvalue ones.
-            # H = hessian_matrix(image, sigma)
-            # evs = hessian_matrix_eigvals(H)
-            # return cp.prod(evs, axis=0)
+            # general, n-dimensional case (warning: high memory usage)
             hessian_mat_array = _symmetric_image(hessian_matrix(image, sigma))
             det = cp.linalg.det(hessian_mat_array)
         return det

--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -4,9 +4,9 @@ from itertools import combinations_with_replacement
 
 import cupy as cp
 import numpy as np
-import cucim.skimage._vendored.ndimage as ndi
 from scipy import spatial  # TODO: use cuSpatial if cKDTree becomes available
 
+import cucim.skimage._vendored.ndimage as ndi
 from cucim.skimage.util import img_as_float
 
 from .._shared._gradient import gradient

--- a/python/cucim/src/cucim/skimage/feature/peak.py
+++ b/python/cucim/src/cucim/skimage/feature/peak.py
@@ -1,10 +1,10 @@
 from warnings import warn
 
 import cupy as cp
-import cucim.skimage._vendored.ndimage as ndi
 import numpy as np
 from scipy.ndimage import find_objects as cpu_find_objects
 
+import cucim.skimage._vendored.ndimage as ndi
 # from ..filters import rank_order
 from cucim.skimage import measure
 

--- a/python/cucim/src/cucim/skimage/feature/tests/test_blob.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_blob.py
@@ -2,7 +2,6 @@ import math
 
 import cupy as cp
 import pytest
-
 from skimage.draw import disk
 from skimage.draw.draw3d import ellipsoid
 

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -129,11 +129,11 @@ def test_hessian_matrix(dtype):
     out_dtype = _supported_float_type(dtype)
     assert all(a.dtype == out_dtype for a in (Hrr, Hrc, Hcc))
     # fmt: off
-    assert_array_almost_equal(Hrr, cp.asarray([[0, 0,  0, 0, 0],    # noqa
+    assert_array_almost_equal(Hrr, cp.asarray([[0, 0,  2, 0, 0],    # noqa
                                                [0, 0,  0, 0, 0],    # noqa
-                                               [2, 0, -2, 0, 2],    # noqa
+                                               [0, 0, -2, 0, 0],    # noqa
                                                [0, 0,  0, 0, 0],    # noqa
-                                               [0, 0,  0, 0, 0]]))  # noqa
+                                               [0, 0,  2, 0, 0]]))  # noqa
 
     assert_array_almost_equal(Hrc, cp.asarray([[0,  0, 0,  0, 0],    # noqa
                                                [0,  1, 0, -1, 0],    # noqa
@@ -141,17 +141,36 @@ def test_hessian_matrix(dtype):
                                                [0, -1, 0,  1, 0],    # noqa
                                                [0,  0, 0,  0, 0]]))  # noqa
 
-    assert_array_almost_equal(Hcc, cp.asarray([[0, 0,  2, 0, 0],    # noqa
+    assert_array_almost_equal(Hcc, cp.asarray([[0, 0,  0, 0, 0],    # noqa
                                                [0, 0,  0, 0, 0],    # noqa
-                                               [0, 0, -2, 0, 0],    # noqa
+                                               [2, 0, -2, 0, 2],    # noqa
                                                [0, 0,  0, 0, 0],    # noqa
-                                               [0, 0,  2, 0, 0]]))  # noqa
+                                               [0, 0,  0, 0, 0]]))  # noqa
     # fmt: on
 
     with expected_warnings(["use_gaussian_derivatives currently defaults"]):
         # FutureWarning warning when use_gaussian_derivatives is not
         # specified.
         hessian_matrix(square, sigma=0.1, order="rc")
+
+
+@pytest.mark.parametrize('use_gaussian_derivatives', [False, True])
+def test_hessian_matrix_order(use_gaussian_derivatives):
+    square = cp.zeros((5, 5), dtype=float)
+    square[2, 2] = 4
+
+    Hxx, Hxy, Hyy = hessian_matrix(
+        square, sigma=0.1, order="xy",
+        use_gaussian_derivatives=use_gaussian_derivatives)
+
+    Hrr, Hrc, Hcc = hessian_matrix(
+        square, sigma=0.1, order="rc",
+        use_gaussian_derivatives=use_gaussian_derivatives)
+
+    # verify results are equivalent, just reversed in order
+    cp.testing.assert_allclose(Hxx, Hcc, atol=1e-30)
+    cp.testing.assert_allclose(Hxy, Hrc, atol=1e-30)
+    cp.testing.assert_allclose(Hyy, Hrr, atol=1e-30)
 
 
 def test_hessian_matrix_3d():
@@ -168,6 +187,21 @@ def test_hessian_matrix_3d():
                                     [0, -1,  0,  1,  0],    # noqa
                                     [0,  0,  0,  0,  0]]))  # noqa
     # fmt: on
+
+
+@pytest.mark.parametrize('use_gaussian_derivatives', [False, True])
+def test_hessian_matrix_3d_xy(use_gaussian_derivatives):
+
+    img = cp.ones((5, 5, 5))
+
+    # order="xy" is only permitted for 2D
+    with pytest.raises(ValueError):
+        hessian_matrix(img, sigma=0.1, order="xy",
+                       use_gaussian_derivatives=use_gaussian_derivatives)
+
+    with pytest.raises(ValueError):
+        hessian_matrix(img, sigma=0.1, order='nonexistant',
+                       use_gaussian_derivatives=use_gaussian_derivatives)
 
 
 @pytest.mark.parametrize('dtype', [cp.float16, cp.float32, cp.float64])

--- a/python/cucim/src/cucim/skimage/filters/_gabor.py
+++ b/python/cucim/src/cucim/skimage/filters/_gabor.py
@@ -1,8 +1,8 @@
 import math
 
 import cupy as cp
-import cucim.skimage._vendored.ndimage as ndi
 
+import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import _supported_float_type, check_nD, warn
 

--- a/python/cucim/src/cucim/skimage/filters/_median.py
+++ b/python/cucim/src/cucim/skimage/filters/_median.py
@@ -4,8 +4,9 @@ import cupy as cp
 import numpy as np
 
 import cucim.skimage._vendored.ndimage as ndi
+
 from .._shared.utils import deprecate_kwarg
-from ._median_hist import _can_use_histogram, _median_hist, KernelResourceError
+from ._median_hist import KernelResourceError, _can_use_histogram, _median_hist
 
 try:
     from math import prod

--- a/python/cucim/src/cucim/skimage/filters/edges.py
+++ b/python/cucim/src/cucim/skimage/filters/edges.py
@@ -13,6 +13,7 @@ import math
 
 import cupy as cp
 import numpy as np
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import _supported_float_type, check_nD

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -93,7 +93,7 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     return hessian_eigenvalues
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_circulant_init_kernel(ndim, alpha):
     operation = f"""
     for (int x=0; x < {ndim}; x++) {{
@@ -284,9 +284,8 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     return filtered_max  # Return pixel-wise max over all sigmas.
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_frangi2d_sum_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F lambda1, F lambda2',  # noqa
         out_params='F r_g',
@@ -300,9 +299,8 @@ def _get_frangi2d_sum_kernel():
     )
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_frangi2d_inner_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F lambda1, F lambda2, F r_g, float64 beta_sq, float64 gamma_sq',  # noqa
         out_params='F result',
@@ -328,9 +326,8 @@ def _get_frangi2d_inner_kernel():
     )
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_frangi3d_sum_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F lambda1, F lambda2, F lambda3',  # noqa
         out_params='F r_g',
@@ -345,9 +342,8 @@ def _get_frangi3d_sum_kernel():
     )
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_frangi3d_inner_kernel():
-
     return cp.ElementwiseKernel(
         in_params='F lambda1, F lambda2, F lambda3, F r_g, float64 alpha_sq, float64 beta_sq, float64 gamma_sq',  # noqa
         out_params='F result',

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -201,7 +201,6 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
         if max_val > 0:
             vals /= max_val
         filtered_max = cp.maximum(filtered_max, vals)
-        # print(f"{black_ridges=}, {image.max()=}, {sigma=}, {filtered_max=}")
 
     return filtered_max  # Return pixel-wise max over all sigmas.
 

--- a/python/cucim/src/cucim/skimage/filters/thresholding.py
+++ b/python/cucim/src/cucim/skimage/filters/thresholding.py
@@ -6,13 +6,13 @@ from collections.abc import Iterable
 
 import cupy as cp
 import numpy as np
-import cucim.skimage._vendored.ndimage as ndi
 from skimage.filters import threshold_isodata as _threshold_isodata_cpu
 from skimage.filters import threshold_minimum as _threshold_minimum_cpu
 from skimage.filters import threshold_multiotsu as _threshold_multiotsu_cpu
 from skimage.filters import threshold_otsu as _threshold_otsu_cpu
 from skimage.filters import threshold_yen as _threshold_yen_cpu
 
+import cucim.skimage._vendored.ndimage as ndi
 from cucim import _misc
 
 from .._shared.filters import gaussian

--- a/python/cucim/src/cucim/skimage/measure/_blur_effect.py
+++ b/python/cucim/src/cucim/skimage/measure/_blur_effect.py
@@ -1,4 +1,5 @@
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from ..color import rgb2gray

--- a/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments_analytical.py
@@ -4,7 +4,6 @@ import math
 import cupy as cp
 import numpy as np
 
-
 _order0_or_1 = """
     mc[0] = m[0];
 """

--- a/python/cucim/src/cucim/skimage/measure/_regionprops_utils.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops_utils.py
@@ -3,6 +3,7 @@ import math
 import cupy as cp
 import cupyx.scipy.ndimage as ndi
 import numpy as np
+
 from .._shared.utils import deprecate_kwarg
 
 # Don't allocate STREL_* on GPU as we don't know in advance which device

--- a/python/cucim/src/cucim/skimage/measure/profile.py
+++ b/python/cucim/src/cucim/skimage/measure/profile.py
@@ -2,6 +2,7 @@ import math
 
 import cupy as cp
 import numpy as np
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import _fix_ndimage_mode, _validate_interpolation_order

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -11,10 +11,10 @@ from skimage.segmentation import slic
 
 from cucim.skimage import transform
 from cucim.skimage._shared._warnings import expected_warnings
-from cucim.skimage.measure._regionprops import \
-    _inertia_eigvals_to_axes_lengths_3D  # noqa
 from cucim.skimage.measure import (euler_number, perimeter, perimeter_crofton,
                                    regionprops, regionprops_table)
+from cucim.skimage.measure._regionprops import \
+    _inertia_eigvals_to_axes_lengths_3D  # noqa
 from cucim.skimage.measure._regionprops import (COL_DTYPES, OBJECT_COLUMNS,
                                                 PROPS, _parse_docs,
                                                 _props_to_dict,

--- a/python/cucim/src/cucim/skimage/metrics/_contingency_table.py
+++ b/python/cucim/src/cucim/skimage/metrics/_contingency_table.py
@@ -1,5 +1,5 @@
-import cupyx.scipy.sparse as sparse
 import cupy as cp
+import cupyx.scipy.sparse as sparse
 
 __all__ = ['contingency_table']
 

--- a/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
@@ -134,8 +134,9 @@ def structural_similarity(im1, im2,
     of Y), so one cannot calculate a channel-averaged SSIM with a single call
     to this function, as identical ranges are assumed for each channel.
 
-    To match the implementation of Wang et. al. [1]_, set `gaussian_weights`
-    to True, `sigma` to 1.5, and `use_sample_covariance` to False.
+    To match the implementation of Wang et al. [1]_, set `gaussian_weights`
+    to True, `sigma` to 1.5, `use_sample_covariance` to False, and
+    specify the `data_range` argument.
 
     .. versionchanged:: 0.16
         This function was renamed from ``skimage.measure.compare_ssim`` to
@@ -236,11 +237,22 @@ def structural_similarity(im1, im2,
         raise ValueError('Window size must be odd.')
 
     if data_range is None:
+        if (cp.issubdtype(im1.dtype, cp.floating) or
+            cp.issubdtype(im2.dtype, cp.floating)):
+            raise ValueError(
+                'Since image dtype is floating point, you must specify '
+                'the data_range parameter. Please read the documentation '
+                'carefully (including the note). It is recommended that '
+                'you always specify the data_range anyway.')
         if im1.dtype != im2.dtype:
-            warn("Inputs have mismatched dtype.  Setting data_range based on "
+            warn("Inputs have mismatched dtypes.  Setting data_range based on "
                  "im1.dtype.", stacklevel=2)
         dmin, dmax = dtype_range[im1.dtype.type]
         data_range = dmax - dmin
+        if cp.issubdtype(im1.dtype, cp.integer) and (im1.dtype != cp.uint8):
+            warn("Setting data_range based on im1.dtype. " +
+                 ("data_range = %.0f. " % data_range) +
+                 "Please specify data_range explicitly to avoid mistakes.", stacklevel=2)
 
     ndim = im1.ndim
 

--- a/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
@@ -32,9 +32,8 @@ _ssim_operation = """
 """
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_ssim_kernel():
-
     return cp.ElementwiseKernel(
         in_params='float64 cov_norm, F ux, F uy, F uxx, F uyy, F uxy, float64 data_range, float64 K1, float64 K2',  # noqa
         out_params='F ssim',
@@ -43,9 +42,8 @@ def _get_ssim_kernel():
     )
 
 
-@cp.memoize()
+@cp.memoize(for_each_device=True)
 def _get_ssim_grad_kernel():
-
     return cp.ElementwiseKernel(
         in_params='float64 cov_norm, F ux, F uy, F uxx, F uyy, F uxy, float64 data_range, float64 K1, float64 K2',  # noqa
         out_params='F ssim, F grad_temp1, F grad_temp2, F grad_temp3',

--- a/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
@@ -1,6 +1,7 @@
 import functools
 
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared import utils

--- a/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/_structural_similarity.py
@@ -242,8 +242,10 @@ def structural_similarity(im1, im2,
         raise ValueError('Window size must be odd.')
 
     if data_range is None:
-        if (cp.issubdtype(im1.dtype, cp.floating) or
-            cp.issubdtype(im2.dtype, cp.floating)):
+        if (
+            cp.issubdtype(im1.dtype, cp.floating) or
+            cp.issubdtype(im2.dtype, cp.floating)
+        ):
             raise ValueError(
                 'Since image dtype is floating point, you must specify '
                 'the data_range parameter. Please read the documentation '
@@ -257,7 +259,8 @@ def structural_similarity(im1, im2,
         if cp.issubdtype(im1.dtype, cp.integer) and (im1.dtype != cp.uint8):
             warn("Setting data_range based on im1.dtype. " +
                  ("data_range = %.0f. " % data_range) +
-                 "Please specify data_range explicitly to avoid mistakes.", stacklevel=2)
+                 "Please specify data_range explicitly to avoid mistakes.",
+                 stacklevel=2)
 
     ndim = im1.ndim
 

--- a/python/cucim/src/cucim/skimage/metrics/_variation_of_information.py
+++ b/python/cucim/src/cucim/skimage/metrics/_variation_of_information.py
@@ -1,7 +1,8 @@
 import cupy as cp
 import cupyx.scipy.sparse as sparse
-from ._contingency_table import contingency_table
+
 from .._shared.utils import check_shape_equality
+from ._contingency_table import contingency_table
 
 __all__ = ['variation_of_information']
 

--- a/python/cucim/src/cucim/skimage/metrics/tests/test_segmentation_metrics.py
+++ b/python/cucim/src/cucim/skimage/metrics/tests/test_segmentation_metrics.py
@@ -1,12 +1,10 @@
 import cupy as cp
 import pytest
+from cupy.testing import assert_array_equal
 from numpy.testing import assert_almost_equal, assert_equal
 
-from cucim.skimage.metrics import (adapted_rand_error,
-                                   variation_of_information,
-                                   contingency_table)
-
-from cupy.testing import assert_array_equal
+from cucim.skimage.metrics import (adapted_rand_error, contingency_table,
+                                   variation_of_information)
 
 
 def test_contingency_table():

--- a/python/cucim/src/cucim/skimage/metrics/tests/test_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/tests/test_structural_similarity.py
@@ -238,7 +238,9 @@ def test_mssim_vs_legacy(dtype):
 
 
 def test_mssim_mixed_dtype():
-    mssim = structural_similarity(cam, cam_noisy.astype(cam.dtype), data_range=255.0)
+    mssim = structural_similarity(
+        cam, cam_noisy.astype(cam.dtype), data_range=255.0
+    )
     with expected_warnings(["Inputs have mismatched dtypes"]):
         mssim_mixed = structural_similarity(cam, cam_noisy.astype(cp.int16))
     assert_almost_equal(mssim, mssim_mixed)

--- a/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
@@ -1,9 +1,9 @@
 import warnings
 
 import cupy as cp
-import cucim.skimage._vendored.ndimage as ndi
 import numpy as np
 
+import cucim.skimage._vendored.ndimage as ndi
 from cucim.core.operations.morphology import distance_transform_edt
 
 from .._shared.utils import check_nD, deprecate_kwarg

--- a/python/cucim/src/cucim/skimage/morphology/binary.py
+++ b/python/cucim/src/cucim/skimage/morphology/binary.py
@@ -4,6 +4,7 @@ Binary morphological operations
 import functools
 
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import deprecate_kwarg

--- a/python/cucim/src/cucim/skimage/morphology/gray.py
+++ b/python/cucim/src/cucim/skimage/morphology/gray.py
@@ -4,6 +4,7 @@ Grayscale morphological operations
 import functools
 
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import deprecate_kwarg

--- a/python/cucim/src/cucim/skimage/morphology/misc.py
+++ b/python/cucim/src/cucim/skimage/morphology/misc.py
@@ -2,6 +2,7 @@
 import functools
 
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import remove_arg, warn

--- a/python/cucim/src/cucim/skimage/restoration/j_invariant.py
+++ b/python/cucim/src/cucim/skimage/restoration/j_invariant.py
@@ -3,6 +3,7 @@ import itertools
 
 import cupy as cp
 import numpy as np
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import _supported_float_type

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_denoise.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_denoise.py
@@ -167,4 +167,5 @@ def test_denoise_tv_chambolle_weighting():
     denoised_2d = restoration.denoise_tv_chambolle(img2d, weight=w)
     denoised_4d = restoration.denoise_tv_chambolle(img4d, weight=w)
     assert (structural_similarity(denoised_2d,
-                                  denoised_4d[:, :, 0, 0]) > 0.99)
+                                  denoised_4d[:, :, 0, 0],
+                                  data_range=1.0) > 0.98)

--- a/python/cucim/src/cucim/skimage/segmentation/boundaries.py
+++ b/python/cucim/src/cucim/skimage/segmentation/boundaries.py
@@ -1,4 +1,5 @@
 import cupy as cp
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import _supported_float_type

--- a/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
+++ b/python/cucim/src/cucim/skimage/segmentation/morphsnakes.py
@@ -4,8 +4,8 @@ from itertools import cycle
 import cupy as cp
 import numpy as np
 from cupyx import rsqrt
-import cucim.skimage._vendored.ndimage as ndi
 
+import cucim.skimage._vendored.ndimage as ndi
 from cucim import _misc
 
 from .._shared._gradient import gradient

--- a/python/cucim/src/cucim/skimage/segmentation/random_walker_segmentation.py
+++ b/python/cucim/src/cucim/skimage/segmentation/random_walker_segmentation.py
@@ -9,9 +9,10 @@ import math
 
 import cupy as cp
 import numpy as np
-import cucim.skimage._vendored.ndimage as ndi
 from cupyx.scipy import sparse
 from cupyx.scipy.sparse.linalg import cg, spsolve
+
+import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared import utils
 from ..util import img_as_float

--- a/python/cucim/src/cucim/skimage/transform/_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/_warps.py
@@ -2,6 +2,7 @@ import math
 
 import cupy as cp
 import numpy as np
+
 import cucim.skimage._vendored.ndimage as ndi
 
 from .._shared.utils import (_to_ndimage_mode, _validate_interpolation_order,

--- a/python/cucim/src/cucim/skimage/util/dtype.py
+++ b/python/cucim/src/cucim/skimage/util/dtype.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from warnings import warn
 
 import cupy as cp

--- a/python/cucim/src/cucim/skimage/util/dtype.py
+++ b/python/cucim/src/cucim/skimage/util/dtype.py
@@ -27,13 +27,19 @@ _integer_ranges = {t: (cp.iinfo(t).min, cp.iinfo(t).max)
                    for t in _integer_types}
 dtype_range = {bool: (False, True),
                cp.bool_: (False, True),
-               cp.bool8: (False, True),
                float: (-1, 1),
                cp.float_: (-1, 1),
                cp.float16: (-1, 1),
                cp.float32: (-1, 1),
                cp.float64: (-1, 1)}
 dtype_range.update(_integer_ranges)
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+    # cp.bool8 is a deprecated alias of cp.bool_
+    if hasattr(cp, 'bool8'):
+        dtype_range[cp.bool8] = (False, True)
 
 _supported_types = list(dtype_range.keys())
 

--- a/python/cucim/src/cucim/skimage/util/lookfor.py
+++ b/python/cucim/src/cucim/skimage/util/lookfor.py
@@ -13,13 +13,19 @@ def lookfor(what):
 
     Examples
     --------
-    >>> import skimage
-    >>> skimage.lookfor('regular_grid')  # doctest: +SKIP
-    Search results for 'regular_grid'
-    ---------------------------------
-    skimage.lookfor
-        Do a keyword search on scikit-image docstrings.
-    skimage.util.regular_grid
-        Find `n_points` regularly spaced along `ar_shape`.
+    >>> import cucim.skimage
+    >>> cucim.skimage.lookfor('median')  # doctest: +SKIP
+    Search results for 'median'
+    ---------------------------
+    cucim.skimage.filters.median
+        Return local median of an image.
+    cucim.skimage.measure.block_reduce
+        Downsample image by applying function `func` to local blocks.
+    cucim.skimage.filters.threshold_local
+        Compute a threshold mask image based on local pixel neighborhood.
+    cucim.skimage.registration.optical_flow_ilk
+        Coarse to fine optical flow estimator.
+    cucim.skimage.registration.optical_flow_tvl1
+        Coarse to fine optical flow estimator.
     """
     return np.lookfor(what, sys.modules[__name__.split('.')[0]])

--- a/python/cucim/src/cucim/skimage/util/tests/test_dtype.py
+++ b/python/cucim/src/cucim/skimage/util/tests/test_dtype.py
@@ -110,18 +110,18 @@ def test_copy():
 
 
 def test_bool():
-    img_ = cp.zeros((10, 10), bool)
-    img8 = cp.zeros((10, 10), cp.bool8)
+    img = cp.zeros((10, 10), bool)
+    img_ = cp.zeros((10, 10), cp.bool_)
+    img[1, 1] = True
     img_[1, 1] = True
-    img8[1, 1] = True
     for (func, dt) in [(img_as_int, cp.int16),
                        (img_as_float, cp.float64),
                        (img_as_uint, cp.uint16),
                        (img_as_ubyte, cp.ubyte)]:
+        converted = func(img)
+        assert cp.sum(converted) == dtype_range[dt][1]
         converted_ = func(img_)
         assert cp.sum(converted_) == dtype_range[dt][1]
-        converted8 = func(img8)
-        assert cp.sum(converted8) == dtype_range[dt][1]
 
 
 def test_clobber():


### PR DESCRIPTION
a few additional late additions from skimage 0.20
- better warnings/errors related to `data_range` for `structural_similarity`
- fix bug where order of the returned elements from `hessian_matrix` was reversed
- fix stacklevel of warning in lab2xyz

and two minor updates to previously merged cucim 2022.12.00 MRs
- allow a device scalar for the `data_range` argument for `structural_similarity`
- provide dedicated 2D and 3D kernels for `hessian_matrix_det`

Each of these are in separate commits, so can be reveiwed independently