### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -45,6 +45,14 @@ cd "${package_dir}"
 
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
+# Because we built the library with the run script and manually copied the shared pybind11
+# library, the subsequent py_project.toml wheel build was as a pure Python package and results in
+# tags that incorrectly indicate it is a universal wheel. To fix this, we need to modify the wheel
+# to have CPython ABI and Python tags matching the version of Python that the Python bindings were
+# built with.
+WHEEL_PYTHON_TAG=cp$(echo ${RAPIDS_PY_VERSION} | sed 's/\.//g')
+python -m wheel tags --remove --python-tag="${WHEEL_PYTHON_TAG}" --abi-tag="${WHEEL_PYTHON_TAG}" dist/*
+
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.