### PR TITLE
test providing fallback in case of kernel fusion failure in MOC computation

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy as cp
 from cupy.cuda import driver
 


### PR DESCRIPTION
testing potential fix for the `test_moc` [failure](https://github.com/rapidsai/cucim/actions/runs/5539741155/jobs/10144657106) seen in #572