### PR TITLE
Remove libwebp-base upper bound.

### DIFF
--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -13,9 +13,6 @@ cuda11_compiler:
 sysroot_version:
   - "2.17"
 
-libwebp_base_version:
-  - "<1.3a0"
-
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package
 # for CUDA 11. The "*_host_*" version specifiers correspond to `11.8` packages
 # and the "*_run_*" version specifiers correspond to `11.x` packages.

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -68,7 +68,7 @@ requirements:
     - libnvjpeg-static
     {% endif %}
     - jbig
-    - libwebp-base {{ libwebp_base_version }}
+    - libwebp-base
     - nvtx-c >=3.1.0
     - openslide
     - xz


### PR DESCRIPTION
Reverts the `libwebp-base` upper bound introduced in #541 because it causes conflicts seen in https://github.com/rapidsai/integration/pull/674.