### PR TITLE
Add disambiguation option to phase_cross_correlation (skimage 0.20 feature)

### DIFF
--- a/python/cucim/src/cucim/skimage/color/colorconv.py
+++ b/python/cucim/src/cucim/skimage/color/colorconv.py
@@ -1201,13 +1201,16 @@ def _get_lab_to_xyz_kernel(xyz_ref_white, name='lab2xyz'):
 
 @channel_as_last_axis()
 def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
-    """CIE-LAB to XYZcolor space conversion.
+    """Convert image in CIE-LAB to XYZ color space.
 
     Parameters
     ----------
     lab : (..., 3, ...) array_like
-        The image in Lab format. By default, the final dimension denotes
+        The input image in CIE-LAB color space.
+        Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
+        The L* values range from 0 to 100;
+        the a* and b* values range from -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional
@@ -1219,7 +1222,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Returns
     -------
     out : (..., 3, ...) ndarray
-        The image in XYZ format. Same dimensions as input.
+        The image in XYZ color space. Same dimensions as input.
 
     Raises
     ------
@@ -1233,14 +1236,14 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    By default Observer="2", Illuminant="D65". CIE XYZ tristimulus values x_ref
-    = 95.047, y_ref = 100., z_ref = 108.883. See function 'get_xyz_coords' for
-    a list of supported illuminants.
+    The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
+    z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
+    supported illuminants.
 
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
-    .. [2] https://en.wikipedia.org/wiki/Lab_color_space
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
     """
     lab = _prepare_colorarray(lab, force_c_contiguous=True,
                               channel_axis=channel_axis)
@@ -1311,13 +1314,16 @@ def rgb2lab(rgb, illuminant="D65", observer="2", *, channel_axis=-1):
 
 @channel_as_last_axis()
 def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
-    """Lab to RGB color space conversion.
+    """Convert image in CIE-LAB to sRGB color space.
 
     Parameters
     ----------
     lab : (..., 3, ...) array_like
-        The image in Lab format. By default, the final dimension denotes
+        The input image in CIE-LAB color space.
+        Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
+        The L* values range from 0 to 100;
+        the a* and b* values range from -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional
@@ -1339,13 +1345,14 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Notes
     -----
     This function uses lab2xyz and xyz2rgb.
-    By default Observer="2", Illuminant="D65". CIE XYZ tristimulus values
-    x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
-    a list of supported illuminants.
+    The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
+    z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
+    supported illuminants.
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
     """
     return xyz2rgb(lab2xyz(lab, illuminant, observer))
 

--- a/python/cucim/src/cucim/skimage/registration/_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/_phase_cross_correlation.py
@@ -151,7 +151,7 @@ def _disambiguate_shift(reference_image, moving_image, shift):
     positive_shift = [shift_i % s for shift_i, s in zip(shift, shape)]
     negative_shift = [shift_i - s
                       for shift_i, s in zip(positive_shift, shape)]
-    subpixel = any(s % 1 !=0 for s in shift)
+    subpixel = any(s % 1 != 0 for s in shift)
     interp_order = 3 if subpixel else 0
     shifted = ndi.shift(
         moving_image, shift, mode='grid-wrap', order=interp_order
@@ -325,10 +325,10 @@ def phase_cross_correlation(reference_image, moving_image, *,
     cross_correlation = fft.ifftn(image_product)
 
     # Locate maximum
-    maxima = np.unravel_index(int(cp.argmax(cp.abs(cross_correlation))), cross_correlation.shape)
+    maxima = np.unravel_index(
+        int(cp.argmax(cp.abs(cross_correlation))), cross_correlation.shape
+    )
     midpoint = tuple(float(axis_size // 2) for axis_size in shape)
-
-    float_dtype = image_product.real.dtype
     shift = tuple(_max - axis_size if _max > mid else _max
                   for _max, mid, axis_size in zip(maxima, midpoint, shape))
 

--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -67,7 +67,8 @@ def test_real_input(dtype):
     result, error, diffphase = phase_cross_correlation(reference_image,
                                                        shifted_image,
                                                        upsample_factor=100)
-    assert result.dtype == _supported_float_type(dtype)
+    assert isinstance(result, tuple)
+    assert all(isinstance(s, float) for s in result)
     assert_allclose(result[:2], -cp.array(subpixel_shift), atol=0.05)
 
 

--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -10,7 +10,6 @@ from skimage.data import camera, eagle
 from cucim.skimage import img_as_float
 from cucim.skimage._shared._warnings import expected_warnings
 from cucim.skimage._shared.fft import fftmodule as fft
-from cucim.skimage._shared.utils import _supported_float_type
 from cucim.skimage.data import binary_blobs
 from cucim.skimage.registration._phase_cross_correlation import (
     _upsampled_dft, phase_cross_correlation)
@@ -176,9 +175,9 @@ def test_mismatch_offsets_size():
 
 
 @pytest.mark.parametrize(
-        ('shift0', 'shift1'),
-        itertools.product((100, -100, 350, -350), (100, -100, 350, -350)),
-        )
+    ('shift0', 'shift1'),
+    itertools.product((100, -100, 350, -350), (100, -100, 350, -350)),
+)
 def test_disambiguate_2d(shift0, shift1):
     image = cp.array(eagle()[500:, 900:])  # use a highly textured image region
     shift = (shift0, shift1)
@@ -189,8 +188,8 @@ def test_disambiguate_2d(shift0, shift1):
         else:
             origin0.append(-s)
     origin1 = np.array(origin0) + shift
-    slice0 = tuple(slice(o, o+450) for o in origin0)
-    slice1 = tuple(slice(o, o+450) for o in origin1)
+    slice0 = tuple(slice(o, o + 450) for o in origin0)
+    slice1 = tuple(slice(o, o + 450) for o in origin1)
     reference = image[slice0]
     moving = image[slice1]
     computed_shift, _, _ = phase_cross_correlation(


### PR DESCRIPTION
This MR ports a couple of recent features merged upstream for scikit-image 0.20

- a docstring update to `lab2rgb` and `rgb2lab`
- a new "disambiguation" flag to `phase_cross_correlation` (default of False matches the old behavior)

There is also one change that is technically breaking in that the shift is now always returned as a tuple of floats rather than as a `cupy.ndarray` of size `refernce_image.ndim`. I think this is preferable and working with small coordinate tuples rather than using array operations allows avoiding kernel launch overheads. Upstream scikit-image is a bit inconsistent in that it returns a tuple when `disambiguate` is True, but a numpy.ndarray otherwise. It should probably be changed to return a tuple in all cases.
