### PR TITLE
Remove usage of rapids-get-rapids-version-from-git

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -18,7 +18,7 @@ rapids-print-env
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-VERSION_NUMBER=$(rapids-get-rapids-version-from-git)
+VERSION_NUMBER="23.06"
 
 rapids-mamba-retry install \
     --channel "${CPP_CHANNEL}" \

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -48,3 +48,4 @@ sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NE
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
+sed_runner "s/VERSION_NUMBER=\".*/VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh


### PR DESCRIPTION
Instead of using `rapids-get-rapids-version-from-git` we can just hardcode the version and use `update-version.sh` to update it