### PR TITLE
Retag wheels to be `cpXY`

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -45,6 +45,10 @@ cd "${package_dir}"
 
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
+# Fix Python wheel tag to be restricted to CPython and version dependent
+WHEEL_PYTHON_TAG=`python -c 'import sys; print("cp{0}{1}".format(*sys.version_info[:2]))'`
+python -m wheel tags --remove --python-tag="${WHEEL_PYTHON_TAG}" --abi-tag="${WHEEL_PYTHON_TAG}" dist/*
+
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -50,7 +50,7 @@ python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 # tags that incorrectly indicate it is a universal wheel. To fix this, we need to modify the wheel
 # to have CPython ABI and Python tags matching the version of Python that the Python bindings were
 # built with.
-WHEEL_PYTHON_TAG=`python -c 'import sys; print("cp{0}{1}".format(*sys.version_info[:2]))'`
+WHEEL_PYTHON_TAG=cp$(echo ${RAPIDS_PY_VERSION} | sed 's/\.//g')
 python -m wheel tags --remove --python-tag="${WHEEL_PYTHON_TAG}" --abi-tag="${WHEEL_PYTHON_TAG}" dist/*
 
 mkdir -p final_dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -45,7 +45,11 @@ cd "${package_dir}"
 
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
-# Fix Python wheel tag to be restricted to CPython and version dependent
+# Because we built the library with the run script and manually copied the shared pybind11
+# library, the subsequent py_project.toml wheel build was as a pure Python package and results in
+# tags that incorrectly indicate it is a universal wheel. To fix this, we need to modify the wheel
+# to have CPython ABI and Python tags matching the version of Python that the Python bindings were
+# built with.
 WHEEL_PYTHON_TAG=`python -c 'import sys; print("cp{0}{1}".format(*sys.version_info[:2]))'`
 python -m wheel tags --remove --python-tag="${WHEEL_PYTHON_TAG}" --abi-tag="${WHEEL_PYTHON_TAG}" dist/*
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cucim/issues/641

After building the wheels, this...

* Creates the tag string from `cp` (CPython) and the `python`'s version
* Uses the tag string to replace the `python_tag` and `abi_tag`
* Removes the previous wheels while performing this conversion
* Hands them to `auditwheel` for final steps