### PR TITLE
Add support for Python 3.11, require NumPy 1.23+

### DIFF
--- a/benchmarks/skimage/_image_bench.py
+++ b/benchmarks/skimage/_image_bench.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import scipy.ndimage
 import skimage.data
-
 from cucim.time import repeat
 
 

--- a/benchmarks/skimage/bench_convolve.py
+++ b/benchmarks/skimage/bench_convolve.py
@@ -3,8 +3,6 @@ Benchmark locally modified ndimage functions vs. their CuPy counterparts
 """
 import cupy as cp
 import cupyx.scipy.ndimage as ndi
-from cupyx.profiler import benchmark
-
 from cucim.skimage._vendored.ndimage import (  # noqa: F401
     convolve1d,
     correlate1d,
@@ -18,6 +16,7 @@ from cucim.skimage._vendored.ndimage import (  # noqa: F401
     uniform_filter,
     uniform_filter1d,
 )
+from cupyx.profiler import benchmark
 
 d = cp.cuda.Device()
 

--- a/benchmarks/skimage/cucim_color_bench.py
+++ b/benchmarks/skimage/cucim_color_bench.py
@@ -2,6 +2,8 @@ import argparse
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.color
 import cupy
 import cupy as cp
 import cupyx.scipy.ndimage
@@ -11,9 +13,6 @@ import scipy
 import skimage
 import skimage.color
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.color
 
 func_name_choices = [
     "convert_colorspace",

--- a/benchmarks/skimage/cucim_exposure_bench.py
+++ b/benchmarks/skimage/cucim_exposure_bench.py
@@ -2,6 +2,8 @@ import argparse
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.exposure
 import cupy
 import cupy as cp
 import numpy as np
@@ -9,9 +11,6 @@ import pandas as pd
 import skimage
 import skimage.exposure
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.exposure
 
 
 class ExposureBench(ImageBench):

--- a/benchmarks/skimage/cucim_feature_bench.py
+++ b/benchmarks/skimage/cucim_feature_bench.py
@@ -3,17 +3,16 @@ import math
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.feature
 import cupy as cp
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.feature
 from _image_bench import ImageBench
-from skimage import data, draw
-
-import cucim.skimage
-import cucim.skimage.feature
 from cucim.skimage import exposure
+from skimage import data, draw
 
 
 class BlobDetectionBench(ImageBench):

--- a/benchmarks/skimage/cucim_filters_bench.py
+++ b/benchmarks/skimage/cucim_filters_bench.py
@@ -2,14 +2,13 @@ import argparse
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.filters
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.filters
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.filters
 
 
 def main(args):

--- a/benchmarks/skimage/cucim_measure_bench.py
+++ b/benchmarks/skimage/cucim_measure_bench.py
@@ -3,6 +3,8 @@ import math
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.measure
 import cupy as cp
 import numpy as np
 import pandas as pd
@@ -10,9 +12,6 @@ import skimage
 import skimage.measure
 from _image_bench import ImageBench
 from cucim_metrics_bench import MetricsBench
-
-import cucim.skimage
-import cucim.skimage.measure
 
 
 class LabelBench(ImageBench):

--- a/benchmarks/skimage/cucim_metrics_bench.py
+++ b/benchmarks/skimage/cucim_metrics_bench.py
@@ -2,15 +2,14 @@ import argparse
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.metrics
 import cupy as cp
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.metrics
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.metrics
 from cucim.skimage import data, measure
 
 

--- a/benchmarks/skimage/cucim_morphology_bench.py
+++ b/benchmarks/skimage/cucim_morphology_bench.py
@@ -6,6 +6,8 @@ import operator
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.morphology
 import cupy as cp
 import numpy as np
 import pandas as pd
@@ -14,9 +16,6 @@ import skimage
 import skimage.data
 import skimage.morphology
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.morphology
 
 
 class BinaryMorphologyBench(ImageBench):

--- a/benchmarks/skimage/cucim_registration_bench.py
+++ b/benchmarks/skimage/cucim_registration_bench.py
@@ -3,15 +3,14 @@ import math
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.registration
 import cupy as cp
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.registration
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.registration
 
 
 class RegistrationBench(ImageBench):

--- a/benchmarks/skimage/cucim_restoration_bench.py
+++ b/benchmarks/skimage/cucim_restoration_bench.py
@@ -3,6 +3,8 @@ import math
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.restoration
 import cupy as cp
 import cupyx.scipy.ndimage as ndi
 import numpy as np
@@ -10,11 +12,8 @@ import pandas as pd
 import skimage
 import skimage.restoration
 from _image_bench import ImageBench
-from skimage.restoration import denoise_tv_chambolle as tv_cpu
-
-import cucim.skimage
-import cucim.skimage.restoration
 from cucim.skimage.restoration import denoise_tv_chambolle as tv_gpu
+from skimage.restoration import denoise_tv_chambolle as tv_cpu
 
 
 class DenoiseBench(ImageBench):

--- a/benchmarks/skimage/cucim_segmentation_bench.py
+++ b/benchmarks/skimage/cucim_segmentation_bench.py
@@ -3,14 +3,13 @@ import math
 import os
 import pickle
 
+import cucim.skimage
 import cupy as cp
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.segmentation
 from _image_bench import ImageBench
-
-import cucim.skimage
 from cucim.skimage import data, measure
 
 

--- a/benchmarks/skimage/cucim_transform_bench.py
+++ b/benchmarks/skimage/cucim_transform_bench.py
@@ -2,14 +2,13 @@ import argparse
 import os
 import pickle
 
+import cucim.skimage
+import cucim.skimage.transform
 import numpy as np
 import pandas as pd
 import skimage
 import skimage.transform
 from _image_bench import ImageBench
-
-import cucim.skimage
-import cucim.skimage.transform
 
 
 def main(args):

--- a/ci/wheel_smoke_test.py
+++ b/ci/wheel_smoke_test.py
@@ -1,8 +1,6 @@
-import cupy as cp
-
 import cucim
 import cucim.skimage
-
+import cupy as cp
 
 if __name__ == "__main__":
     # verify that all top-level modules are available

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -40,7 +40,7 @@ dependencies:
 - pytest-lazy-fixture>=0.6.3
 - pytest-xdist
 - pytest>=6.2.4,<8.0.0a0
-- python>=3.8,<3.11
+- python>=3.8,<3.12
 - pywavelets>=1.0
 - recommonmark
 - scikit-image>=0.19.0,<0.23.0a0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - matplotlib-base
 - nbsphinx
 - ninja
-- numpy>=1.21.3
+- numpy>=1.23.4
 - numpydoc>=1.5
 - nvcc_linux-64=11.8
 - openslide-python>=1.3.0

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - matplotlib-base
 - nbsphinx
 - ninja
-- numpy>=1.21.3
+- numpy>=1.23.4
 - numpydoc>=1.5
 - openslide-python>=1.3.0
 - pip

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - pytest-lazy-fixture>=0.6.3
 - pytest-xdist
 - pytest>=6.2.4,<8.0.0a0
-- python>=3.8,<3.11
+- python>=3.8,<3.12
 - pywavelets>=1.0
 - recommonmark
 - scikit-image>=0.19.0,<0.23.0a0

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     {% endif %}
     - cupy >=12.0.0
     - libcucim ={{ version }}
-    - numpy 1.21
+    - numpy 1.23
     - python
     - scikit-image >=0.19.0,<0.23.0a0
     - scipy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -234,6 +234,10 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
+            packages:
+              - python=3.11
+          - matrix:
             packages:
               - python>=3.8,<3.11
   run:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -239,7 +239,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.8,<3.11
+              - python>=3.8,<3.12
   run:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -250,7 +250,7 @@ dependencies:
       - output_types: conda
         packages:
           - cupy>=12.0.0
-          - numpy>=1.21.3
+          - numpy>=1.23.4
           # All dependencies below this point are specific to `cucim.clara` and
           # are not needed for either `cucim.core` or `cucim.skimage`. I did
           # not include these under a "pyproject" output so that it is still

--- a/examples/python/distance_transform_edt_demo.py
+++ b/examples/python/distance_transform_edt_demo.py
@@ -10,11 +10,10 @@ except ImportError as e:
     print("This demo requires the matplotlib and colorcet packages.")
     raise (e)
 
-from skimage import data
-
 from cucim.core.operations.morphology import distance_transform_edt
 from cucim.skimage.color import label2rgb
 from cucim.skimage.segmentation import relabel_sequential
+from skimage import data
 
 
 def coords_to_labels(coords):

--- a/examples/python/gds_whole_slide/benchmark_round_trip.py
+++ b/examples/python/gds_whole_slide/benchmark_round_trip.py
@@ -1,15 +1,14 @@
 import os
 from time import time
 
+import cucim.skimage.filters
 import cupy as cp
 import kvikio
 import kvikio.defaults
 import numpy as np
+from cucim.core.operations.color import image_to_absorbance
 from cupyx.profiler import benchmark
 from demo_implementation import cupy_to_zarr, read_tiled
-
-import cucim.skimage.filters
-from cucim.core.operations.color import image_to_absorbance
 
 data_dir = os.environ.get("WHOLE_SLIDE_DATA_DIR", os.path.dirname("__file__"))
 fname = os.path.join(data_dir, "resize.tiff")

--- a/examples/python/gds_whole_slide/benchmark_zarr_write.py
+++ b/examples/python/gds_whole_slide/benchmark_zarr_write.py
@@ -4,11 +4,10 @@ import os
 import cupy as cp
 import kvikio.defaults
 import numpy as np
+from cucim.core.operations.color import image_to_absorbance
 from cupyx.profiler import benchmark
 from demo_implementation import cupy_to_zarr, get_n_tiles, read_tiled
 from tifffile import TiffFile
-
-from cucim.core.operations.color import image_to_absorbance
 
 data_dir = os.environ.get("WHOLE_SLIDE_DATA_DIR", os.path.dirname("__file__"))
 fname = os.path.join(data_dir, "resize.tiff")

--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -8,13 +8,12 @@ import kvikio.defaults
 import numpy as np
 import openslide
 import tifffile
+from cucim.clara import filesystem
 from kvikio.cufile import IOFuture
 from kvikio.zarr import GDSStore
 from tifffile import TiffFile
 from zarr import DirectoryStore
 from zarr.creation import init_array
-
-from cucim.clara import filesystem
 
 """
 Developed with Dask 2022.05.2

