### PR TITLE
Fix CI (pt. 2)

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -47,5 +47,6 @@ python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*
+ls -1 final_dist | grep -vqz 'none'
 
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -48,3 +48,4 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
 sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
+sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/test_python.sh

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
+export RAPIDS_VERSION_NUMBER="24.02"
+
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -35,7 +35,8 @@ rapids-print-env
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
-  libcucim cucim
+  "libcucim=${RAPIDS_VERSION_NUMBER}" \
+  "cucim=${RAPIDS_VERSION_NUMBER}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     - jbig
     - libwebp-base
     - nvtx-c >=3.1.0
-    - openslide 3
+    - openslide
     - xz
     - zlib
     - zstd

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     - jbig
     - libwebp-base
     - nvtx-c >=3.1.0
-    - openslide
+    - openslide 3
     - xz
     - zlib
     - zstd


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cucim/issues/664

* Pin RAPIDS packages to intended version (this helped find the `openslide` / `openslide-python` issue)
* Validate wheels have the expected name (no `none` in them like with pure wheels)