### PR TITLE
Allow scikit-image 0.21.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -34,7 +34,7 @@ dependencies:
 - pytest>=6.2.4
 - python>=3.8,<3.11
 - recommonmark
-- scikit-image >=0.19.0,<0.21.0a0
+- scikit-image >=0.19.0,<0.22.0a0
 - scipy
 - sphinx<6
 - sysroot_linux-64==2.17

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - libcucim ={{ version }}
     - numpy 1.21
     - python
-    - scikit-image >=0.19.0,<0.21.0a0
+    - scikit-image >=0.19.0,<0.22.0a0
     - scipy
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
@@ -59,7 +59,7 @@ requirements:
     - libcucim ={{ version }}
     # - openslide # skipping here but benchmark binary would need openslide library
     - python
-    - scikit-image >=0.19.0,<0.21.0a0
+    - scikit-image >=0.19.0,<0.22.0a0
     - scipy
 
 tests:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -137,7 +137,7 @@ dependencies:
           - jbig
           - libwebp-base
           - numpy >=1.21.3
-          - scikit-image >=0.19.0,<0.21.0a0
+          - scikit-image >=0.19.0,<0.22.0a0
           - scipy
           - xz
           - zlib


### PR DESCRIPTION
Follow up to PR ( https://github.com/rapidsai/cucim/pull/573 )

This allows `scikit-image` version `0.21.0` to be installed alongside `cucim`.