### PR TITLE
Require `click` as a wheel dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -244,6 +244,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
+          - click
           - lazy_loader>=0.1
           - numpy>=1.23.4,<2.0a0
           - scikit-image>=0.19.0,<0.23.0a0
@@ -257,7 +258,6 @@ dependencies:
           # possible to run `pip install .` from the python/cucim folder
           # without having build the C++ library at all. This allows, usage of
           # usage of `cucim.skimage` on Windows, for example.
-          - click
           - jbig
           - libwebp-base
           - xz
@@ -297,7 +297,6 @@ dependencies:
           - openslide-python>=1.3.0; platform_machine=='x86_64'
           - matplotlib
           - opencv-python-headless>=4.6
-          - click
       - output_types: [pyproject]
         packages:
           # Already added to requirements via docs. This is for tests.

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -24,6 +24,7 @@ authors = [
 license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
+    "click",
     "cupy-cuda11x>=12.0.0",
     "lazy_loader>=0.1",
     "numpy>=1.23.4,<2.0a0",
@@ -57,7 +58,6 @@ Tracker = "https://github.com/rapidsai/cucim/issues"
 [project.optional-dependencies]
 test = [
     "GPUtil>=1.4.0",
-    "click",
     "imagecodecs>=2021.6.8; platform_machine=='x86_64'",
     "matplotlib",
     "numpydoc>=1.5",


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cucim/issues/703

Trying to `import cucim` results in `import click`, which fails if `click` is not installed. This was encountered recently by a user that tested out the cuCIM wheel packages.

The Conda packages already solve this by adding `click` to `requirements/run`. So this makes an equivalent change to the wheel packages.

Should fix user install issues.