### PR TITLE
Binary morphology: omit weights array when possible

### DIFF
--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -835,6 +835,10 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
     # structure is used by morphology.grey_erosion() and grey_dilation()
     # and not by the regular min/max filters
 
+    if isinstance(ftprnt, tuple) and size is None:
+        size = ftprnt
+        ftprnt = None
+
     sizes, ftprnt, structure = _filters_core._check_size_footprint_structure(
         input.ndim, size, ftprnt, structure)
     if cval is cupy.nan:

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
@@ -289,12 +289,12 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     return output
 
 
-def _prep_structure(structure):
+def _prep_structure(structure, ndim):
     if structure is None:
-        structure = generate_binary_structure(input.ndim, 1)
+        structure = generate_binary_structure(ndim, 1)
         return structure, structure.shape, True
     if isinstance(structure, int):
-        structure = (structure,) * input.ndim
+        structure = (structure,) * ndim
     elif isinstance(structure, list):
         structure = tuple(structure)
     if isinstance(structure, tuple):
@@ -353,7 +353,7 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
 
     .. seealso:: :func:`scipy.ndimage.binary_erosion`
     """
-    structure, _, _ = _prep_structure(structure)
+    structure, _, _ = _prep_structure(structure, input.ndim)
     return _binary_erosion(input, structure, iterations, mask, output,
                            border_value, origin, 0, brute_force)
 
@@ -401,7 +401,8 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
 
     .. seealso:: :func:`scipy.ndimage.binary_dilation`
     """
-    structure, structure_shape, symmetric = _prep_structure(structure)
+    structure, structure_shape, symmetric = _prep_structure(structure,
+                                                            input.ndim)
     origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
     if not symmetric:
         structure = structure[tuple([slice(None, None, -1)] * structure.ndim)]
@@ -460,7 +461,7 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
 
     .. seealso:: :func:`scipy.ndimage.binary_opening`
     """
-    structure, _, _ = _prep_structure(structure)
+    structure, _, _ = _prep_structure(structure, input.ndim)
     tmp = binary_erosion(input, structure, iterations, mask, None,
                          border_value, origin, brute_force)
     return binary_dilation(tmp, structure, iterations, mask, output,
@@ -514,7 +515,7 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
 
     .. seealso:: :func:`scipy.ndimage.binary_closing`
     """
