### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/3rdparty/LICENSE.dockcross
+++ b/3rdparty/LICENSE.dockcross
@@ -1,0 +1,19 @@
+Copyright (c) 2015, 2016, 2017, 2018, 2021 Steeve Morin, Rob Burns, Matthew McCormick, Jean-Christophe-Fillion-Robin, Bensuperpc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Dockerfile-cuda110
+++ b/Dockerfile-cuda110
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM gigony/manylinux2014-x64:20201013-46b1bff
+FROM dockcross/manylinux2014-x64:20230215-2dd9a1c
 
 ENV DEFAULT_DOCKCROSS_IMAGE gigony/manylinux2014-x64:cuda110
 ENV PATH=/usr/local/cuda/bin/:$PATH
@@ -22,7 +22,7 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:/usr/local/cuda/nvvm/lib64:${LD_LIBRA
 
 RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run && \
     chmod +x cuda_*.run && \
-    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit --override && \
     rm -f cuda_*.run;
 
 RUN curl -LO https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/libnvjpeg2k0-0.0.1.17-1.x86_64.rpm && \

--- a/Dockerfile-cuda111
+++ b/Dockerfile-cuda111
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM gigony/manylinux2014-x64:20201013-46b1bff
+FROM dockcross/manylinux2014-x64:20230215-2dd9a1c
 
 ENV DEFAULT_DOCKCROSS_IMAGE gigony/manylinux2014-x64:cuda111
 ENV PATH=/usr/local/cuda/bin/:$PATH
@@ -22,7 +22,7 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:/usr/local/cuda/nvvm/lib64:${LD_LIBRA
 
 RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run && \
     chmod +x cuda_*.run && \
-    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit --override && \
     rm -f cuda_*.run;
 
 RUN curl -LO https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/libnvjpeg2k0-0.0.1.17-1.x86_64.rpm && \

--- a/LICENSE-3rdparty.md
+++ b/LICENSE-3rdparty.md
@@ -287,3 +287,9 @@ PBA+
   - https://github.com/orzzzjq/Parallel-Banding-Algorithm-plus/blob/master/LICENSE
 - Copyright: School of Computing, National University of Singapore
 - Usage: PBA+ is used to implement the Euclidean distance transform.
+
+dockcross
+- License: MIT License
+  - https://github.com/dockcross/dockcross/blob/master/LICENSE
+- Copyright: Steeve Morin, Rob Burns, Matthew McCormick, Jean-Christophe-Fillion-Robin, Bensuperpc
+- Usage: Building Python wheels for Linux

--- a/cpp/cmake/deps/pybind11.cmake
+++ b/cpp/cmake/deps/pybind11.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::pybind11)
     FetchContent_Declare(
             deps-pybind11
             GIT_REPOSITORY https://github.com/pybind/pybind11.git
-            GIT_TAG v2.6.2
+            GIT_TAG v2.10.3
             GIT_SHALLOW TRUE
     )
     FetchContent_GetProperties(deps-pybind11)

--- a/python/cmake/deps/pybind11.cmake
+++ b/python/cmake/deps/pybind11.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::pybind11)
     FetchContent_Declare(
             deps-pybind11
             GIT_REPOSITORY https://github.com/pybind/pybind11.git
-            GIT_TAG v2.6.2
+            GIT_TAG v2.10.3
             GIT_SHALLOW TRUE
     )
     FetchContent_GetProperties(deps-pybind11)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.