### PR TITLE
Update ops-bot.yaml

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -7,3 +7,4 @@ label_checker: true
 release_drafter: true
 external_contributors: false
 recently_updated: true
+forward_merger: true


### PR DESCRIPTION
This PR enables the ForwardMerger [ops-bot](https://github.com/rapidsai/ops-bot) plugin.
