### PR TITLE
remove checks for versions of scikit-image that are no longer supported

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/testing.py
+++ b/python/cucim/src/cucim/skimage/_shared/testing.py
@@ -15,14 +15,11 @@ fixture = pytest.fixture
 
 have_fetch = True
 try:
-    # scikit-image 0.19
+    # scikit-image >=0.19
     from skimage.data._fetchers import _fetch
 except ImportError:
-    # scikit-image 0.18
-    try:
-        from skimage.data import _fetch
-    except ImportError:
-        have_fetch = False
+    # skip this test if private API changed on scikit-image end
+    have_fetch = False
 
 
 def fetch(data_filename):

--- a/python/cucim/src/cucim/skimage/feature/tests/test_canny.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_canny.py
@@ -76,7 +76,6 @@ class TestCanny():
         result2 = feature.canny(cp.zeros((20, 20)), 4, 0, 0)
         assert cp.all(result1 == result2)
 
-    @cp.testing.with_requires("scikit-image>=0.18")
     @pytest.mark.parametrize('image_dtype', [cp.uint8, cp.int32, cp.float32,
                                              cp.float64])
     def test_use_quantiles(self, image_dtype):

--- a/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
@@ -282,20 +282,17 @@ class TestSimpleImage:
         assert_array_equal(ref, out)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_otsu_camera_image():
     camera = util.img_as_ubyte(camerad)
     assert 101 < threshold_otsu(camera) < 103
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_otsu_camera_image_histogram():
     camera = util.img_as_ubyte(camerad)
     hist = histogram(camera.ravel(), 256, source_range="image")
     assert 101 < threshold_otsu(hist=hist) < 103
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_otsu_camera_image_counts():
     camera = util.img_as_ubyte(camerad)
     counts, bin_centers = histogram(camera.ravel(), 256, source_range="image")
@@ -341,7 +338,6 @@ def test_otsu_one_color_image_3d():
     assert threshold_otsu(img) == 1
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_li_camera_image():
     image = util.img_as_ubyte(camerad)
     threshold = threshold_li(image)
@@ -431,20 +427,17 @@ def test_li_pathological_arrays():
     assert cp.all(cp.isfinite(thresholds))
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_yen_camera_image():
     camera = util.img_as_ubyte(camerad)
     assert 145 < threshold_yen(camera) < 147
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_yen_camera_image_histogram():
     camera = util.img_as_ubyte(camerad)
     hist = histogram(camera.ravel(), 256, source_range="image")
     assert 145 < threshold_yen(hist=hist) < 147
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_yen_camera_image_counts():
     camera = util.img_as_ubyte(camerad)
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
@@ -467,7 +460,6 @@ def test_local_even_block_size_error():
         threshold_local(img, block_size=4)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_isodata_camera_image():
     camera = util.img_as_ubyte(camerad)
 
@@ -479,7 +471,6 @@ def test_isodata_camera_image():
     assert_array_equal(threshold_isodata(camera, return_all=True), [102, 103])
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_isodata_camera_image_histogram():
     camera = util.img_as_ubyte(camerad)
     hist = histogram(camera.ravel(), 256, source_range='image')
@@ -487,7 +478,6 @@ def test_isodata_camera_image_histogram():
     assert threshold == 102
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_isodata_camera_image_counts():
     camera = util.img_as_ubyte(camerad)
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
@@ -551,7 +541,6 @@ def test_isodata_moon_image_negative_float():
     # fmt: on
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_threshold_minimum():
     camera = util.img_as_ubyte(camerad)
 
@@ -563,7 +552,6 @@ def test_threshold_minimum():
     assert_array_equal(threshold, 114)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_threshold_minimum_histogram():
     camera = util.img_as_ubyte(camerad)
     hist = histogram(camera.ravel(), 256, source_range='image')
@@ -578,7 +566,6 @@ def test_threshold_minimum_deprecated_max_iter_kwarg():
         threshold_minimum(hist=hist, max_iter=5000)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_threshold_minimum_counts():
     camera = util.img_as_ubyte(camerad)
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
@@ -774,7 +761,6 @@ def test_multiotsu_more_classes_then_values():
         threshold_multiotsu(img, classes=4)
 
 
