### PR TITLE
Only load versioned `libcufile`

### DIFF
--- a/cpp/include/cucim/dynlib/helper.h
+++ b/cpp/include/cucim/dynlib/helper.h
@@ -30,6 +30,7 @@
 #include "../macros/defines.h"
 
 #include <string>
+#include <vector>
 
 #if CUCIM_PLATFORM_LINUX
 #    include <dlfcn.h>
@@ -69,6 +70,25 @@ inline LibraryHandle load_library(const char* library_name, int mode = -1)
     {
         return dlopen(library_name, mode);
     }
+#else
+#    error "This platform is not supported!"
+#endif
+}
+
+inline LibraryHandle load_library(const std::vector<const char*>& names,
+                                  int mode = -1)
+{
+#if CUCIM_PLATFORM_LINUX
+    LibraryHandle handle_ = nullptr;
+    for (const char* name : names)
+    {
+        handle_= load_library(name, mode);
+        if (handle_ != nullptr)
+        {
+            return handle_;
+        }
+    }
+    return nullptr;
 #else
 #    error "This platform is not supported!"
 #endif

--- a/gds/src/cufile_stub.cpp
+++ b/gds/src/cufile_stub.cpp
@@ -59,7 +59,7 @@ void CuFileStub::load()
 #if !CUCIM_STATIC_GDS
         if (handle_ == nullptr)
         {
-            // Note: Load the dynamic library with RTLD_NODELETE flag because libcufile.so uses therad_local which can
+            // Note: Load the dynamic library with RTLD_NODELETE flag because libcufile.so uses thread_local which can
             // cause a segmentation fault if the library is dynamically loaded/unloaded. (See #158)
             // CUDA versions before CUDA 11.7.1 did not ship libcufile.so.0, so this is
             // a workaround that adds support for all prior versions of libcufile.

--- a/gds/src/cufile_stub.cpp
+++ b/gds/src/cufile_stub.cpp
@@ -61,7 +61,21 @@ void CuFileStub::load()
         {
             // Note: Load the dynamic library with RTLD_NODELETE flag because libcufile.so uses therad_local which can
             // cause a segmentation fault if the library is dynamically loaded/unloaded. (See #158)
-            handle_ = cucim::dynlib::load_library("libcufile.so", RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
+            // CUDA versions before CUDA 11.7.1 did not ship libcufile.so.0, so this is
+            // a workaround that adds support for all prior versions of libcufile.
+            handle_ = cucim::dynlib::load_library(
+                {
+                    "libcufile.so.0",
+                    "libcufile.so.1.3.0" /* 11.7.0 */,
+                    "libcufile.so.1.2.1" /* 11.6.2, 11.6.1 */,
+                    "libcufile.so.1.2.0" /* 11.6.0 */,
+                    "libcufile.so.1.1.1" /* 11.5.1 */,
+                    "libcufile.so.1.1.0" /* 11.5.0 */,
+                    "libcufile.so.1.0.2" /* 11.4.4, 11.4.3, 11.4.2 */,
+                    "libcufile.so.1.0.1" /* 11.4.1 */,
+                    "libcufile.so.1.0.0" /* 11.4.0 */
+                },
+                RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
             if (handle_ == nullptr)
             {
                 return;


### PR DESCRIPTION
Fixes the `dlopen` logic around `libcufile` to load either the SOVERSION library or the fully versioned library. This includes logic to handle the missing SOVERSION library on older CUDA versions. Drops loading the stub library, which typically only shows up in development environments.

<hr>

Fixes https://github.com/rapidsai/cucim/issues/504

Borrows from PR ( https://github.com/rapidsai/cudf/pull/13210 ) and PR ( https://github.com/rapidsai/kvikio/pull/203 ). Also adapts this logic to cuCIM ( https://github.com/rapidsai/kvikio/pull/141 )