-    structure, _, _ = _prep_structure(structure)
+    structure, _, _ = _prep_structure(structure, input.ndim)
     tmp = binary_dilation(input, structure, iterations, mask, None,
                           border_value, origin, brute_force)
     return binary_erosion(tmp, structure, iterations, mask, output,

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
@@ -681,7 +681,6 @@ def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
 
     .. seealso:: :func:`scipy.ndimage.grey_erosion`
     """
-
     if size is None and footprint is None and structure is None:
         raise ValueError('size, footprint or structure must be specified')
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
@@ -365,13 +365,14 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
     Args:
         input(cupy.ndarray): The input binary array_like to be dilated.
             Non-zero (True) elements form the subset to be dilated.
-        structure(cupy.ndarray or tuple or int, optional): The structuring element used for the
-            erosion. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None). If a tuple of
-            integers is provided, a structuring element of the specified shape
-            is used (all elements True). If an integer is provided, the
-            structuring element will have the same size along all axes.
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the erosion. Non-zero elements are considered
+            True. If no structuring element is provided an element is generated
+            with a square connectivity equal to one. (Default value = None). If
+            a tuple of integers is provided, a structuring element of the
+            specified shape is used (all elements True). If an integer is
+            provided, the structuring element will have the same size along all
+            axes.
         iterations(int, optional): The dilation is repeated ``iterations``
             times (one, by default). If iterations is less than 1, the dilation
             is repeated until the result does not change anymore. Only an

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
@@ -178,7 +178,9 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
         # transfer to CPU for use in determining if it is fully dense
         # structure_cpu = cupy.asnumpy(structure)
         if structure.ndim != input.ndim:
-            raise RuntimeError('structure and input must have same dimensionality')
+            raise RuntimeError(
+                'structure and input must have same dimensionality'
+            )
         if not structure.flags.c_contiguous:
             structure = cupy.ascontiguousarray(structure)
         if structure.size < 1:
@@ -315,13 +317,14 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
     Args:
         input(cupy.ndarray): The input binary array_like to be eroded.
             Non-zero (True) elements form the subset to be eroded.
-        structure(cupy.ndarray or tuple or int, optional): The structuring element used for the
-            erosion. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None). If a tuple of
-            integers is provided, a structuring element of the specified shape
-            is used (all elements True). If an integer is provided, the
-            structuring element will have the same size along all axes.
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the erosion. Non-zero elements are considered
+            True. If no structuring element is provided an element is generated
+            with a square connectivity equal to one. (Default value = None). If
+            a tuple of integers is provided, a structuring element of the
+            specified shape is used (all elements True). If an integer is
+            provided, the structuring element will have the same size along all
+            axes.
         iterations(int, optional): The erosion is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the erosion is
             repeated until the result does not change anymore. Only an integer
@@ -420,13 +423,14 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
     Args:
         input(cupy.ndarray): The input binary array to be opened.
             Non-zero (True) elements form the subset to be opened.
-        structure(cupy.ndarray or tuple or int, optional): The structuring element used for the
-            erosion. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None). If a tuple of
-            integers is provided, a structuring element of the specified shape
-            is used (all elements True). If an integer is provided, the
-            structuring element will have the same size along all axes.
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the erosion. Non-zero elements are considered
+            True. If no structuring element is provided an element is generated
+            with a square connectivity equal to one. (Default value = None). If
+            a tuple of integers is provided, a structuring element of the
+            specified shape is used (all elements True). If an integer is
+            provided, the structuring element will have the same size along all
+            axes.
         iterations(int, optional): The opening is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the opening is
             repeated until the result does not change anymore. Only an integer
@@ -473,13 +477,14 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
     Args:
         input(cupy.ndarray): The input binary array to be closed.
             Non-zero (True) elements form the subset to be closed.
-        structure(cupy.ndarray or tuple or int, optional): The structuring element used for the
-            erosion. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None). If a tuple of
-            integers is provided, a structuring element of the specified shape
-            is used (all elements True). If an integer is provided, the
-            structuring element will have the same size along all axes.
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the erosion. Non-zero elements are considered
+            True. If no structuring element is provided an element is generated
+            with a square connectivity equal to one. (Default value = None). If
+            a tuple of integers is provided, a structuring element of the
+            specified shape is used (all elements True). If an integer is
+            provided, the structuring element will have the same size along all
+            axes.
         iterations(int, optional): The closing is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the closing is
             repeated until the result does not change anymore. Only an integer

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -19,7 +19,6 @@ from cucim.skimage.feature import (corner_foerstner, corner_harris,
                                    structure_tensor,
                                    structure_tensor_eigenvalues)
 from cucim.skimage.feature.corner import _symmetric_image
-from cucim.skimage.morphology import cube
 
 
 @pytest.fixture

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -227,9 +227,11 @@ def test_structure_tensor_eigenvalues(dtype):
 
 
 def test_structure_tensor_eigenvalues_3d():
-    image = pad(cube(9), 5, mode='constant') * 1000
-    boundary = (pad(cube(9), 5, mode='constant')
-                - pad(cube(7), 6, mode='constant')).astype(bool)
+    cube9 = cp.ones((9,) * 3, dtype=cp.uint8)
+    cube7 = cp.ones((7,) * 3, dtype=cp.uint8)
+    image = pad(cube9, 5, mode='constant') * 1000
+    boundary = (pad(cube9, 5, mode='constant')
+                - pad(cube7, 6, mode='constant')).astype(bool)
     A_elems = structure_tensor(image, sigma=0.1)
     e0, e1, e2 = structure_tensor_eigenvalues(A_elems)
     # e0 should detect facets

--- a/python/cucim/src/cucim/skimage/morphology/footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/footprints.py
@@ -114,7 +114,7 @@ def footprint_from_sequence(footprints):
     return morphology.binary_dilation(imag, footprints)
 
 
-def square(width, dtype=cp.uint8, *, decomposition=None):
+def square(width, dtype=None, *, decomposition=None):
     """Generates a flat, square-shaped footprint.
 
     Every pixel along the perimeter has a chessboard distance
@@ -127,8 +127,11 @@ def square(width, dtype=cp.uint8, *, decomposition=None):
 
     Other Parameters
     ----------------
-    dtype : data-type, optional
-        The data type of the footprint.
+    dtype : data-type or None, optional
+        The data type of the footprint. When None, a tuple will be returned in
+        place of the actual footprint array. This can be be passed to grayscale
+        and binary morphology functions in place of an explicit array to avoid
+        array allocation overhead.
     decomposition : {None, 'separable', 'sequence'}, optional
         If None, a single array is returned. For 'sequence', a tuple of smaller
         footprints is returned. Applying this series of smaller footprints will
@@ -163,15 +166,27 @@ def square(width, dtype=cp.uint8, *, decomposition=None):
     The 'sequence' decomposition mode only supports odd valued `width`. If
     `width` is even, the sequence used will be identical to the 'separable'
     mode.
+
     """
     if decomposition is None:
-        return cp.ones((width, width), dtype=dtype)
+        if dtype is None:
+            return (width, width)
+        else:
+            return cp.ones((width, width), dtype=dtype)
 
     if decomposition == 'separable' or width % 2 == 0:
-        sequence = (((width, 1), 1), ((1, width), 1))
+        if dtype is None:
+            sequence = (((width, 1), 1), ((1, width), 1))
+        else:
+            sequence = ((cp.ones((width, 1), dtype=dtype), 1),
+                        (cp.ones((1, width), dtype=dtype), 1))
     elif decomposition == 'sequence':
         # only handles odd widths
-        sequence = (((3, 3), _decompose_size(width, 3)),)
+        if dtype is None:
+            sequence = (((3, 3), _decompose_size(width, 3)),)
+        else:
+            sequence = ((cp.ones((3, 3), dtype=dtype),
+                        _decompose_size(width, 3)),)
     else:
         raise ValueError(f"Unrecognized decomposition: {decomposition}")
     return sequence
@@ -190,7 +205,7 @@ def _decompose_size(size, kernel_size=3):
     return 1 + (size - kernel_size) // (kernel_size - 1)
 
 
-def rectangle(nrows, ncols, dtype=cp.uint8, *, decomposition=None):
+def rectangle(nrows, ncols, dtype=None, *, decomposition=None):
     """Generates a flat, rectangular-shaped footprint.
 
     Every pixel in the rectangle generated for a given width and given height
@@ -205,8 +220,11 @@ def rectangle(nrows, ncols, dtype=cp.uint8, *, decomposition=None):
 
     Other Parameters
     ----------------
-    dtype : data-type, optional
-        The data type of the footprint.
+    dtype : data-type or None, optional
+        The data type of the footprint. When None, a tuple will be returned in
+        place of the actual footprint array. This can be be passed to grayscale
+        and binary morphology functions in place of an explicit array to avoid
+        array allocation overhead.
     decomposition : {None, 'separable', 'sequence'}, optional
         If None, a single array is returned. For 'sequence', a tuple of smaller
         footprints is returned. Applying this series of smaller footprints will
@@ -246,27 +264,49 @@ def rectangle(nrows, ncols, dtype=cp.uint8, *, decomposition=None):
       version 0.18.0. Use ``nrows`` and ``ncols`` instead.
     """
     if decomposition is None:  # TODO: check optimal width setting here
-        return cp.ones((nrows, ncols), dtype=dtype)
+        if dtype is None:
+            return (nrows, ncols)
+        else:
+            return cp.ones((nrows, ncols), dtype=dtype)
 
     even_rows = nrows % 2 == 0
     even_cols = ncols % 2 == 0
     if decomposition == 'separable' or even_rows or even_cols:
-        sequence = [((nrows, 1), 1), ((1, ncols), 1)]
+        if dtype is None:
+            sequence = [((nrows, 1), 1), ((1, ncols), 1)]
+        else:
+            sequence = [
+                (cp.ones((nrows, 1), dtype=dtype), 1),
+                (cp.ones((1, ncols), dtype=dtype), 1),
+            ]
     elif decomposition == 'sequence':
         # this branch only support odd nrows, ncols
         sq_size = 3
         sq_reps = _decompose_size(min(nrows, ncols), sq_size)
-        sequence = [((3, 3), sq_reps)]
+        if dtype is None:
+            sequence = [((3, 3), sq_reps)]
+        else:
+            sequence = [(cp.ones((3, 3), dtype=dtype), sq_reps)]
         if nrows > ncols:
             nextra = nrows - ncols
-            sequence.append(
-                ((nextra + 1, 1), 1)
-            )
+            if dtype is None:
+                sequence.append(
+                    ((nextra + 1, 1), 1)
+                )
+            else:
+                sequence.append(
+                    (cp.ones((nextra + 1, 1), dtype=dtype), 1)
+                )
         elif ncols > nrows:
             nextra = ncols - nrows
-            sequence.append(
-                ((1, nextra + 1), 1)
-            )
+            if dtype is None:
+                sequence.append(
+                    ((1, nextra + 1), 1)
+                )
+            else:
+                sequence.append(
+                    (cp.ones((1, nextra + 1), dtype=dtype), 1)
+                )
     else:
         raise ValueError(f"Unrecognized decomposition: {decomposition}")
     return tuple(sequence)
@@ -330,7 +370,7 @@ def diamond(radius, dtype=cp.uint8, *, decomposition=None):
     return footprint
 
 
-def _nsphere_series_decomposition(radius, ndim, dtype=cp.uint8):
+def _nsphere_series_decomposition(radius, ndim, dtype=None):
     """Generate a sequence of footprints approximating an n-sphere.
 
     Morphological operations with an n-sphere (hypersphere) footprint can be
@@ -385,12 +425,16 @@ def _nsphere_series_decomposition(radius, ndim, dtype=cp.uint8):
     num_t_series, num_diamond, num_square = precomputed_decompositions[radius]
 
     sequence = []
+    if dtype is None:
+        _dtype = cp.uint8
+    else:
+        _dtype = dtype
     if num_t_series > 0:
         # shape (3, ) * ndim "T-shaped" footprints
-        all_t = _t_shaped_element_series(ndim=ndim, dtype=dtype)
+        all_t = _t_shaped_element_series(ndim=ndim, dtype=_dtype)
         [sequence.append((t, num_t_series)) for t in all_t]
     if num_diamond > 0:
-        d = np.zeros((3,) * ndim, dtype=dtype)
+        d = np.zeros((3,) * ndim, dtype=_dtype)
         sl = [slice(1, 2)] * ndim
         for ax in range(ndim):
             sl[ax] = slice(None)
@@ -398,7 +442,10 @@ def _nsphere_series_decomposition(radius, ndim, dtype=cp.uint8):
             sl[ax] = slice(1, 2)
         sequence.append((cp.asarray(d), num_diamond))
     if num_square > 0:
-        sequence.append(((3, ) * ndim, num_square))
+        if dtype is None:
+            sequence.append(((3, ) * ndim, num_square))
+        else:
+            sequence.append((cp.ones((3, ) * ndim, dtype=_dtype), num_square))
     return tuple(sequence)
 
 
@@ -664,7 +711,7 @@ def ellipse(width, height, dtype=cp.uint8, *, decomposition=None):
     return sequence
 
 
-def cube(width, dtype=cp.uint8, *, decomposition=None):
+def cube(width, dtype=None, *, decomposition=None):
     """ Generates a cube-shaped footprint.
 
     This is the 3D equivalent of a square.
@@ -678,8 +725,11 @@ def cube(width, dtype=cp.uint8, *, decomposition=None):
 
     Other Parameters
     ----------------
-    dtype : data-type, optional
-        The data type of the footprint.
+    dtype : data-type or None, optional
+        The data type of the footprint. When None, a tuple will be returned in
+        place of the actual footprint array. This can be be passed to grayscale
+        and binary morphology functions in place of an explicit array to avoid
+        array allocation overhead.
     decomposition : {None, 'separable', 'sequence'}, optional
         If None, a single array is returned. For 'sequence', a tuple of smaller
         footprints is returned. Applying this series of smaller footprints will
@@ -712,14 +762,29 @@ def cube(width, dtype=cp.uint8, *, decomposition=None):
     mode.
     """
     if decomposition is None:
-        return cp.ones((width, width, width), dtype=dtype)
+        if dtype is None:
+            return (width, width, width)
+        else:
+            return cp.ones((width, width, width), dtype=dtype)
     if decomposition == 'separable' or width % 2 == 0:
-        sequence = (((width, 1, 1), 1), ((1, width, 1), 1), ((1, 1, width), 1))
+        if dtype is None:
+            sequence = (((width, 1, 1), 1), ((1, width, 1), 1), ((1, 1, width), 1))
+        else:
+            sequence = (
+                (cp.ones((width, 1, 1), dtype=dtype), 1),
+                (cp.ones((1, width, 1), dtype=dtype), 1),
+                (cp.ones((1, 1, width), dtype=dtype), 1),
+            )
     elif decomposition == 'sequence':
         # only handles odd widths
-        sequence = (
-            ((3, 3, 3), _decompose_size(width, 3)),
-        )
+        if dtype is None:
+            sequence = (
+                ((3, 3, 3), _decompose_size(width, 3)),
+            )
+        else:
+            sequence = (
+                (cp.ones((3, 3, 3), dtype=dtype), _decompose_size(width, 3)),
+            )
     else:
         raise ValueError(f"Unrecognized decomposition: {decomposition}")
     return sequence

--- a/python/cucim/src/cucim/skimage/morphology/footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/footprints.py
@@ -49,6 +49,7 @@ def _footprint_is_sequence(footprint):
         raise ValueError("footprint must be either an ndarray or Sequence")
     return True
 
+
 def _footprint_shape(footprint):
     if isinstance(footprint, tuple):
         return footprint
@@ -768,7 +769,9 @@ def cube(width, dtype=None, *, decomposition=None):
             return cp.ones((width, width, width), dtype=dtype)
     if decomposition == 'separable' or width % 2 == 0:
         if dtype is None:
-            sequence = (((width, 1, 1), 1), ((1, width, 1), 1), ((1, 1, width), 1))
+            sequence = (
+                ((width, 1, 1), 1), ((1, width, 1), 1), ((1, 1, width), 1)
+            )
         else:
             sequence = (
                 (cp.ones((width, 1, 1), dtype=dtype), 1),

--- a/python/cucim/src/cucim/skimage/morphology/footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/footprints.py
@@ -35,9 +35,11 @@ def _footprint_is_sequence(footprint):
             )
             and isinstance(t[1], Integral)
         )
