### PR TITLE
pin to OpenSlide <4 during the conda build of libcucim

### DIFF
--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -70,7 +70,7 @@ requirements:
     - jbig
     - libwebp-base
     - nvtx-c >=3.1.0
-    - openslide
+    - openslide <4
     - xz
     - zlib
     - zstd


### PR DESCRIPTION
A conda package for openslide 4.0 was released yesterday, but it appears to not automatically pull in a required libdicom dependency. Pin to openslide<4 for now to avoid this issue and because we have not tested the library with 4.0.
