### PR TITLE
Consolidate test requirements in `dependencies.yaml`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -254,10 +254,10 @@ dependencies:
         packages:
           - GPUtil>=1.4.0
           - psutil>=5.8.0
+          - pytest>=6.2.4
           - pytest-cov>=2.12.1
           - pytest-lazy-fixture>=0.6.3
           - pytest-xdist
-          - pytest>=6.2.4
           - tifffile>=2022.7.28
           - pooch>=1.6.0  # needed to download scikit-image sample data
       - output_types: [conda]

--- a/python/cucim/requirements-test.txt
+++ b/python/cucim/requirements-test.txt
@@ -1,9 +1,0 @@
-GPUtil>=1.4.0
-imagecodecs>=2021.6.8
-openslide-python>=1.3.0
-opencv-python-headless>=4.6
-psutil>=5.8.0
-pytest>=6.2.4
-pytest-cov>=2.12.1
-pytest-lazy-fixture>=0.6.3
-tifffile>=2022.7.28

--- a/run
+++ b/run
@@ -608,11 +608,13 @@ install_python_test_deps_() {
         # (https://github.com/rapidsai/cucim/pull/433)
         run_command pip install -r ${TOP}/python/cucim/requirements-test.txt
     else
+        pushd "${TOP}/python/cucim"
         if [ -n "${VIRTUAL_ENV}" ]; then
-            run_command pip3 install -r ${TOP}/python/cucim/requirements-test.txt
+            run_command pip3 install -e .[test]
         else
-            run_command pip3 install --user -r ${TOP}/python/cucim/requirements-test.txt
+            run_command pip3 install --user -e .[test]
         fi
+	popd
     fi
     hash -r
 }


### PR DESCRIPTION
Instead of having test requirements in `requirements-test.txt` and `dependencies.yaml`, consolidate test requirements into `dependencies.yaml` and rely on that (and where it propagates) to handle installing test dependencies