-
     if isinstance(footprint, Sequence):
-        if not all(_validate_sequence_element(t) for t in footprint):
+        if all(isinstance(t, int) for t in footprint):
+            # allow pass through of a single shape tuple
+            return False
+        elif not all(_validate_sequence_element(t) for t in footprint):
             raise ValueError(
                 "All elements of footprint sequence must be a 2-tuple where "
                 "the first element of the tuple is an ndarray and the second "

--- a/python/cucim/src/cucim/skimage/morphology/footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/footprints.py
@@ -82,7 +82,7 @@ def _shape_from_sequence(footprints, require_odd_size=False):
         fp, nreps = footprints[0]
         fp_shape = _footprint_shape(fp)
         _odd_size(fp_shape[d], require_odd_size)
-        shape[d] = fp_shape[d] + (nreps - 1) * (fp.shape[d] - 1)
+        shape[d] = fp_shape[d] + (nreps - 1) * (fp_shape[d] - 1)
         for fp, nreps in footprints[1:]:
             fp_shape = _footprint_shape(fp)
             _odd_size(fp_shape[d], require_odd_size)

--- a/python/cucim/src/cucim/skimage/morphology/gray.py
+++ b/python/cucim/src/cucim/skimage/morphology/gray.py
@@ -260,7 +260,7 @@ def erosion(image, footprint=None, out=None, shift_x=False, shift_y=False):
             raise ValueError(
                 "footprint.ndim={len(footprint)}, image.ndim={image.ndim}"
             )
-        if image.ndim == 2 and any(s % 2 for s in footprint):
+        if image.ndim == 2 and any(s % 2 == 0 for s in footprint):
             # only odd-shaped footprints are properly handled for tuples
             footprint = cp.ones(footprint, dtype=bool)
         else:
@@ -609,6 +609,14 @@ def white_tophat(image, footprint=None, out=None):
         out_ = out
     if _footprint_is_sequence(footprint):
         return _white_tophat_seqence(image_, footprint, out_)
+    elif isinstance(footprint, tuple):
+        if len(footprint) != image.ndim:
+            raise ValueError(
+                "footprint.ndim={len(footprint)}, image.ndim={image.ndim}"
+            )
+        ndi.white_tophat(image, size=footprint, output=out)
+        return out
+
     out_ = ndi.white_tophat(image_, footprint=footprint, output=out_)
     return out
 

--- a/python/cucim/src/cucim/skimage/morphology/gray.py
+++ b/python/cucim/src/cucim/skimage/morphology/gray.py
@@ -25,13 +25,24 @@ def _iterate_gray_func(gray_func, image, footprints, out):
     (e.g. `scipy.ndimage.binary_erosion`).
     """
     fp, num_iter = footprints[0]
-    gray_func(image, footprint=fp, output=out)
+    tuple_fp = isinstance(fp, tuple)
+    if tuple_fp:
+        gray_func(image, size=fp, output=out)
+    else:
+        gray_func(image, footprint=fp, output=out)
     for _ in range(1, num_iter):
-        gray_func(out.copy(), footprint=fp, output=out)
+        if tuple_fp:
+            gray_func(out.copy(), size=fp, output=out)
+        else:
+            gray_func(out.copy(), footprint=fp, output=out)
     for fp, num_iter in footprints[1:]:
+        tuple_fp = isinstance(fp, tuple)
         # Note: out.copy() because the computation cannot be in-place!
         for _ in range(num_iter):
-            gray_func(out.copy(), footprint=fp, output=out)
+            if tuple_fp:
+                gray_func(out.copy(), size=fp, output=out)
+            else:
+                gray_func(out.copy(), footprint=fp, output=out)
     return out
 
 
@@ -53,7 +64,7 @@ def _shift_footprint(footprint, shift_x, shift_y):
     out : 2D array, shape (M + int(shift_x), N + int(shift_y))
         The shifted footprint.
     """
-    if footprint.ndim != 2:
+    if isinstance(footprint, tuple) or footprint.ndim != 2:
         # do nothing for 1D or 3D or higher footprints
         return footprint
     m, n = footprint.shape
@@ -101,6 +112,9 @@ def _invert_footprint(footprint):
     ----------
     .. [1] https://github.com/scipy/scipy/blob/ec20ababa400e39ac3ffc9148c01ef86d5349332/scipy/ndimage/morphology.py#L1285  # noqa
     """
+    if isinstance(footprint, tuple):
+        # fully populated rectangle is symmetric
+        return footprint
     inverted = footprint[(slice(None, None, -1),) * footprint.ndim]
     return inverted
 
@@ -135,6 +149,8 @@ def pad_for_eccentric_footprints(func):
             # Note: in practice none of our built-in footprint sequences will
             #       require padding (all are symmetric and have odd sizes)
             footprint_shape = _shape_from_sequence(footprint)
+        elif isinstance(footprint, tuple):
+            footprint_shape = footprint
         else:
             footprint_shape = footprint.shape
         for axis_len in footprint_shape:
@@ -232,6 +248,18 @@ def erosion(image, footprint=None, out=None, shift_x=False, shift_y=False):
                            for fp, n in footprint)
         return _iterate_gray_func(ndi.grey_erosion, image, footprints, out)
 
+    if isinstance(footprint, tuple):
+        if len(footprint) != image.ndim:
+            raise ValueError(
+                "footprint.ndim={len(footprint)}, image.ndim={image.ndim}"
+            )
+        if image.ndim == 2 and any(s % 2 for s in footprint):
+            # only odd-shaped footprints are properly handled for tuples
+            footprint = cp.ones(footprint, dtype=bool)
+        else:
+            ndi.grey_erosion(image, size=footprint, output=out)
+            return out
+
     footprint = _shift_footprint(footprint, shift_x, shift_y)
     ndi.grey_erosion(image, footprint=footprint, output=out)
     return out
@@ -314,6 +342,18 @@ def dilation(image, footprint=None, out=None, shift_x=False, shift_y=False):
             for fp, n in footprint
         )
         return _iterate_gray_func(ndi.grey_dilation, image, footprints, out)
+
+    if isinstance(footprint, tuple):
+        if len(footprint) != image.ndim:
+            raise ValueError(
+                "footprint.ndim={len(footprint)}, image.ndim={image.ndim}"
+            )
+        if image.ndim == 2 and any(s % 2 == 0 for s in footprint):
+            # only odd-shaped footprints are properly handled for tuples
+            footprint = cp.ones(footprint, dtype=bool)
+        else:
+            ndi.grey_dilation(image, size=footprint, output=out)
+            return out
 
     footprint = _shift_footprint(footprint, shift_x, shift_y)
     # Inside ndi.grey_dilation, the footprint is inverted,

--- a/python/cucim/src/cucim/skimage/morphology/gray.py
+++ b/python/cucim/src/cucim/skimage/morphology/gray.py
@@ -64,7 +64,14 @@ def _shift_footprint(footprint, shift_x, shift_y):
     out : 2D array, shape (M + int(shift_x), N + int(shift_y))
         The shifted footprint.
     """
-    if isinstance(footprint, tuple) or footprint.ndim != 2:
+    if isinstance(footprint, tuple):
+        if len(footprint) == 2 and any(s % 2 == 0 for s in footprint):
+            # have to use an explicit array to shift the footprint below
+            footprint = cp.ones(footprint, dtype=bool)
+        else:
+            # no shift needed
+            return footprint
+    if footprint.ndim != 2:
         # do nothing for 1D or 3D or higher footprints
         return footprint
     m, n = footprint.shape

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_footprints.py
@@ -177,11 +177,15 @@ def test_footprint_dtype(function, args, supports_sequence_decomposition,
                          dtype):
     # make sure footprint dtype matches what was requested
     footprint = function(*args, dtype=dtype)
-    assert footprint.dtype == dtype
+    if not isinstance(footprint, tuple):
+        assert footprint.dtype == dtype
 
     if supports_sequence_decomposition:
         sequence = function(*args, dtype=dtype, decomposition='sequence')
-        assert all([fp_tuple[0].dtype == dtype for fp_tuple in sequence])
+        assert all(
+            [fp_tuple[0].dtype == dtype
+             for fp_tuple in sequence if not isinstance(fp_tuple[0], tuple)]
+        )
 
 
 @pytest.mark.parametrize("function", ["disk", "ball"])

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_footprints.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_footprints.py
@@ -19,7 +19,7 @@ class TestSElem:
     def test_square_footprint(self):
         """Test square footprints"""
         for k in range(0, 5):
-            actual_mask = footprints.square(k)
+            actual_mask = footprints.square(k, dtype=cp.uint8)
             expected_mask = np.ones((k, k), dtype='uint8')
             assert_array_equal(expected_mask, actual_mask)
 
@@ -27,14 +27,14 @@ class TestSElem:
         """Test rectangle footprints"""
         for i in range(0, 5):
             for j in range(0, 5):
-                actual_mask = footprints.rectangle(i, j)
+                actual_mask = footprints.rectangle(i, j, dtype=cp.uint8)
                 expected_mask = np.ones((i, j), dtype='uint8')
                 assert_array_equal(expected_mask, actual_mask)
 
     def test_cube_footprint(self):
         """Test cube footprints"""
         for k in range(0, 5):
-            actual_mask = footprints.cube(k)
+            actual_mask = footprints.cube(k, dtype=cp.uint8)
             expected_mask = np.ones((k, k, k), dtype='uint8')
             assert_array_equal(expected_mask, actual_mask)
 
@@ -177,15 +177,11 @@ def test_footprint_dtype(function, args, supports_sequence_decomposition,
                          dtype):
     # make sure footprint dtype matches what was requested
     footprint = function(*args, dtype=dtype)
-    if not isinstance(footprint, tuple):
-        assert footprint.dtype == dtype
+    assert footprint.dtype == dtype
 
     if supports_sequence_decomposition:
         sequence = function(*args, dtype=dtype, decomposition='sequence')
-        assert all(
-            [fp_tuple[0].dtype == dtype
-             for fp_tuple in sequence if not isinstance(fp_tuple[0], tuple)]
-        )
+        assert all([fp_tuple[0].dtype == dtype for fp_tuple in sequence])
 
 
 @pytest.mark.parametrize("function", ["disk", "ball"])

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_gray.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_gray.py
@@ -369,14 +369,14 @@ def test_rectangle_decomposition(cam_image, function, nrows, ncols,
                  "black_tophat"],
 )
 @pytest.mark.parametrize("radius", (2, 3))
