### PR TITLE
Pin `libwebp-base`

### DIFF
--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -6,3 +6,6 @@ cxx_compiler_version:
 
 sysroot_version:
   - "2.17"
+
+libwebp_base_version:
+  - "<1.3a0"

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -58,7 +58,6 @@ requirements:
     - {{ pin_compatible('libwebp-base', max_pin='x.x') }}
     - jbig
     - jpeg
-    - libwebp-base  # [linux or osx]
     # - openslide # skipping here but benchmark binary would need openslide library
     - xz
     - zlib

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}
     - jbig
     - jpeg
-    - libwebp-base  # [linux or osx]
+    - libwebp-base {{ libwebp_base_version }}  # [linux or osx]
     - openslide
     - xz
     - zlib

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -16,6 +16,8 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  ignore_run_exports:
+    - libwebp-base
   script_env:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
@@ -53,6 +55,7 @@ requirements:
     - zstd
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - {{ pin_compatible('libwebp-base', max_pin='x.x') }}
     - jbig
     - jpeg
     - libwebp-base  # [linux or osx]


### PR DESCRIPTION
This PR pins `libwebp-base`, since newer versions conflict with other RAPIDS packages.

The screenshot below shows the solver issues.

![image](https://user-images.githubusercontent.com/7400326/231845892-02c19e96-4671-4568-86b8-c96c095583b4.png)

It appears that `cucim` and `cuxfilter` are currently incompatible, likely due to the changes outlined in the issue/commit below:

- https://github.com/conda-forge/conda-forge.github.io/issues/673
- https://github.com/conda-forge/libjpeg-turbo-feedstock/commit/6cee8324c6109060155cfe31c4175a62f7628eef