### PR TITLE
add a 20 minute timeout for pytest runs on CI

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -44,7 +44,7 @@ set +e
 
 rapids-logger "pytest cucim"
 pushd python/cucim
-pytest \
+timeout 20m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cucim.xml" \
   --numprocesses=8 \
@@ -53,6 +53,7 @@ pytest \
   --cov=cucim \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cucim-coverage.xml" \
   --cov-report=term \
+  -v \
   src \
   tests/unit \
   tests/performance


### PR DESCRIPTION
Recently some CI runs seemed to hang for multiple hours with tests at 99% complete.

This PR adds a 20 minute timeout on the pytest run to avoid this issue. I also added a verbose flag so that if things get stuck we can identify which test case may be the cause.
