### PR TITLE
Minor fixes for NumPy 2.0 compatiblity

### DIFF
--- a/python/cucim/src/cucim/skimage/segmentation/_chan_vese.py
+++ b/python/cucim/src/cucim/skimage/segmentation/_chan_vese.py
@@ -429,6 +429,7 @@ def chan_vese(
         energies = []
     phivar = tol + 1
 
+    dt = cp.asarray(dt, dtype=float_dtype)
     while phivar > tol and i < max_num_iter:
         # Save old level set values
         oldphi = phi

--- a/python/cucim/tests/unit/core/test_stain_normalizer.py
+++ b/python/cucim/tests/unit/core/test_stain_normalizer.py
@@ -137,7 +137,7 @@ class TestStainExtractorMacenko:
                 stain_extraction_pca(image)
         else:
             result = stain_extraction_pca(image)
-            cp.testing.assert_allclose(result, expected)
+            cp.testing.assert_allclose(result, expected, rtol=1e-6)
 
 
 class TestStainNormalizerMacenko:


### PR DESCRIPTION
This MR resolves issues 3 and 4 reported [here](https://github.com/rapidsai/cucim/issues/742#issuecomment-2218492642) when testing with NumPy 2.0 and CuPy 13.2 locally (issues 1 and 2 will be addressed in CuPy itself)
https://github.com/rapidsai/cucim/issues/742#issuecomment-2218492642

For now, leave NumPy pinning as-is. Tests should continue to pass with NumPy 1.x