-# @testing.with_requires("scikit-image>=0.18")
 # @pytest.mark.parametrize(
 #     "thresholding, lower, upper",
 #     [

--- a/python/cucim/src/cucim/skimage/metrics/tests/test_simple_metrics.py
+++ b/python/cucim/src/cucim/skimage/metrics/tests/test_simple_metrics.py
@@ -24,7 +24,6 @@ assert_almost_equal = cp.testing.assert_array_almost_equal
 
 
 @pytest.mark.parametrize('dtype', [cp.uint8, cp.float32, cp.float64])
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_PSNR_vs_IPOL(dtype):
     """Tests vs. imdiff result from the following IPOL article and code:
     https://www.ipol.im/pub/art/2011/g_lmii/.

--- a/python/cucim/src/cucim/skimage/metrics/tests/test_structural_similarity.py
+++ b/python/cucim/src/cucim/skimage/metrics/tests/test_structural_similarity.py
@@ -188,7 +188,6 @@ def test_structural_similarity_multichannel_chelsea():
     assert_equal(structural_similarity(Xc, Xc, channel_axis=-1), 1.0)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_gaussian_structural_similarity_vs_IPOL():
     """Tests vs. imdiff result from the following IPOL article and code:
     https://www.ipol.im/pub/art/2011/g_lmii/.
@@ -209,7 +208,6 @@ def test_gaussian_structural_similarity_vs_IPOL():
 @pytest.mark.parametrize(
     'dtype', [np.uint8, np.int32, np.float16, np.float32, np.float64]
 )
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_mssim_vs_legacy(dtype):
     # check that ssim with default options matches skimage 0.11 result
     mssim_skimage_0pt17 = 0.3674518327910367

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_j_invariant.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_j_invariant.py
@@ -23,12 +23,6 @@ noisy_img_3d = random_noise(test_img_3d, mode="gaussian", var=0.1)
 
 # TODO: replace with CuPy version once completed
 def _denoise_wavelet(image, rescale_sigma=True, **kwargs):
-
-    if 'channel_axis' in kwargs and skimage.__version__ < '0.19.0':
-        # convert channel_axis to older multichannel kwarg for skimage 0.18.x
-        channel_axis = kwargs.pop('channel_axis')
-        kwargs['multichannel'] = False if channel_axis is None else True
-
     return cp.asarray(
         denoise_wavelet(
             cp.asnumpy(image), rescale_sigma=rescale_sigma, **kwargs

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_j_invariant.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_j_invariant.py
@@ -1,7 +1,6 @@
 import cupy as cp
 import numpy as np
 import pytest
-import skimage
 from skimage.data import camera, chelsea
 # from cucim.skimage.restoration import denoise_wavelet
 from skimage.restoration import denoise_wavelet

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
@@ -136,7 +136,6 @@ def test_unsupervised_wiener_deprecated_user_param():
         )
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_image_shape():
     """Test that shape of output image in deconvolution is same as input.
 
@@ -177,7 +176,6 @@ def test_richardson_lucy():
 
 @pytest.mark.parametrize('dtype_image', [cp.float16, cp.float32, cp.float64])
 @pytest.mark.parametrize('dtype_psf', [cp.float32, cp.float64])
-@testing.with_requires("scikit-image>=0.18")
 def test_richardson_lucy_filtered(dtype_image, dtype_psf):
     if dtype_image == cp.float64:
         atol = 1e-8

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
@@ -1,7 +1,6 @@
 import cupy as cp
 import numpy as np
 import pytest
-from cupy import testing
 from cupyx.scipy import ndimage as ndi
 from scipy import signal
 

--- a/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
+++ b/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
@@ -171,7 +171,6 @@ def test_clip_poisson():
     assert (cam_poisson2.max() > 1.3) and (cam_poisson2.min() == -1.0)
 
 
-@cp.testing.with_requires("scikit-image>=0.18")
 def test_clip_gaussian():
     seed = 42
     data = camerad  # 512x512 grayscale uint8


### PR DESCRIPTION
closes #581

This is a maintenance PR that removes some version checks that are no longer relevant (we require skimage >= 0.19 now to install cuCIM)
