### PR TITLE
[REVIEW] Closes #490 -- fixes bug in hue jitter

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/kernel/cuda_kernel_source.py
+++ b/python/cucim/src/cucim/core/operations/color/kernel/cuda_kernel_source.py
@@ -205,7 +205,7 @@ __global__ void huejitter_kernel(unsigned char *input_rgb, \
     float s = __uint2float_rn((unsigned int)s_char);
     float v = __uint2float_rn((unsigned int)v_char);
 
-    if (s == 0) {
+    if (v == 0) {
       // write zero and out
       output_rgb[idx] = 0;
       output_rgb[idx+pitch] = 0;


### PR DESCRIPTION
This PR fixes a small bug in hue color jitter, as described in Issue #490. In images of all gray, some or all pixels are set to black when they shouldn't be. Looking at the CUDA kernel, it seems like the issue lies on line 208 of [cuda_kernel_source.py](https://github.com/rapidsai/cucim/blob/6c50a4edc94494bbb57dbd02749870d45533ee68/python/cucim/src/cucim/core/operations/color/kernel/cuda_kernel_source.py).

Currently in the kernel if `s == 0` then it sets the whole output to zero. But HSV is only black if `v == 0`, not s. So line 208 is here changed to:
```
if (v == 0) {
```

First PR here, so let me know what else is needed! Thanks.