### PR TITLE
Use linalg & inline `_get_manders_overlap_coeff`

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -178,7 +178,7 @@ def manders_coloc_coeff(image0, image1_mask, mask=None):
 
 @cp.fuse()
 def _get_manders_overlap_coeff(image0, image1):
-    denom = cp.sqrt(cp.sum(cp.square(image0)) * (cp.sum(cp.square(image1))))
+    denom = cp.linalg.norm(image0) * cp.linalg.norm(image1)
     return cp.sum(cp.multiply(image0, image1)) / denom
 
 

--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -179,7 +179,7 @@ def manders_coloc_coeff(image0, image1_mask, mask=None):
 @cp.fuse()
 def _get_manders_overlap_coeff(image0, image1):
     denom = cp.linalg.norm(image0) * cp.linalg.norm(image1)
-    return cp.sum(cp.multiply(image0, image1)) / denom
+    return cp.vdot(image0, image1) / denom
 
 
 def manders_overlap_coeff(image0, image1, mask=None):

--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -176,11 +176,6 @@ def manders_coloc_coeff(image0, image1_mask, mask=None):
     return cp.sum(image0 * image1_mask) / img_sum
 
 
-def _get_manders_overlap_coeff(image0, image1):
-    denom = cp.linalg.norm(image0) * cp.linalg.norm(image1)
-    return cp.vdot(image0, image1) / denom
-
-
 def manders_overlap_coeff(image0, image1, mask=None):
     r"""Manders' overlap coefficient
 
@@ -260,7 +255,8 @@ def manders_overlap_coeff(image0, image1, mask=None):
     if image1.min() < 0:
         raise ValueError("image1 contains negative values")
 
-    return _get_manders_overlap_coeff(image0, image1)
+    denom = cp.linalg.norm(image0) * cp.linalg.norm(image1)
+    return cp.vdot(image0, image1) / denom
 
 
 def intersection_coeff(image0_mask, image1_mask, mask=None):

--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -176,7 +176,6 @@ def manders_coloc_coeff(image0, image1_mask, mask=None):
     return cp.sum(image0 * image1_mask) / img_sum
 
 
-@cp.fuse()
 def _get_manders_overlap_coeff(image0, image1):
     denom = cp.linalg.norm(image0) * cp.linalg.norm(image1)
     return cp.vdot(image0, image1) / denom

--- a/python/cucim/src/cucim/skimage/measure/_colocalization.py
+++ b/python/cucim/src/cucim/skimage/measure/_colocalization.py
@@ -178,7 +178,7 @@ def manders_coloc_coeff(image0, image1_mask, mask=None):
 
 @cp.fuse()
 def _get_manders_overlap_coeff(image0, image1):
-    denom = (cp.sum(cp.square(image0)) * (cp.sum(cp.square(image1)))) ** 0.5
+    denom = cp.sqrt(cp.sum(cp.square(image0)) * (cp.sum(cp.square(image1))))
     return cp.sum(cp.multiply(image0, image1)) / denom
 
 


### PR DESCRIPTION
As most of the operations in `_get_manders_overlap_coeff` can be constructed from other linalg operations, use those directly to compute the result. Once this is done, there is less of a need to `fuse` it into a kernel. Instead those linalg functions can just be called as-is.

Note: This resolves a bug seen with `test_moc` in the CUDA 11.2 CI on the CUDA 12 PR  ( https://github.com/rapidsai/cucim/pull/572#issuecomment-1631610100 ) ( https://github.com/rapidsai/cucim/pull/572#discussion_r1264224233 )