### PR TITLE
Update `isort` version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   #    - id: end-of-file-fixer
   #    - id: debug-statements
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: ^python/cucim/src/.*


### PR DESCRIPTION
Poetry version 1.5.0 broke installs of `isort` prior to 5.11.5 (see pycqa/isort#2077 and pycqa/isort#2078).

This is fixed in 5.12.0.

xref: https://github.com/rapidsai/cudf/pull/12645
