### PR TITLE
Fix `return_error='always'` behavior in phase_cross_correlation

### DIFF
--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -180,9 +180,12 @@ def test_mismatch_offsets_size():
 )
 def test_disambiguate_2d(shift0, shift1):
     image = cp.array(eagle()[500:, 900:])  # use a highly textured image region
-    # protect against some versions of scikit-image + imagio loading as RGB instead of Grayscale
+
+    # Protect against some versions of scikit-image + imagio loading as
+    # RGB instead of grayscale.
     if image.ndim == 3:
         image = image[..., 0]
+
     shift = (shift0, shift1)
     origin0 = []
     for s in shift:

--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -180,6 +180,9 @@ def test_mismatch_offsets_size():
 )
 def test_disambiguate_2d(shift0, shift1):
     image = cp.array(eagle()[500:, 900:])  # use a highly textured image region
+    # protect against some versions of scikit-image + imagio loading as RGB instead of Grayscale
+    if image.ndim == 3:
+        image = image[..., 0]
     shift = (shift0, shift1)
     origin0 = []
     for s in shift:


### PR DESCRIPTION
This MR updates behavior of the `return_error` argument to match the final version implemented in scikit-image 0.20.

It also fixes a test suite error seen when recent `imageio` causes one of the test images to be loaded as RGB instead of grayscale.