### PR TITLE
use cp.around instead of cp.round for CuPy 10.x compatiblity

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -120,7 +120,7 @@ def _absorbance_to_image_int(absorbance, source_intensity, min_val, max_val):
     rgb = cp.exp(-absorbance) * source_intensity
     # prevent overflow/underflow
     rgb = cp.minimum(cp.maximum(rgb, min_val), max_val)
-    return cp.round(rgb)
+    return cp.around(rgb)
 
 
 @cp.fuse()
@@ -128,7 +128,7 @@ def _absorbance_to_image_uint8(absorbance, source_intensity):
     rgb = cp.exp(-absorbance) * source_intensity
     # prevent overflow/underflow
     rgb = cp.minimum(cp.maximum(rgb, 0), 255)
-    return cp.round(rgb).astype(cp.uint8)
+    return cp.around(rgb).astype(cp.uint8)
 
 
 def absorbance_to_image(absorbance, source_intensity=255, dtype=cp.uint8):

--- a/python/cucim/src/cucim/skimage/feature/template.py
+++ b/python/cucim/src/cucim/skimage/feature/template.py
@@ -106,13 +106,13 @@ def match_template(image, template, pad_input=False, mode='constant',
            [ 0.,  0.,  0.,  0., -1.,  0.],
            [ 0.,  0.,  0.,  0.,  0.,  0.]])
     >>> result = match_template(image, template)
-    >>> cp.round(result, 3)
+    >>> cp.around(result, 3)
     array([[ 1.   , -0.125,  0.   ,  0.   ],
            [-0.125, -0.125,  0.   ,  0.   ],
            [ 0.   ,  0.   ,  0.125,  0.125],
            [ 0.   ,  0.   ,  0.125, -1.   ]])
     >>> result = match_template(image, template, pad_input=True)
-    >>> cp.round(result, 3)
+    >>> cp.around(result, 3)
     array([[-0.125, -0.125, -0.125,  0.   ,  0.   ,  0.   ],
            [-0.125,  1.   , -0.125,  0.   ,  0.   ,  0.   ],
            [-0.125, -0.125, -0.125,  0.   ,  0.   ,  0.   ],

--- a/python/cucim/src/cucim/skimage/measure/_moments.py
+++ b/python/cucim/src/cucim/skimage/measure/_moments.py
@@ -101,8 +101,8 @@ def moments_coords_central(coords, center=None, order=3):
     point, this no longer holds:
 
     >>> coords2 = cp.concatenate((coords, cp.array([[17, 17]])), axis=0)
-    >>> cp.round(moments_coords_central(coords2),
-    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE
+    >>> cp.around(moments_coords_central(coords2),
+    ...           decimals=2)  # doctest: +NORMALIZE_WHITESPACE
     array([[17.  ,  0.  , 22.12, -2.49],
            [ 0.  ,  3.53,  1.73,  7.4 ],
            [25.88,  6.02, 36.63,  8.83],


### PR DESCRIPTION
`around` and `round` are equivalent, but `round` is only present in CuPy>=11. Switch to `around` here for compatibility with CuPy 10.x releases.
