### PR TITLE
Fix SHA256 check failure in test suite

### DIFF
--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -178,6 +178,7 @@ def test_mismatch_offsets_size():
     ('shift0', 'shift1'),
     itertools.product((100, -100, 350, -350), (100, -100, 350, -350)),
 )
+@cp.testing.with_requires("scikit-image>=0.20")
 def test_disambiguate_2d(shift0, shift1):
     image = cp.array(eagle()[500:, 900:])  # use a highly textured image region
 


### PR DESCRIPTION
Due to a [recent change in the eagle image](https://gitlab.com/scikit-image/data/-/merge_requests/22) used in one of our test cases, skimage 0.19 fails to load it. As a solution, we can just restrict this one test to run only for `scikit-image>=0.20`.

Should resolve test failures seen in #563
