### PR TITLE
Standardize on `rng` over `seed` and fix miscellaneous deprecation warnings

### DIFF
--- a/benchmarks/skimage/cucim_metrics_bench.py
+++ b/benchmarks/skimage/cucim_metrics_bench.py
@@ -51,10 +51,10 @@ class SegmentationMetricBench(ImageBench):
             run_cpu=run_cpu,
         )
 
-    def _generate_labels(self, dtype, seed=5):
+    def _generate_labels(self, dtype, rng=5):
         ndim = len(self.shape)
         blobs_kwargs = dict(
-            blob_size_fraction=0.05, volume_fraction=0.35, seed=seed
+            blob_size_fraction=0.05, volume_fraction=0.35, rng=rng
         )
         # binary blobs only creates square outputs
         labels = measure.label(
@@ -67,8 +67,8 @@ class SegmentationMetricBench(ImageBench):
         return labels.astype(dtype, copy=False)
 
     def set_args(self, dtype):
-        labels1_d = self._generate_labels(dtype, seed=5)
-        labels2_d = self._generate_labels(dtype, seed=3)
+        labels1_d = self._generate_labels(dtype, rng=5)
+        labels2_d = self._generate_labels(dtype, rng=3)
         labels1 = cp.asnumpy(labels1_d)
         labels2 = cp.asnumpy(labels2_d)
         self.args_cpu = (labels1, labels2)

--- a/benchmarks/skimage/cucim_segmentation_bench.py
+++ b/benchmarks/skimage/cucim_segmentation_bench.py
@@ -42,7 +42,7 @@ class LabelBench(ImageBench):
     def _generate_labels(self, dtype):
         ndim = len(self.shape)
         blobs_kwargs = dict(
-            blob_size_fraction=0.05, volume_fraction=0.35, seed=5
+            blob_size_fraction=0.05, volume_fraction=0.35, rng=5
         )
         # binary blobs only creates square outputs
         labels = measure.label(
@@ -107,7 +107,7 @@ class RandomWalkerBench(ImageBench):
         n_dim = len(self.shape)
         data = cucim.skimage.img_as_float(
             cucim.skimage.data.binary_blobs(
-                length=max(self.shape), n_dim=n_dim, seed=1
+                length=max(self.shape), n_dim=n_dim, rng=1
             )
         )
         data = data[tuple(slice(s) for s in self.shape)]

--- a/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
@@ -157,7 +157,7 @@ def distance_transform_edt(
         if len(unique_sampling) == 1:
             # In the isotropic case, can use the kernels without sample scaling
             # and just adjust the final distance accordingly.
-            scalar_sampling = float(unique_sampling)
+            scalar_sampling = float(unique_sampling[0])
             sampling = None
 
     if image.ndim == 3:

--- a/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_distance_transform.py
@@ -1,4 +1,4 @@
-import numpy as np
+import cupy as cp
 
 from ._pba_2d import _pba_2d
 from ._pba_3d import _pba_3d
@@ -153,11 +153,11 @@ def distance_transform_edt(
     """
     scalar_sampling = None
     if sampling is not None:
-        unique_sampling = np.unique(np.atleast_1d(sampling))
+        unique_sampling = cp.unique(cp.atleast_1d(sampling))
         if len(unique_sampling) == 1:
             # In the isotropic case, can use the kernels without sample scaling
             # and just adjust the final distance accordingly.
-            scalar_sampling = float(unique_sampling[0])
+            scalar_sampling = float(unique_sampling)
             sampling = None
 
     if image.ndim == 3:

--- a/python/cucim/src/cucim/skimage/_shared/utils.py
+++ b/python/cucim/src/cucim/skimage/_shared/utils.py
@@ -638,8 +638,7 @@ def check_random_state(seed):
     if isinstance(seed, cp.random.RandomState):
         return seed
     raise ValueError(
-        "%r cannot be used to seed a numpy.random.RandomState"
-        " instance" % seed
+        "%r cannot be used to seed a cupy.random.RandomState" " instance" % seed
     )
 
 

--- a/python/cucim/src/cucim/skimage/_shared/utils.py
+++ b/python/cucim/src/cucim/skimage/_shared/utils.py
@@ -638,7 +638,7 @@ def check_random_state(seed):
     if isinstance(seed, cp.random.RandomState):
         return seed
     raise ValueError(
-        "%r cannot be used to seed a cupy.random.RandomState" " instance" % seed
+        f"{seed} cannot be used to seed a cupy.random.RandomState instance"
     )
 
 

--- a/python/cucim/src/cucim/skimage/data/tests/test_data.py
+++ b/python/cucim/src/cucim/skimage/data/tests/test_data.py
@@ -1,4 +1,5 @@
 import cupy as cp
+import pytest
 from numpy.testing import assert_almost_equal
 
 from cucim.skimage import data
@@ -15,3 +16,8 @@ def test_binary_blobs():
         length=32, volume_fraction=0.25, n_dim=3
     )
     assert not cp.all(blobs == other_realization)
+
+
+def test_binary_blobs_futurewarning():
+    with pytest.warns(FutureWarning):
+        data.binary_blobs(length=128, seed=5)

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -342,7 +342,7 @@ def _reference_eigvals_computation(S_elems):
 def test_custom_eigvals_kernels_vs_linalg_eigvalsh(shape, dtype):
     rng = cp.random.default_rng(seed=5)
     img = rng.integers(0, 256, shape)
-    H = hessian_matrix(img)
+    H = hessian_matrix(img, use_gaussian_derivatives=False)
     H = tuple(h.astype(dtype, copy=False) for h in H)
     evs1 = _reference_eigvals_computation(H)
     evs2 = hessian_matrix_eigvals(H)

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -492,8 +492,8 @@ def test_corner_foerstner_dtype(dtype):
 def test_noisy_square_image():
     im = cp.zeros((50, 50)).astype(float)
     im[:25, :25] = 1.0
-    np.random.seed(seed=1234)  # result is specific to this NumPy seed
-    im = im + cp.asarray(np.random.uniform(size=im.shape)) * 0.2
+    rng = np.random.default_rng(1234)  # result is specific to this NumPy seed
+    im = im + cp.asarray(rng.uniform(size=im.shape)) * 0.2
 
     # # Moravec
     # results = peak_local_max(corner_moravec(im),

--- a/python/cucim/src/cucim/skimage/filters/tests/test_edges.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_edges.py
@@ -640,7 +640,7 @@ MAX_FARID_ND = cp.array([
     ],
 )
 def test_3d_edge_filters(func, max_edge):
-    blobs = binary_blobs(length=128, n_dim=3, seed=5)
+    blobs = binary_blobs(length=128, n_dim=3, rng=5)
     edges = func(blobs)
     center = max_edge.shape[0] // 2
     if center == 2:
@@ -663,7 +663,7 @@ def test_3d_edge_filters(func, max_edge):
     ],
 )
 def test_3d_edge_filters_single_axis(func, max_edge):
-    blobs = binary_blobs(length=128, n_dim=3, seed=5)
+    blobs = binary_blobs(length=128, n_dim=3, rng=5)
     edges0 = func(blobs, axis=0)
     center = max_edge.shape[0] // 2
     if center == 2:

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_binary.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_binary.py
@@ -65,7 +65,7 @@ def _get_decomp_test_data(function, ndim=2):
         img = cp.zeros((17,) * ndim, dtype=cp.uint8)
         img[(8,) * ndim] = 1
     else:
-        img = cp.asarray(data.binary_blobs(32, n_dim=ndim, seed=1))
+        img = cp.asarray(data.binary_blobs(32, n_dim=ndim, rng=1))
     return img
 
 

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -1,4 +1,5 @@
 import cupy as cp
+import numpy as np
 import pytest
 from cupy.testing import assert_array_equal
 from skimage import data
@@ -93,7 +94,7 @@ class TestMedialAxis:
         result = medial_axis(cp.zeros((10, 10), bool), cp.zeros((10, 10), bool))
         assert not cp.any(result)
 
-    def test_vertical_line(self):
+    def _test_vertical_line(self, **kwargs):
         """Test a thick vertical line, issue #3861"""
         img = cp.zeros((9, 9))
         img[:, 2] = 1
@@ -103,8 +104,34 @@ class TestMedialAxis:
         expected = cp.full(img.shape, False)
         expected[:, 3] = True
 
-        result = medial_axis(img)
+        result = medial_axis(img, **kwargs)
         assert_array_equal(result, expected)
+
+    def test_vertical_line(self):
+        """Test a thick vertical line, issue #3861"""
+        self._test_vertical_line()
+
+    def test_rng_numpy(self):
+        # NumPy Generator allowed
+        self._test_vertical_line(rng=np.random.default_rng())
+
+    def test_rng_cupy(self):
+        # CuPy Generator not currently supported
+        with pytest.raises(ValueError):
+            self._test_vertical_line(rng=cp.random.default_rng())
+
+    def test_rng_int(self):
+        self._test_vertical_line(rng=15)
+
+    def test_vertical_line_seed(self):
+        """seed was deprecated (now use rng)"""
+        with pytest.warns(FutureWarning):
+            self._test_vertical_line(seed=15)
+
+    def test_vertical_line_random_state(self):
+        """random_state was deprecated (now use rng)"""
+        with pytest.warns(FutureWarning):
+            self._test_vertical_line(random_state=15)
 
     def test_01_01_rectangle(self):
         """Test skeletonize on a rectangle"""

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
@@ -143,6 +143,19 @@ def test_unsupervised_wiener_deprecated_user_param():
             random_state=5,
         )
 
+    with expected_warnings(
+        [
+            "`seed` is a deprecated argument name",
+        ]
+    ):
+        restoration.unsupervised_wiener(
+            data,
+            otf,
+            reg=laplacian,
+            is_real=False,
+            seed=5,
+        )
+
 
 def test_image_shape():
     """Test that shape of output image in deconvolution is same as input.

--- a/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
+++ b/python/cucim/src/cucim/skimage/restoration/tests/test_restoration.py
@@ -80,7 +80,7 @@ def test_unsupervised_wiener(dtype):
 
     psf = cp.asarray(psf, dtype=dtype)
     data = cp.asarray(data, dtype=dtype)
-    deconvolved, _ = restoration.unsupervised_wiener(data, psf, seed=seed)
+    deconvolved, _ = restoration.unsupervised_wiener(data, psf, rng=seed)
     float_type = _supported_float_type(dtype)
     assert deconvolved.dtype == float_type
 
@@ -108,7 +108,7 @@ def test_unsupervised_wiener(dtype):
             "max_num_iter": 200,
             "min_num_iter": 30,
         },
-        seed=seed,
+        rng=seed,
     )[0]
     assert deconvolved2.real.dtype == float_type
 

--- a/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
+++ b/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
@@ -4,6 +4,7 @@ from cupy.testing import assert_allclose, assert_array_equal
 from skimage.data import camera
 
 from cucim.skimage.util import img_as_float, random_noise
+from cucim.skimage.util.noise import _normal
 
 camerad = cp.asarray(camera())
 
@@ -11,14 +12,14 @@ camerad = cp.asarray(camera())
 def test_set_seed():
     seed = 42
     cam = cp.asarray(camerad)
-    test = random_noise(cam, seed=seed)
-    assert_array_equal(test, random_noise(cam, seed=seed))
+    test = random_noise(cam, rng=seed)
+    assert_array_equal(test, random_noise(cam, rng=seed))
 
 
 def test_salt():
-    seed = 42
+    amount = 0.15
     cam = img_as_float(camerad)
-    cam_noisy = random_noise(cam, seed=seed, mode="salt", amount=0.15)
+    cam_noisy = random_noise(cam, rng=42, mode="salt", amount=amount)
     saltmask = cam != cam_noisy
 
     # Ensure all changes are to 1.0
@@ -26,7 +27,8 @@ def test_salt():
 
     # Ensure approximately correct amount of noise was added
     proportion = float(saltmask.sum()) / (cam.shape[0] * cam.shape[1])
-    assert 0.11 < proportion <= 0.15
+    tolerance = 1e-2
+    assert abs(amount - proportion) <= tolerance
 
 
 def test_salt_p1():
@@ -38,7 +40,7 @@ def test_salt_p1():
 def test_singleton_dim():
     """Ensure images where size of a given dimension is 1 work correctly."""
     image = cp.random.rand(1, 20)
-    noisy = random_noise(image, mode="salt", amount=0.1, seed=42)
+    noisy = random_noise(image, mode="salt", amount=0.1, rng=42)
     assert cp.sum(noisy == 1) == 3  # GRL: modified to match value for CuPy
 
 
@@ -47,7 +49,8 @@ def test_pepper():
     cam = img_as_float(camerad)
     data_signed = cam * 2.0 - 1.0  # Same image, on range [-1, 1]
 
-    cam_noisy = random_noise(cam, seed=seed, mode="pepper", amount=0.15)
+    amount = 0.15
+    cam_noisy = random_noise(cam, rng=seed, mode="pepper", amount=amount)
     peppermask = cam != cam_noisy
 
     # Ensure all changes are to 1.0
@@ -55,25 +58,26 @@ def test_pepper():
 
     # Ensure approximately correct amount of noise was added
     proportion = float(peppermask.sum()) / (cam.shape[0] * cam.shape[1])
-    assert 0.11 < proportion <= 0.15
+    tolerance = 1e-2
+    assert abs(amount - proportion) <= tolerance
 
     # Check to make sure pepper gets added properly to signed images
     orig_zeros = (data_signed == -1).sum()
     cam_noisy_signed = random_noise(
-        data_signed, seed=seed, mode="pepper", amount=0.15
+        data_signed, rng=seed, mode="pepper", amount=0.15
     )
 
     proportion = float((cam_noisy_signed == -1).sum() - orig_zeros) / (
         cam.shape[0] * cam.shape[1]
     )
-    assert 0.11 < proportion <= 0.15
+    assert abs(amount - proportion) <= tolerance
 
 
 def test_salt_and_pepper():
     seed = 42
     cam = img_as_float(camerad)
     cam_noisy = random_noise(
-        cam, seed=seed, mode="s&p", amount=0.15, salt_vs_pepper=0.25
+        cam, rng=seed, mode="s&p", amount=0.15, salt_vs_pepper=0.25
     )
     saltmask = cp.logical_and(cam != cam_noisy, cam_noisy == 1.0)
     peppermask = cp.logical_and(cam != cam_noisy, cam_noisy == 0.0)
@@ -95,10 +99,10 @@ def test_salt_and_pepper():
 def test_gaussian():
     seed = 42
     data = cp.zeros((128, 128)) + 0.5
-    data_gaussian = random_noise(data, seed=seed, var=0.01)
+    data_gaussian = random_noise(data, rng=seed, var=0.01)
     assert 0.008 < data_gaussian.var() < 0.012
 
-    data_gaussian = random_noise(data, seed=seed, mean=0.3, var=0.015)
+    data_gaussian = random_noise(data, rng=seed, mean=0.3, var=0.015)
     assert 0.28 < data_gaussian.mean() - 0.5 < 0.32
     assert 0.012 < data_gaussian.var() < 0.018
 
@@ -112,7 +116,7 @@ def test_localvar():
     local_vars[64:, 64:] = 0.45
 
     data_gaussian = random_noise(
-        data, mode="localvar", seed=seed, local_vars=local_vars, clip=False
+        data, mode="localvar", rng=seed, local_vars=local_vars, clip=False
     )
     assert 0.0 < data_gaussian[:64, :64].var() < 0.002
     assert 0.095 < data_gaussian[:64, 64:].var() < 0.105
@@ -122,27 +126,24 @@ def test_localvar():
     # Ensure local variance bounds checking works properly
     bad_local_vars = cp.zeros_like(data)
     with pytest.raises(ValueError):
-        random_noise(
-            data, mode="localvar", seed=seed, local_vars=bad_local_vars
-        )
+        random_noise(data, mode="localvar", rng=seed, local_vars=bad_local_vars)
 
     bad_local_vars += 0.1
     bad_local_vars[0, 0] = -1
     with pytest.raises(ValueError):
-        random_noise(
-            data, mode="localvar", seed=seed, local_vars=bad_local_vars
-        )
+        random_noise(data, mode="localvar", rng=seed, local_vars=bad_local_vars)
 
 
 def test_speckle():
     seed = 42
     data = cp.zeros((128, 128)) + 0.1
-    cp.random.seed(seed=seed)
-    noise = cp.random.normal(0.1, 0.02**0.5, (128, 128))
+
+    rng = cp.random.default_rng(seed)
+    noise = _normal(rng, 0.1, 0.02**0.5, (128, 128))
     expected = cp.clip(data + data * noise, 0, 1)
 
     data_speckle = random_noise(
-        data, mode="speckle", seed=seed, mean=0.1, var=0.02
+        data, mode="speckle", rng=seed, mean=0.1, var=0.02
     )
     assert_allclose(expected, data_speckle)
 
@@ -150,11 +151,11 @@ def test_speckle():
 def test_poisson():
     seed = 42
     data = camerad  # 512x512 grayscale uint8
-    cam_noisy = random_noise(data, mode="poisson", seed=seed)
-    cam_noisy2 = random_noise(data, mode="poisson", seed=seed, clip=False)
+    cam_noisy = random_noise(data, mode="poisson", rng=seed)
+    cam_noisy2 = random_noise(data, mode="poisson", rng=seed, clip=False)
 
-    cp.random.seed(seed=seed)
-    expected = cp.random.poisson(img_as_float(data) * 256) / 256.0
+    rng = cp.random.default_rng(seed)
+    expected = rng.poisson(img_as_float(data) * 256) / 256.0
     assert_allclose(cam_noisy, cp.clip(expected, 0.0, 1.0))
     assert_allclose(cam_noisy2, expected)
 
@@ -165,17 +166,17 @@ def test_clip_poisson():
     data_signed = img_as_float(data) * 2.0 - 1.0  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
-    cam_poisson = random_noise(data, mode="poisson", seed=seed, clip=True)
+    cam_poisson = random_noise(data, mode="poisson", rng=seed, clip=True)
     cam_poisson2 = random_noise(
-        data_signed, mode="poisson", seed=seed, clip=True
+        data_signed, mode="poisson", rng=seed, clip=True
     )
     assert (cam_poisson.max() == 1.0) and (cam_poisson.min() == 0.0)
     assert (cam_poisson2.max() == 1.0) and (cam_poisson2.min() == -1.0)
 
     # Signed and unsigned, unclipped
-    cam_poisson = random_noise(data, mode="poisson", seed=seed, clip=False)
+    cam_poisson = random_noise(data, mode="poisson", rng=seed, clip=False)
     cam_poisson2 = random_noise(
-        data_signed, mode="poisson", seed=seed, clip=False
+        data_signed, mode="poisson", rng=seed, clip=False
     )
     assert (cam_poisson.max() > 1.15) and (cam_poisson.min() == 0.0)
     assert (cam_poisson2.max() > 1.3) and (cam_poisson2.min() == -1.0)
@@ -187,17 +188,15 @@ def test_clip_gaussian():
     data_signed = img_as_float(data) * 2.0 - 1.0  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
-    cam_gauss = random_noise(data, mode="gaussian", seed=seed, clip=True)
-    cam_gauss2 = random_noise(
-        data_signed, mode="gaussian", seed=seed, clip=True
-    )
+    cam_gauss = random_noise(data, mode="gaussian", rng=seed, clip=True)
+    cam_gauss2 = random_noise(data_signed, mode="gaussian", rng=seed, clip=True)
     assert (cam_gauss.max() == 1.0) and (cam_gauss.min() == 0.0)
     assert (cam_gauss2.max() == 1.0) and (cam_gauss2.min() == -1.0)
 
     # Signed and unsigned, unclipped
-    cam_gauss = random_noise(data, mode="gaussian", seed=seed, clip=False)
+    cam_gauss = random_noise(data, mode="gaussian", rng=seed, clip=False)
     cam_gauss2 = random_noise(
-        data_signed, mode="gaussian", seed=seed, clip=False
+        data_signed, mode="gaussian", rng=seed, clip=False
     )
     assert (cam_gauss.max() > 1.22) and (cam_gauss.min() < -0.33)
     assert (cam_gauss2.max() > 1.219) and (cam_gauss2.min() < -1.219)
@@ -209,17 +208,17 @@ def test_clip_speckle():
     data_signed = img_as_float(data) * 2.0 - 1.0  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
-    cam_speckle = random_noise(data, mode="speckle", seed=seed, clip=True)
+    cam_speckle = random_noise(data, mode="speckle", rng=seed, clip=True)
     cam_speckle_sig = random_noise(
-        data_signed, mode="speckle", seed=seed, clip=True
+        data_signed, mode="speckle", rng=seed, clip=True
     )
     assert (cam_speckle.max() == 1.0) and (cam_speckle.min() == 0.0)
     assert (cam_speckle_sig.max() == 1.0) and (cam_speckle_sig.min() == -1.0)
 
     # Signed and unsigned, unclipped
-    cam_speckle = random_noise(data, mode="speckle", seed=seed, clip=False)
+    cam_speckle = random_noise(data, mode="speckle", rng=seed, clip=False)
     cam_speckle_sig = random_noise(
-        data_signed, mode="speckle", seed=seed, clip=False
+        data_signed, mode="speckle", rng=seed, clip=False
     )
     assert (cam_speckle.max() > 1.219) and (cam_speckle.min() == 0.0)
     assert (cam_speckle_sig.max() > 1.219) and (cam_speckle_sig.min() < -1.219)

--- a/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
+++ b/python/cucim/src/cucim/skimage/util/tests/test_random_noise.py
@@ -16,6 +16,14 @@ def test_set_seed():
     assert_array_equal(test, random_noise(cam, rng=seed))
 
 
+def test_random_noise_futurewarning():
+    seed = 42
+    cam = cp.asarray(camerad)
+    with pytest.warns(FutureWarning):
+        test = random_noise(cam, seed=seed)
+    assert_array_equal(test, random_noise(cam, rng=seed))
+
+
 def test_salt():
     amount = 0.15
     cam = img_as_float(camerad)


### PR DESCRIPTION
This PR fixes the following warnings observed when running the test suite:

```
src/cucim/core/operations/morphology/tests/test_distance_transform.py: 90 warnings
  /pyenv/versions/3.9.18/lib/python3.9/site-packages/cucim/core/operations/morphology/_distance_transform.py:160: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    scalar_sampling = float(unique_sampling)
```

```
 src/cucim/skimage/feature/tests/test_corner.py::test_custom_eigvals_kernels_vs_linalg_eigvalsh[float64-shape2]
  /__w/cucim/cucim/python/cucim/src/cucim/skimage/feature/tests/test_corner.py:345: FutureWarning: use_gaussian_derivatives currently defaults to False, but will change to True in a future version. Please specify this argument explicitly to maintain the current behavior
    H = hessian_matrix(img)
```

```
 src/cucim/skimage/morphology/tests/test_binary.py: 148 warnings
  /__w/cucim/cucim/python/cucim/src/cucim/skimage/morphology/tests/test_binary.py:68: FutureWarning: `seed` is a deprecated argument name for `binary_blobs`. It will be removed in version 0.23. Please use `rng` instead.
    img = cp.asarray(data.binary_blobs(32, n_dim=ndim, seed=1))
```
