### PR TITLE
Enable sccache hits from local builds

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -32,6 +32,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=cucim-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=cucim-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
 
 requirements:
   build:

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -33,6 +33,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=libcucim-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=libcucim-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
 
 requirements:
   build:


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.