### PR TITLE
Update `numpy` version specifier

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - libwebp-base
 - nbsphinx
 - ninja
-- numpy >=1.21.3
+- numpy >=1.21.3, <1.24
 - numpydoc
 - nvcc_linux-64=11.8
 - openslide-python>=1.1.2

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}
     - cupy >=10,<12.0.0a0
     - libcucim ={{ version }}
-    - numpy >=1.21.3
+    - numpy >=1.21.3,<1.24
     - python
     - scikit-image >=0.19.0,<0.20.0a0
     - scipy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -129,7 +129,7 @@ dependencies:
           - jbig
           - jpeg
           - libwebp-base
-          - numpy >=1.21.3
+          - numpy >=1.21.3, <1.24
           - scikit-image >=0.19.0,<0.20.0a0
           - scipy
           - xz


### PR DESCRIPTION
This PR updates the `numpy` version specifier for `cucim`.

It was previously updated in [this commit](https://github.com/rapidsai/cucim/pull/476/commits/043810aa6115b6b7183535037f6d9366769e6ece) to enable publishing Python `3.10` packages.

However, since there was no maximum version in that specifier, `conda` was picking up the latest version of `numpy` (`1.24.1`) which is incompatible with `cudf`'s version of `numba` ([`numba>=0.56.2`](https://github.com/rapidsai/cudf/blob/36b07f13480d8f7ba18274cb3a63f06855d848ff/conda/recipes/cudf/meta.yaml#L52)).

For instance, if you try to run this: `mamba create -n test 'numba>=0.56.2' 'numpy>=1.24.1'`, it will fail to solve.

Running with the new version specifier in this PR does solve: `mamba create -n test 'numba>=0.56.2' 'numpy>=1.21.3,<1.24'`.

Therefore, this maximum version limit seems necessary for `cucim` to be compatible with the rest of RAPIDS.