### PR TITLE
Allow numpy 1.24.

### DIFF
--- a/python/cucim/docs/requirements.txt
+++ b/python/cucim/docs/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==4.5.0
 sphinx-autobuild
 myst-parser
 sphinx-book-theme
-numpy<1.24
+numpy
 matplotlib
 ipywidgets
 pandas


### PR DESCRIPTION
This removes the upper bound on `numpy<1.24` to allow newer NumPy versions.