### PR TITLE
Build CUDA `11.8` and Python `3.10` Packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   cpp-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   python-build:
     needs: [cpp-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -46,7 +46,7 @@ jobs:
   upload-conda:
     needs: [cpp-build, python-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,25 +17,25 @@ jobs:
       - conda-python-build
       - conda-python-tests
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@cuda-118
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@cuda-118
   conda-cpp-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@cuda-118
     with:
       build_type: pull-request
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,18 +107,19 @@ cd $CUCIM_HOME
 ```
 ## Local Development using Conda Environment (for gcc 9.x and nvcc 11.0.x)
 
-Conda can be used to setup GCC 9.x, CUDA Toolkit (including nvcc) 11.0.x, and other dependent libraries (as shown in `./conda/environments/env.yml`) for building cuCIM.
+Conda can be used to setup an environment which includes all of the necessary dependencies (as shown in `./conda/environments/all_cuda-118_arch-x86_64.yaml`) for building cuCIM.
 
 Otherwise, you may need to install dependencies (such as zlib, xz, yasm) through your OS's package manager (`apt`, `yum`, and so on).
 
 
 ### Creating the Conda Development Environment `cucim`
 
-Note that `./conda/environments/env.yml` is currently set to use gcc 9.x (gxx_linux-64) and CUDA 11.0.x (cudatoolkit & cudatoolkit-dev). If you want to change the version of gcc or CUDA toolkit
-package, please update `./conda/environments/env.yml` before executing the following commands.
+Note that `./conda/environments/all_cuda-118_arch-x86_64.yaml` is currently set to use specific versions of gcc (gxx_linux-64) and CUDA (cudatoolkit & cudatoolkit-dev).
+
+If you want to change the version of gcc or CUDA toolkit package, please update `./conda/environments/all_cuda-118_arch-x86_64.yaml` before executing the following commands.
 
 ```bash
-conda env create -f ./conda/environments/env.yml
+conda env create -n cucim -f ./conda/environments/all_cuda-118_arch-x86_64.yaml
 # activate the environment
 conda activate cucim
 ```

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - libwebp-base
 - nbsphinx
 - ninja
-- numpy
+- numpy >=1.21.3
 - numpydoc
 - nvcc_linux-64=11.8
 - openslide-python>=1.1.2

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - click
 - cmake>=3.23.1,!=3.25.0
-- cudatoolkit=11.5
+- cudatoolkit=11.8
 - cupy >=10,<12.0.0a0
 - cxx-compiler
 - gcc_linux-64=9.*
@@ -23,7 +23,7 @@ dependencies:
 - ninja
 - numpy
 - numpydoc
-- nvcc_linux-64=11.5
+- nvcc_linux-64=11.8
 - openslide-python>=1.1.2
 - pip
 - pre-commit
@@ -33,7 +33,7 @@ dependencies:
 - pytest-lazy-fixture>=0.6.3
 - pytest-xdist
 - pytest>=6.2.4
-- python>=3.8,<3.10
+- python>=3.8,<3.11
 - recommonmark
 - scikit-image >=0.19.0,<0.20.0a0
 - scipy
@@ -46,4 +46,4 @@ dependencies:
 - zstd
 - pip:
   - opencv-python-headless>=4.6
-name: all_cuda-115_arch-x86_64
+name: all_cuda-118_arch-x86_64

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - cmake >=3.23.1,!=3.25.0
+    - make
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}
     - cupy >=10,<12.0.0a0
     - libcucim ={{ version }}
-    - numpy 1.19
+    - numpy >=1.21.3
     - python
     - scikit-image >=0.19.0,<0.20.0a0
     - scipy

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - binutils
     - cmake >=3.23.1,!=3.25.0
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - {{ compiler("cxx") }}
     - binutils
     - cmake >=3.23.1,!=3.25.0
+    - make
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
     - yasm # [x86_64]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["11.5"]
+      cuda: ["11.8"]
       arch: [x86_64]
     includes:
       - build
@@ -58,14 +58,14 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
-              cuda: "11.5"
+              cuda: "11.8"
             packages:
-              - nvcc_linux-64=11.5
+              - nvcc_linux-64=11.8
           - matrix:
               arch: aarch64
-              cuda: "11.5"
+              cuda: "11.8"
             packages:
-              - nvcc_linux-aarch64=11.5
+              - nvcc_linux-aarch64=11.8
   checks:
     common:
       - output_types: [conda, requirements]
@@ -87,6 +87,10 @@ dependencies:
               cuda: "11.5"
             packages:
               - cudatoolkit=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cudatoolkit=11.8
   doc:
     common:
       - output_types: [conda, requirements]
@@ -110,8 +114,12 @@ dependencies:
             packages:
               - python=3.9
           - matrix:
+              py: "3.10"
             packages:
-              - python>=3.8,<3.10
+              - python=3.10
+          - matrix:
+            packages:
+              - python>=3.8,<3.11
   run:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -129,7 +129,7 @@ dependencies:
           - jbig
           - jpeg
           - libwebp-base
-          - numpy
+          - numpy >=1.21.3
           - scikit-image >=0.19.0,<0.20.0a0
           - scipy
           - xz

--- a/python/cucim/setup.py
+++ b/python/cucim/setup.py
@@ -60,6 +60,7 @@ opts = dict(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         # 'Operating System :: OS Independent',
         # 'Operating System :: Unix',
         # 'Operating System :: POSIX',


### PR DESCRIPTION
This PR updates `cucim` to build against branch [cuda-118](https://github.com/rapidsai/shared-action-workflows/compare/cuda-118) of the `shared-action-workflow` repository.

That branch contains updates for CUDA `11.8` and Python `3.10` packages.

It also includes some minor file renames.
