### PR TITLE
Improve rank filtering performance by removing use of footprint kernel when possible

### DIFF
--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1126,12 +1126,8 @@ def _rank_filter(input, get_rank, size=None, footprint=None, output=None,
     kernel = _get_rank_kernel(filter_size, rank, mode, footprint_shape,
                               offsets, float(cval), int_type,
                               has_weights=has_weights)
-    if has_weights:
-        return _filters_core._call_kernel(kernel, input, footprint, output,
-                                          weights_dtype=bool)
-    else:
-        return _filters_core._call_kernel(kernel, input, None, output,
-                                          weights_dtype=bool)
+    return _filters_core._call_kernel(kernel, input, None, output,
+                                      weights_dtype=bool)
 
 
 __SHELL_SORT = '''

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1117,11 +1117,11 @@ def _rank_filter(input, get_rank, size=None, footprint=None, output=None,
         min_max_op = None
     if min_max_op is not None:
         if sizes is not None:
-            return _min_or_max_filter(input, sizes[0], None, None, output, mode,
-                                      cval, origins, min_max_op)
+            return _min_or_max_filter(input, sizes[0], None, None, output,
+                                      mode, cval, origins, min_max_op)
         else:
-            return _min_or_max_filter(input, None, footprint, None, output, mode,
-                                      cval, origins, min_max_op)
+            return _min_or_max_filter(input, None, footprint, None, output,
+                                      mode, cval, origins, min_max_op)
     offsets = _filters_core._origins_to_offsets(origins, footprint_shape)
     kernel = _get_rank_kernel(filter_size, rank, mode, footprint_shape,
                               offsets, float(cval), int_type,

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -62,10 +62,14 @@ def _check_nd_args(input, weights, mode, origin, wghts_name='filter weights',
     if weights is not None:
         # Weights must always be less than 2 GiB
         if weights.nbytes >= (1 << 31):
-            raise RuntimeError('weights must be 2 GiB or less, use FFTs instead')
+            raise RuntimeError(
+                "weights must be 2 GiB or less, use FFTs instead"
+            )
         weight_dims = [x for x in weights.shape if x != 0]
         if len(weight_dims) != input.ndim:
-            raise RuntimeError('{} array has incorrect shape'.format(wghts_name))
+            raise RuntimeError(
+                "{} array has incorrect shape".format(wghts_name)
+            )
     elif sizes is None:
         raise ValueError("must specify either weights array or sizes")
     else:

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -118,7 +118,7 @@ def _run_1d_filters(filters, input, args, output, mode, cval, origin=0,
     return input
 
 
-def _call_kernel(kernel, input, weights=None, output=None, structure=None,
+def _call_kernel(kernel, input, weights, output, structure=None,
                  weights_dtype=numpy.float64, structure_dtype=numpy.float64):
     """
     Calls a constructed ElementwiseKernel. The kernel must take an input image,

--- a/python/cucim/src/cucim/skimage/filters/_median.py
+++ b/python/cucim/src/cucim/skimage/filters/_median.py
@@ -137,7 +137,9 @@ def median(image, footprint=None, out=None, mode='nearest', cval=0.0,
     if algorithm == 'sorting':
         can_use_histogram = False
     elif algorithm in ['auto', 'histogram']:
-        can_use_histogram, reason = _can_use_histogram(image, footprint, footprint_shape)
+        can_use_histogram, reason = _can_use_histogram(
+            image, footprint, footprint_shape
+        )
     else:
         raise ValueError(f"unknown algorithm: {algorithm}")
 

--- a/python/cucim/src/cucim/skimage/filters/_median_hist.py
+++ b/python/cucim/src/cucim/skimage/filters/_median_hist.py
@@ -230,7 +230,7 @@ def _check_global_scratch_space_size(
     return (n_fine + n_coarse) * cp.dtype(hist_dtype).itemsize
 
 
-def _can_use_histogram(image, footprint):
+def _can_use_histogram(image, footprint, footprint_shape=None):
     """Validate compatibility with histogram-based median.
 
     Parameters
@@ -255,23 +255,32 @@ def _can_use_histogram(image, footprint):
         return False, "Only 8 and 16-bit integer image types (signed or "
         "unsigned)."
 
+    if footprint is None:
+        if footprint_shape is None:
+            raise ValueError(
+                "must provide either footprint or footprint_shape"
+            )
+    else:
+        footprint_shape = footprint.shape
+
     # only odd-sized footprints are supported
-    if not all(s % 2 == 1 for s in footprint.shape):
+    if not all(s % 2 == 1 for s in footprint_shape):
         return False, "footprint must have odd size on both axes"
 
-    if any(s == 1 for s in footprint.shape):
+    if any(s == 1 for s in footprint_shape):
         return False, "footprint must have size >= 3"
 
     # footprint radius can't be larger than the image
     # TODO: need to check if we need this exact restriction
     #       (may be specific to OpenCV's boundary handling)
-    radii = tuple(s // 2 for s in footprint.shape)
+    radii = tuple(s // 2 for s in footprint_shape)
     if any(r > s for r, s in zip(radii, image.shape)):
         return False, "footprint half-width cannot exceed the image extent"
 
-    # only fully populated footprint is supported
-    if not np.all(footprint):  # synchronizes!
-        return False, "footprint must be 1 everywhere"
+    if footprint is not None:
+        # only fully populated footprint is supported
+        if not np.all(footprint):  # synchronizes!
+            return False, "footprint must be 1 everywhere"
 
     return True, None
 
@@ -439,7 +448,17 @@ def _median_hist(image, footprint, output=None, mode='mirror', cval=0,
             "Use of a user-defined output array has not been implemented"
         )
 
-    compatible_image, reason = _can_use_histogram(image, footprint)
+    if footprint is None:
+        footprint_shape = (3,) * image.ndim
+        med_pos = prod(footprint_shape) // 2
+    elif isinstance(footprint, tuple):
+        footprint_shape = footprint
+        footprint = None
+        med_pos = prod(footprint_shape) // 2
+    else:
+        footprint_shape = footprint.shape
+        med_pos = footprint.size // 2
+    compatible_image, reason = _can_use_histogram(image, footprint, footprint_shape)
     if not compatible_image:
         raise ValueError(reason)
 
@@ -451,13 +470,12 @@ def _median_hist(image, footprint, output=None, mode='mirror', cval=0,
     if image.dtype.kind not in 'iu':
         raise ValueError("only integer-type images are accepted")
 
-    radii = tuple(s // 2 for s in footprint.shape)
+    radii = tuple(s // 2 for s in footprint_shape)
     # med_pos is the index corresponding to the median
     # (calculation here assumes all elements of the footprint are True)
-    med_pos = footprint.size // 2
 
     params = _get_kernel_params(
-        image, footprint.shape, value_range, partitions
+        image, footprint_shape, value_range, partitions
     )
 
     # pad as necessary to avoid boundary artifacts

--- a/python/cucim/src/cucim/skimage/filters/_median_hist.py
+++ b/python/cucim/src/cucim/skimage/filters/_median_hist.py
@@ -458,7 +458,9 @@ def _median_hist(image, footprint, output=None, mode='mirror', cval=0,
     else:
         footprint_shape = footprint.shape
         med_pos = footprint.size // 2
-    compatible_image, reason = _can_use_histogram(image, footprint, footprint_shape)
+    compatible_image, reason = _can_use_histogram(
+        image, footprint, footprint_shape
+    )
     if not compatible_image:
         raise ValueError(reason)
 

--- a/python/cucim/src/cucim/skimage/filters/tests/test_median.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_median.py
@@ -69,16 +69,22 @@ def test_selem_kwarg_deprecation(image):
         (3, 3), (5, 5), (9, 15), (2, 2), (1, 1), (2, 7), (23, 23), (15, 35),
     ]
 )
+@pytest.mark.parametrize('footprint_tuple', (False, True))
 @pytest.mark.parametrize('out', [None, cp.uint8, cp.float32, 'array'])
-def test_median_behavior(camera, behavior, func, mode, footprint_shape, out):
-    footprint = cp.ones(footprint_shape, dtype=bool)
+def test_median_behavior(
+    camera, behavior, func, mode, footprint_shape, footprint_tuple, out
+):
+    if footprint_tuple:
+        footprint = footprint_shape
+    else:
+        footprint = cp.ones(footprint_shape, dtype=bool)
     cam2 = camera[:, :177]  # use anisotropic size
     assert cam2.dtype == cp.uint8
     if out == 'array':
         out = cp.zeros_like(cam2)
     assert_allclose(
         median(cam2, footprint, mode=mode, behavior=behavior, out=out),
-        func(cam2, size=footprint.shape, mode=mode, output=out),
+        func(cam2, size=footprint_shape, mode=mode, output=out),
     )
 
 


### PR DESCRIPTION
In many cases such as rank filtering, if all elements of the kernel array are equal to one, then there is no reason to pay the overhead of allocating the footprint or checking its values during the filtering operation.

This MR is a small update to vendored CuPy ndimage code to avoid overhead of footprint creation and use when possible. 

Will update with benchmark results of acceleration vs. the kernel size. It is approximately a 2x improvement for small kernels (e.g. 3x3, 5x5, 3x3x3) approaching no acceleration for larger kernel sizes.