### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/cpp/plugins/cucim.kit.cuslide/cmake/deps/libopenjpeg.cmake
+++ b/cpp/plugins/cucim.kit.cuslide/cmake/deps/libopenjpeg.cmake
@@ -18,7 +18,7 @@ if (NOT TARGET deps::libopenjpeg)
     FetchContent_Declare(
             deps-libopenjpeg
             GIT_REPOSITORY https://github.com/uclouvain/openjpeg.git
-            GIT_TAG v2.4.0
+            GIT_TAG v2.5.0
             GIT_SHALLOW TRUE
     )
     FetchContent_GetProperties(deps-libopenjpeg)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.