### PR TITLE
update version string (e.g. for CHANGELOG link) in pyproject.toml

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -43,6 +43,7 @@ sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" cucim.code-workspace
 sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" README.md
 sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" python/cucim/README.md
+sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" python/cucim/pyproject.toml
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"


### PR DESCRIPTION
There is a version-specific CHANGELOG link in the `pyproject.toml`. This PR makes sure the version will be changed appropriately by the update-version.sh script.

After this change, running "ci/release/update-version.sh" in branch 23.12 followed by
```
grep -r "23\.12\|23\.12|0\.35" --exclude=CHANGELOG.md --exclude-dir=.git .
```

Results in only the following remaining "23.12" version strings, but these are all expected and should remain. They are part of `FutureWarning` messages about the specific release in which a feature was deprecated or is scheduled to be removed.
```
./python/cucim/src/cucim/skimage/filters/lpi_filter.py:    removed_version="2023.12.00",
./python/cucim/src/cucim/skimage/data/_binary_blobs.py:    {"seed": "rng"}, deprecated_version="23.12.00", removed_version="24.12.00"
./python/cucim/src/cucim/skimage/morphology/_skeletonize.py:    {"seed": "rng"}, deprecated_version="23.12", removed_version="24.12"
./python/cucim/src/cucim/skimage/util/noise.py:    {"seed": "rng"}, deprecated_version="23.12", removed_version="24.12"
```

I will make a separate PR to carry out the scheduled function removal for 2023.12.00 mentioned in the `lpi_filter.py` output. 