-@pytest.mark.parametrize("decomposition", ['separable', 'sequence'])
+@pytest.mark.parametrize("decomposition", ['sequence'])
 def test_diamond_decomposition(cam_image, function, radius, decomposition):
     """Validate footprint decomposition for various shapes.
 
     comparison is made to the case without decomposition.
     """
-    footprint_ndarray = morphology.square(radius, decomposition=None)
-    footprint = morphology.square(radius, decomposition=decomposition)
+    footprint_ndarray = morphology.diamond(radius, decomposition=None)
+    footprint = morphology.diamond(radius, decomposition=decomposition)
     func = getattr(morphology, function)
     expected = func(cam_image, footprint=footprint_ndarray)
     out = func(cam_image, footprint=footprint)

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_isotropic.py
@@ -91,7 +91,7 @@ def test_out_argument():
     for func in (morphology.isotropic_erosion, morphology.isotropic_dilation,
                  morphology.isotropic_opening, morphology.isotropic_closing):
         radius = 3
-        img = cp.ones((10, 10))
+        img = cp.ones((10, 10), dtype=bool)
         img[2:5, 2:5] = 0
         out = cp.zeros_like(img)
         out_saved = out.copy()


### PR DESCRIPTION
This is a follow-up to #485 allowing the overhead of creating a weights array of uniform values to be omitted when possible for all binary morphology operators. This gives a large performance benefit for small footprints (and small images) with the benefit becoming minimal for large footprint size.

As currently implemented, a shape tuple can be passed to `structure` to indicate the equivalent of an array of ones of that shape. This is a deviation from SciPy's API which does not currently allow this. I am not positive if this is the best API choice or if it might be better to instead add a `size` keyword-only argument like the grayscale morphology functions currently have.

The footprint generation methods `square`, `rectangle`, `cube` etc. use this new tuple format when possible to reduce overhead.

I will post benchmarks below.