### PR TITLE
Drop unneeded selector on `libwebp-base`

### DIFF
--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -48,7 +48,7 @@ requirements:
   host:
     - cudatoolkit ={{ cuda_version }}
     - jbig
-    - libwebp-base {{ libwebp_base_version }}  # [linux or osx]
+    - libwebp-base {{ libwebp_base_version }}
     - openslide
     - xz
     - zlib


### PR DESCRIPTION
This selector only allows `libwebp-base` on Linux & macOS builds. However the `libcucim` package is only built on Linux and there is no macOS support. So this selector is unneeded. Given this go ahead and drop it.