### PR TITLE
Fix bug in median filter with non-uniform footprint

### DIFF
--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1106,6 +1106,9 @@ def _rank_filter(input, get_rank, size=None, footprint=None, output=None,
             sizes = footprint.shape
             has_weights = False
 
+    if not has_weights:
+        footprint = None
+
     rank = get_rank(filter_size)
     if rank < 0 or rank >= filter_size:
         raise RuntimeError('rank not within filter footprint size')
@@ -1126,7 +1129,7 @@ def _rank_filter(input, get_rank, size=None, footprint=None, output=None,
     kernel = _get_rank_kernel(filter_size, rank, mode, footprint_shape,
                               offsets, float(cval), int_type,
                               has_weights=has_weights)
-    return _filters_core._call_kernel(kernel, input, None, output,
+    return _filters_core._call_kernel(kernel, input, footprint, output,
                                       weights_dtype=bool)
 
 

--- a/python/cucim/src/cucim/skimage/filters/tests/test_median.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_median.py
@@ -4,9 +4,9 @@ from cupy.testing import assert_allclose
 from cupyx.scipy import ndimage
 from skimage import data
 
+from cucim.skimage import morphology
 from cucim.skimage._shared.testing import expected_warnings
 from cucim.skimage.filters import median
-from cucim.skimage import morphology
 
 try:
     from math import prod

--- a/python/cucim/src/cucim/skimage/filters/tests/test_median.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_median.py
@@ -6,6 +6,7 @@ from skimage import data
 
 from cucim.skimage._shared.testing import expected_warnings
 from cucim.skimage.filters import median
+from cucim.skimage import morphology
 
 try:
     from math import prod
@@ -249,3 +250,17 @@ def test_median_preserve_dtype(image, dtype):
 )
 def test_median(img, behavior):
     median(img, behavior=behavior)
+
+
+def test_median_nonsquare():
+    """Test non-uniform footprint.
+
+    https://github.com/rapidsai/cucim/issues/520
+    """
+    rng = cp.random.default_rng()
+    img = rng.integers(0, 256, (128, 128), dtype=cp.uint8)
+    footprint = morphology.disk(5)
+    mode = 'nearest'
+    out = median(img, footprint, mode=mode, behavior='ndimage')
+    expected = ndimage.median_filter(img, footprint=footprint, mode=mode)
+    cp.testing.assert_array_equal(out, expected)


### PR DESCRIPTION
closes #520

#485 Introduced a bug in rank filtering kernels that was not caught by our current test cases
(so this bug is only present in the 23.02 release)

This MR fixes the bug and adds test coverage for this case.