--- a/examples/python/tiff_image/main.py
+++ b/examples/python/tiff_image/main.py
@@ -16,9 +16,8 @@
 import json
 
 import numpy as np
-from PIL import Image
-
 from cucim import CuImage
+from PIL import Image
 
 img = CuImage("image.tif")
 

--- a/experiments/Supporting_Aperio_SVS_Format/benchmark.py
+++ b/experiments/Supporting_Aperio_SVS_Format/benchmark.py
@@ -19,10 +19,9 @@ from datetime import datetime
 from itertools import repeat
 from time import perf_counter
 
-from openslide import OpenSlide
-
 from cucim import CuImage
 from cucim.clara.filesystem import discard_page_cache  # noqa: F401
+from openslide import OpenSlide
 
 
 class Timer(ContextDecorator):

--- a/experiments/Using_Cache/benchmark.py
+++ b/experiments/Using_Cache/benchmark.py
@@ -21,10 +21,9 @@ from time import perf_counter
 
 import numpy as np
 import rasterio
+from cucim import CuImage
 from openslide import OpenSlide
 from rasterio.windows import Window
-
-from cucim import CuImage
 
 
 class Timer(ContextDecorator):


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

It also bumps uses of `NumPy` to `numpy>=1.23`, see https://github.com/rapidsai/build-planning/issues/3#issuecomment-1967952280.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
