### PR TITLE
remove .gitattributes

### DIFF
--- a/python/cucim/.gitattributes
+++ b/python/cucim/.gitattributes
@@ -1,1 +1,0 @@
-src/cucim/_version.py export-subst


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31

Removes `.gitattributes` files.

These have been here since the beginning of the project (https://github.com/rapidsai/cucim/commit/048d53e6f99c2129b9febd08e0ae6d1b37d74451), for use with `versioneer`. Per the `git` docs ([link](https://git-scm.com/docs/gitattributes#_export_subst)), setting the attribute `export-subst` on a file via a `.gitattributes` tell `git` to replace placeholders in the file with some `git` information.

This is no longer done in `_version.py` files in this project, and this project no longer uses `versioneer` (#615). `rapids-build-backend` handles storing git commit information in the published packages.

## Notes for Reviewers

For more details, see https://github.com/rapidsai/build-planning/issues/31#issuecomment-2176853319