### PR TITLE
Switch `pytest-xdist` algorithm to `worksteal`

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -51,7 +51,7 @@ timeout 20m pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cucim.xml" \
   --numprocesses=8 \
-  --dist=loadscope \
+  --dist=worksteal \
   --cov-config=.coveragerc \
   --cov=cucim \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cucim-coverage.xml" \


### PR DESCRIPTION
This PR uses the `worksteal` algorithm to accelerate parallel pytests. See https://github.com/rapidsai/cudf/pull/15207.
