### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,7 @@ python/            @rapidsai/cucim-python-codeowners
 **/cmake/          @rapidsai/cucim-cmake-codeowners
 
 #build/ops code owners
-.github/           @rapidsai/ops-codeowners
-ci/                @rapidsai/ops-codeowners
-conda/             @rapidsai/ops-codeowners
-**/Dockerfile      @rapidsai/ops-codeowners
-**/.dockerignore   @rapidsai/ops-codeowners
-docker/            @rapidsai/ops-codeowners
+/.github/           @rapidsai/ops-codeowners
+/ci/                @rapidsai/ops-codeowners
+/conda/             @rapidsai/ops-codeowners
 dependencies.yaml  @rapidsai/ops-codeowners


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to ensure that the Ops team doesn't get tagged for files that we're not concerned with.

This should prevent PRs like the following from soliciting us for approvals:

- https://github.com/rapidsai/cucim/pull/665
- https://github.com/rapidsai/cucim/pull/666

[skip ci]

