### PR TITLE
Simplify version update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pip install cucim-cu11
 
 ### Notebooks
 
-Please check out our [Welcome](notebooks/Welcome.ipynb) notebook ([NBViewer](https://nbviewer.jupyter.org/github/rapidsai/cucim/blob/branch-24.04/notebooks/Welcome.ipynb))
+Please check out our [Welcome](notebooks/Welcome.ipynb) notebook ([NBViewer](https://nbviewer.org/github/rapidsai/cucim/blob/main/notebooks/Welcome.ipynb))
 
 #### Downloading sample images
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -24,7 +24,6 @@ rapids-mamba-retry install \
     --channel "${PYTHON_CHANNEL}" \
     cucim libcucim
 
-export RAPIDS_VERSION_NUMBER="24.04"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-logger "Build Python docs"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -42,7 +42,6 @@ sed_runner "s/v${CURRENT_LONG_TAG}/v${NEXT_FULL_TAG}/g" python/cucim/docs/gettin
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" python/cucim/docs/getting_started/index.md
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" cucim.code-workspace
 sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" README.md
-sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" python/cucim/pyproject.toml
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,5 +47,4 @@ sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NE
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
 sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/test_python.sh

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -41,7 +41,6 @@ sed_runner "s#\[Version ${CURRENT_LONG_TAG}\](release_notes/v${CURRENT_LONG_TAG}
 sed_runner "s/v${CURRENT_LONG_TAG}/v${NEXT_FULL_TAG}/g" python/cucim/docs/getting_started/index.md
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" python/cucim/docs/getting_started/index.md
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" cucim.code-workspace
-sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NEXT_MINOR}#g" README.md
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,4 +47,3 @@ sed_runner "s#branch-${CURRENT_MAJOR}.${CURRENT_MINOR}#branch-${NEXT_MAJOR}.${NE
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/test_python.sh

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -37,9 +37,6 @@ sed_runner 's/release = .*/release = "'"${NEXT_FULL_TAG}"'"/g' docs/source/conf.
 # Centralized version file update
 echo "${NEXT_FULL_TAG}" > VERSION
 
-sed_runner "s#\[Version ${CURRENT_LONG_TAG}\](release_notes/v${CURRENT_LONG_TAG}.md)#\[Version ${NEXT_FULL_TAG}\](release_notes/v${NEXT_FULL_TAG}.md)#g" python/cucim/docs/index.md
-sed_runner "s/v${CURRENT_LONG_TAG}/v${NEXT_FULL_TAG}/g" python/cucim/docs/getting_started/index.md
-sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" python/cucim/docs/getting_started/index.md
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" cucim.code-workspace
 
 for FILE in .github/workflows/*.yaml; do

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -5,9 +5,9 @@
 
 set -euo pipefail
 
-. /opt/conda/etc/profile.d/conda.sh
+RAPIDS_VERSION_NUMBER=$(rapids-generate-version)
 
-export RAPIDS_VERSION_NUMBER="24.04"
+. /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://developer.nvidia.com/multidimensional-image-processing"
 Documentation = "https://docs.rapids.ai/api/cucim/stable/"
-Changelog = "https://github.com/rapidsai/cucim/blob/branch-24.04/CHANGELOG.md"
+Changelog = "https://github.com/rapidsai/cucim/blob/main/CHANGELOG.md"
 Source = "https://github.com/rapidsai/cucim"
 Tracker = "https://github.com/rapidsai/cucim/issues"
 


### PR DESCRIPTION
* Drop version update steps for doc pages that no longer exist ( https://github.com/rapidsai/cucim/pull/666 )
* Use the `main` branch in links as that is updated every release