### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,9 +154,9 @@ dependencies:
             packages:
               - cuda-version=11.4
           - matrix:
-              cuda: "11.6"
+              cuda: "11.5"
             packages:
-              - cuda-version=11.6
+              - cuda-version=11.5
           - matrix:
               cuda: "11.8"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,8 @@ files:
       arch: [x86_64]
     includes:
       - build
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - checks
       - docs
       - py_version
@@ -16,7 +17,7 @@ files:
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python
   checks:
@@ -27,7 +28,7 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
       - py_version
   py_build:
@@ -140,7 +141,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - pre-commit
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
@@ -148,26 +149,33 @@ dependencies:
               cuda: "11.2"
             packages:
               - cuda-version=11.2
-              - cudatoolkit
           - matrix:
               cuda: "11.4"
             packages:
               - cuda-version=11.4
-              - cudatoolkit
           - matrix:
-              cuda: "11.5"
+              cuda: "11.6"
             packages:
-              - cuda-version=11.5
-              - cudatoolkit
+              - cuda-version=11.6
           - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8
-              - cudatoolkit
           - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.*"
+            packages:
+              - cudatoolkit
+          - matrix:
+              cuda: "12.*"
+            packages:
               - cuda-cudart-dev
               - libnvjpeg-dev
               - libcufile-dev


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI