### PR TITLE
Add `setup.cfg` to disable `universal` wheels

### DIFF
--- a/python/cucim/setup.cfg
+++ b/python/cucim/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 0


### PR DESCRIPTION
Attempting to address issue: https://github.com/rapidsai/cucim/issues/641