### PR TITLE
removal of deprecated functions/kwargs scheduled for release 24.06

### DIFF
--- a/benchmarks/skimage/cucim_morphology_bench.py
+++ b/benchmarks/skimage/cucim_morphology_bench.py
@@ -151,7 +151,7 @@ def main(args):
         # _skeletonize.py
         (
             "medial_axis",
-            dict(random_state=123),
+            dict(rng=123),
             dict(return_distance=[False, True]),
             False,
             False,

--- a/python/cucim/src/cucim/skimage/color/colorconv.py
+++ b/python/cucim/src/cucim/skimage/color/colorconv.py
@@ -58,7 +58,6 @@ from scipy import linalg
 from .._shared.utils import (
     _supported_float_type,
     channel_as_last_axis,
-    deprecate_func,
     identity,
 )
 from ..util import dtype, dtype_limits
@@ -697,43 +696,6 @@ def xyz_tristimulus_values(*, illuminant, observer, dtype=None):
             f"Unknown illuminant/observer combination "
             f"(`{illuminant}`, `{observer}`)"
         )
-
-
-@deprecate_func(
-    hint="Use `skimage.color.xyz_tristimulus_values` instead.",
-    deprecated_version="23.08",
-    removed_version="24.06",
-)
-def get_xyz_coords(illuminant, observer, dtype=float):
-    """Get the XYZ coordinates of the given illuminant and observer [1]_.
-
-    Parameters
-    ----------
-    illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
-        The name of the illuminant (the function is NOT case sensitive).
-    observer : {"2", "10", "R"}, optional
-        One of: 2-degree observer, 10-degree observer, or 'R' observer as in
-        R function grDevices::convertColor.
-    dtype: dtype, optional
-        Output data type.
-
-    Returns
-    -------
-    out : array
-        Array with 3 elements containing the XYZ coordinates of the given
-        illuminant.
-
-    Raises
-    ------
-    ValueError
-        If either the illuminant or the observer angle are not supported or
-        unknown.
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
-    """
-    return xyz_tristimulus_values(illuminant=illuminant, observer=observer)
 
 
 # Haematoxylin-Eosin-DAB colorspace

--- a/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/_skeletonize.py
@@ -171,11 +171,6 @@ def _get_tiebreaker(n, seed):
 
 
 @deprecate_kwarg(
-    {"random_state": "rng"},
-    deprecated_version="23.08",
-    removed_version="24.06",
-)
-@deprecate_kwarg(
     {"seed": "rng"}, deprecated_version="23.12", removed_version="24.12"
 )
 def medial_axis(image, mask=None, return_distance=False, *, rng=None):

--- a/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
+++ b/python/cucim/src/cucim/skimage/morphology/tests/test_skeletonize.py
@@ -128,11 +128,6 @@ class TestMedialAxis:
         with pytest.warns(FutureWarning):
             self._test_vertical_line(seed=15)
 
-    def test_vertical_line_random_state(self):
-        """random_state was deprecated (now use rng)"""
-        with pytest.warns(FutureWarning):
-            self._test_vertical_line(random_state=15)
-
     def test_01_01_rectangle(self):
         """Test skeletonize on a rectangle"""
         image = cp.zeros((9, 15), bool)

--- a/python/cucim/src/cucim/skimage/registration/_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/_phase_cross_correlation.py
@@ -11,7 +11,6 @@ import cupyx.scipy.ndimage as ndi
 import numpy as np
 
 from .._shared.fft import fftmodule as fft
-from .._shared.utils import remove_arg
 from ._masked_phase_cross_correlation import _masked_phase_cross_correlation
 
 
@@ -188,7 +187,6 @@ def _disambiguate_shift(reference_image, moving_image, shift):
     return real_shift
 
 
-@remove_arg("return_error", changed_version="24.06")
 def phase_cross_correlation(
     reference_image,
     moving_image,
@@ -196,7 +194,6 @@ def phase_cross_correlation(
     upsample_factor=1,
     space="real",
     disambiguate=False,
-    return_error=True,
     reference_mask=None,
     moving_mask=None,
     overlap_ratio=0.3,
@@ -307,13 +304,6 @@ def phase_cross_correlation(
            Pattern Recognition, pp. 2918-2925 (2010).
            :DOI:`10.1109/CVPR.2010.5540032`
     """
-    if not return_error:
-        raise ValueError(
-            "return_error must be True (or 'always'), False is no longer "
-            "supported as of cuCIM 24.02 and the `return_error` kwarg will be "
-            "removed in cuCIM 24.06."
-        )
-
     if (reference_mask is not None) or (moving_mask is not None):
         shift = _masked_phase_cross_correlation(
             reference_image,

--- a/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/python/cucim/src/cucim/skimage/registration/tests/test_phase_cross_correlation.py
@@ -220,6 +220,5 @@ def test_disambiguate_zero_shift():
         image,
         image,
         disambiguate=True,
-        return_error="always",
     )
     assert computed_shift == (0, 0)


### PR DESCRIPTION
This MR completes a few scheduled deprecations
- removes renamed `get_xyz_coords` function (it already wasn't accessible from the top-level `cucim.skimage.color` namespace)
- removes deprecated `return_error` kwarg from `phase_cross_correlation` (error is always returned)
- removes deprecated `random_state` kwarg from `medial_axis` (it was renamed to `rng` previously)
