### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -6,3 +6,6 @@ cxx_compiler_version:
 
 sysroot_version:
   - "2.17"
+
+libwebp_base_version:
+  - "<1.3a0"

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -16,6 +16,8 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  ignore_run_exports:
+    - libwebp-base
   script_env:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
@@ -46,16 +48,16 @@ requirements:
     - cudatoolkit ={{ cuda_version }}
     - jbig
     - jpeg
-    - libwebp-base  # [linux or osx]
+    - libwebp-base {{ libwebp_base_version }}  # [linux or osx]
     - openslide
     - xz
     - zlib
     - zstd
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - {{ pin_compatible('libwebp-base', max_pin='x.x') }}
     - jbig
     - jpeg
-    - libwebp-base  # [linux or osx]
     # - openslide # skipping here but benchmark binary would need openslide library
     - xz
     - zlib


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.