### PR TITLE
carry out removals of previously deprecated functions/kwargs

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/filters.py
+++ b/python/cucim/src/cucim/skimage/_shared/filters.py
@@ -81,8 +81,8 @@ def gaussian(
             ``multichannel=None`` was broken in version 0.19. In 0.20 this
             behavior is recovered. The last axis of an `image` with dimensions
             (M, N, 3) is interpreted as a color channel if `channel_axis` is
-            not set. Starting with 2023.03.06, ``channel_axis=None`` will be
-            used as the new default value.
+            not set. Starting with release 23.04.02, ``channel_axis=None`` will
+            be used as the new default value.
 
     Returns
     -------

--- a/python/cucim/src/cucim/skimage/filters/lpi_filter.py
+++ b/python/cucim/src/cucim/skimage/filters/lpi_filter.py
@@ -7,7 +7,7 @@ import cupy as cp
 import numpy as np
 from cupyx.scipy import fft
 
-from .._shared.utils import _supported_float_type, check_nD, deprecate_func
+from .._shared.utils import _supported_float_type, check_nD
 
 eps = np.finfo(float).eps
 
@@ -172,23 +172,6 @@ def filter_forward(
     if predefined_filter is None:
         predefined_filter = LPIFilter2D(impulse_response, **filter_params)
     return predefined_filter(data)
-
-
-@deprecate_func(
-    hint="use cucim.skimage.filters.lpi_filter.filter_inverse instead",
-    deprecated_version="",
-    removed_version="2023.12.00",
-)
-def inverse(
-    data,
-    impulse_response=None,
-    filter_params=None,
-    max_gain=2,
-    predefined_filter=None,
-):
-    return filter_inverse(
-        data, impulse_response, filter_params, max_gain, predefined_filter
-    )
 
 
 def filter_inverse(

--- a/python/cucim/src/cucim/skimage/filters/ridges.py
+++ b/python/cucim/src/cucim/skimage/filters/ridges.py
@@ -14,93 +14,12 @@ from warnings import warn
 import cupy as cp
 import numpy as np
 
-from .._shared.utils import _supported_float_type, check_nD, deprecate_func
+from .._shared.utils import _supported_float_type, check_nD
 from ..feature.corner import (
     _symmetric_compute_eigenvalues,
     hessian_matrix,
     hessian_matrix_eigvals,
 )
-from ..util import img_as_float
-
-
-@deprecate_func(deprecated_version="", removed_version="2023.06.01")
-def compute_hessian_eigenvalues(
-    image,
-    sigma,
-    sorting="none",
-    mode="constant",
-    cval=0,
-    use_gaussian_derivatives=False,
-):
-    """
-    Compute Hessian eigenvalues of nD images.
-
-    For 2D images, the computation uses a more efficient, skimage-based
-    algorithm.
-
-    Parameters
-    ----------
-    image : (N, ..., M) ndarray
-        Array with input image data.
-    sigma : float
-        Smoothing factor of image for detection of structures at different
-        (sigma) scales.
-    sorting : {'val', 'abs', 'none'}, optional
-        Sorting of eigenvalues by values ('val') or absolute values ('abs'),
-        or without sorting ('none'). Default is 'none'.
-    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
-        How to handle values outside the image borders.
-    cval : float, optional
-        Used in conjunction with mode 'constant', the value outside
-        the image boundaries.
-    use_gaussian_derivatives : boolean, optional
-        Indicates whether the Hessian is computed by convolving with Gaussian
-        derivatives, or by a simple finite-difference operation.
-
-    Returns
-    -------
-    eigenvalues : (D, N, ..., M) ndarray
-        Array with (sorted) eigenvalues of Hessian eigenvalues for each pixel
-        of the input image.
-    """
-
-    # Convert image to float
-    float_dtype = _supported_float_type(image.dtype)
-    # rescales integer images to [-1, 1]
-    image = img_as_float(image)
-    # make sure float16 gets promoted to float32
-    image = image.astype(float_dtype, copy=False)
-
-    # Make nD hessian
-    hessian_matrix_kwargs = dict(
-        sigma=sigma,
-        order="rc",
-        mode=mode,
-        cval=cval,
-        use_gaussian_derivatives=use_gaussian_derivatives,
-    )
-    hessian_elements = hessian_matrix(image, **hessian_matrix_kwargs)
-
-    if not use_gaussian_derivatives:
-        # Kept to preserve legacy behavior
-        var = sigma * sigma
-        hessian_elements = [var * e for e in hessian_elements]
-
-    # Compute Hessian eigenvalues
-    hessian_eigenvalues = hessian_matrix_eigvals(hessian_elements)
-
-    if sorting == "abs":
-        # Sort eigenvalues by absolute values in ascending order
-        hessian_eigenvalues = cp.take_along_axis(
-            hessian_eigenvalues, abs(hessian_eigenvalues).argsort(0), 0
-        )
-
-    elif sorting == "val":
-        # Sort eigenvalues by values in ascending order
-        hessian_eigenvalues = cp.sort(hessian_eigenvalues, axis=0)
-
-    # Return Hessian eigenvalues
-    return hessian_eigenvalues
 
 
 @cp.memoize(for_each_device=True)

--- a/python/cucim/src/cucim/skimage/measure/_regionprops_utils.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops_utils.py
@@ -6,8 +6,6 @@ import numpy as np
 
 from cucim.skimage._vendored import pad
 
-from .._shared.utils import deprecate_kwarg
-
 # Don't allocate STREL_* on GPU as we don't know in advance which device
 # fmt: off
 STREL_4 = np.array([[0, 1, 0],
@@ -195,11 +193,6 @@ def euler_number(image, connectivity=None):
         return int(0.125 * coefs @ h)
 
 
-@deprecate_kwarg(
-    kwarg_mapping={"neighbourhood": "neighborhood"},
-    removed_version="2023.06.00",
-    deprecated_version="2022.12.00",
-)
 def perimeter(image, neighborhood=4):
     """Calculate total perimeter of all objects in binary image.
 
@@ -232,9 +225,9 @@ def perimeter(image, neighborhood=4):
     >>> # coins image (binary)
     >>> img_coins = cp.array(data.coins() > 110)
     >>> # total perimeter of all objects in the image
-    >>> perimeter(img_coins, neighbourhood=4)  # doctest: +ELLIPSIS
+    >>> perimeter(img_coins, neighborhood=4)  # doctest: +ELLIPSIS
     array(7796.86799644)
-    >>> perimeter(img_coins, neighbourhood=8)  # doctest: +ELLIPSIS
+    >>> perimeter(img_coins, neighborhood=8)  # doctest: +ELLIPSIS
     array(8806.26807333)
 
     """

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -10,7 +10,6 @@ from skimage import data, draw
 from skimage.segmentation import slic
 
 from cucim.skimage import transform
-from cucim.skimage._shared._warnings import expected_warnings
 from cucim.skimage._vendored import pad
 from cucim.skimage.measure import (
     euler_number,
@@ -756,8 +755,7 @@ def test_perimeter():
     per = regionprops(SAMPLE, spacing=(2, 2))[0].perimeter
     assert_almost_equal(per, 2 * target_per)
 
-    with expected_warnings(["`neighbourhood` is a deprecated argument name"]):
-        per = perimeter(SAMPLE.astype(float), neighbourhood=8)
+    per = perimeter(SAMPLE.astype(float), neighborhood=8)
     assert_almost_equal(per, 46.8284271247)
 
     with pytest.raises(NotImplementedError):

--- a/python/cucim/src/cucim/skimage/restoration/deconvolution.py
+++ b/python/cucim/src/cucim/skimage/restoration/deconvolution.py
@@ -149,13 +149,13 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
 
 @deprecate_kwarg(
     {"random_state": "rng"},
-    removed_version="23.08.00",
-    deprecated_version="24.06.00",
+    removed_version="24.12.00",
+    deprecated_version="23.08.00",
 )
 @deprecate_kwarg(
     {"seed": "rng"},
-    removed_version="23.08.00",
-    deprecated_version="24.12.00",
+    removed_version="24.12.00",
+    deprecated_version="23.12.00",
 )
 def unsupervised_wiener(
     image,


### PR DESCRIPTION
Carry out a scheduled removal of the `inverse` and `compute_hessian_eigenvalues` functions. These were not part of the top level submodule APIs, but not technically private previously so were on a deprecation cycle before their eventual removal.

A couple other minor fixes were made:
- deprecated/removed versions were wrong in `unsupervised_wiener`
- updated a docstring for Gaussian which indicated a kwarg default change would have already taken place. I think we can just make the actual change in the next release rather than this one. (It was not yet changed in the latest scikit-image release, but has been changed on scikit-image main)