### PR TITLE
Drop NumPy build dependency

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -63,7 +63,6 @@ requirements:
     {% endif %}
     - cupy >=12.0.0
     - libcucim ={{ version }}
-    - numpy 1.23
     - python
     - rapids-build-backend >=0.3.0,<0.4.0.dev0
     - scikit-image >=0.19.0,<0.23.0a0
@@ -74,7 +73,7 @@ requirements:
     {% if cuda_major != "11" %}
     - cuda-cudart
     {% endif %}
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.23,<2.0a0
     - click
     - cupy >=12.0.0
     - lazy_loader >=0.1

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -19,7 +19,6 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -447,10 +447,10 @@ py::object py_read_region(const CuImage& cuimg,
     {
         py::gil_scoped_acquire scope_guard;
 
-        py::object mv_obj(py::none());
+        py::object mv_obj = py::none();
         try
         {
-            mv_obj = py::memoryview(location);
+            mv_obj = py::cast(py::memoryview(location));
         }
         catch (const std::exception& e)
         {

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -470,7 +470,7 @@ py::object py_read_region(const CuImage& cuimg,
                 throw std::invalid_argument("Expected C-contiguous array-like");
             }
 
-            int64_t* data_array = static_cast<int64_t*>(buf.ptr);
+            const int64_t* data_array = static_cast<const int64_t*>(buf.ptr);
             ssize_t data_size = buf.size;
             locations.reserve(data_size);
             locations.insert(locations.end(), &data_array[0], &data_array[data_size]);

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -462,7 +462,7 @@ py::object py_read_region(const CuImage& cuimg,
             py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
             if (buf)
             {
-                if (buf.format != 'q')
+                if (buf.format != "q")
                 {
                      throw std::invalid_argument("Expected int64 array-like");
                 }

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -460,7 +460,7 @@ py::object py_read_region(const CuImage& cuimg,
 
         if (has_mv) // fast copy
         {
-            py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
+            py::buffer_info buf = py::buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
             if (buf.format != py::format_descriptor<int64_t>::format())
             {
                 throw std::invalid_argument("Expected int64 array-like");

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -465,7 +465,7 @@ py::object py_read_region(const CuImage& cuimg,
             {
                 throw std::invalid_argument("Expected int64 array-like");
             }
-            if (PyBuffer_IsContiguous(buf.view(), 'C'))
+            if (!PyBuffer_IsContiguous(buf.view(), 'C'))
             {
                 throw std::invalid_argument("Expected C-contiguous array-like");
             }

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -450,7 +450,7 @@ py::object py_read_region(const CuImage& cuimg,
         py::object mv_obj = py::none();
         try
         {
-            mv_obj = py::cast(py::memoryview(location));
+            mv_obj = py::cast<py::object>(py::memoryview(location));
         }
         catch (const std::exception& e)
         {

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -448,7 +448,7 @@ py::object py_read_region(const CuImage& cuimg,
         py::gil_scoped_acquire scope_guard;
 
         py::memoryview mv;
-        try // fast copy
+        try
         {
             mv = py::memoryview(location);
         }

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -448,16 +448,17 @@ py::object py_read_region(const CuImage& cuimg,
         py::gil_scoped_acquire scope_guard;
 
         py::memoryview mv;
+        bool has_mv = false;
         try
         {
             mv = py::memoryview(location);
+            has_mv = true;
         }
         catch (const std::exception& e)
         {
-            mv = nullptr;
         }
 
-        if (mv) // fast copy
+        if (has_mv) // fast copy
         {
             py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
             if (buf.format != py::format_descriptor<int64_t>::format())

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -460,16 +460,13 @@ py::object py_read_region(const CuImage& cuimg,
         if (mv) // fast copy
         {
             py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
-            if (buf)
+            if (buf.format != py::format_descriptor<int64_t>::format())
             {
-                if (buf.format != py::format_descriptor<int64_t>::format())
-                {
-                    throw std::invalid_argument("Expected int64 array-like");
-                }
-                if (PyBuffer_IsContiguous(buf.view(), 'C'))
-                {
-                    throw std::invalid_argument("Expected C-contiguous array-like");
-                }
+                throw std::invalid_argument("Expected int64 array-like");
+            }
+            if (PyBuffer_IsContiguous(buf.view(), 'C'))
+            {
+                throw std::invalid_argument("Expected C-contiguous array-like");
             }
 
             int64_t* data_array = static_cast<int64_t*>(buf.ptr);

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -465,7 +465,7 @@ py::object py_read_region(const CuImage& cuimg,
             {
                 throw std::invalid_argument("Expected int64 array-like");
             }
-            if (!PyBuffer_IsContiguous(buf.view(), 'C'))
+            if (PyBuffer_IsContiguous(buf.view(), 'C') == 0)
             {
                 throw std::invalid_argument("Expected C-contiguous array-like");
             }

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include <Python.h>
 #include <pybind11/buffer_info.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -447,20 +447,20 @@ py::object py_read_region(const CuImage& cuimg,
     {
         py::gil_scoped_acquire scope_guard;
 
-        py::memoryview mv;
-        bool has_mv = false;
+        py::object mv_obj(py::none());
         try
         {
-            mv = py::memoryview(location);
-            has_mv = true;
+            mv_obj = py::memoryview(location);
         }
         catch (const std::exception& e)
         {
         }
 
-        if (has_mv) // fast copy
+        if (!mv_obj.is_none()) // fast copy
         {
-            py::buffer_info buf = py::buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
+            py::memoryview mv(mv_obj);
+            py::buffer_info buf(PyMemoryView_GET_BUFFER(mv.ptr()), false);
+
             if (buf.format != py::format_descriptor<int64_t>::format())
             {
                 throw std::invalid_argument("Expected int64 array-like");

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -462,7 +462,7 @@ py::object py_read_region(const CuImage& cuimg,
             py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
             if (buf)
             {
-                if (buf.format != "q")
+                if (buf.format != py::format_descriptor<int64_t>::format())
                 {
                      throw std::invalid_argument("Expected int64 array-like");
                 }

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -459,8 +459,8 @@ py::object py_read_region(const CuImage& cuimg,
 
         if (mv) // fast copy
         {
-	    py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
-	    if (buf)
+            py::buffer_info buf = buffer_info(PyMemoryView_GET_BUFFER(mv.ptr()), false);
+            if (buf)
             {
                 if (buf.format != 'q')
                 {

--- a/python/pybind11/cucim_py.cpp
+++ b/python/pybind11/cucim_py.cpp
@@ -464,11 +464,11 @@ py::object py_read_region(const CuImage& cuimg,
             {
                 if (buf.format != py::format_descriptor<int64_t>::format())
                 {
-                     throw std::invalid_argument("Expected int64 array-like");
+                    throw std::invalid_argument("Expected int64 array-like");
                 }
                 if (PyBuffer_IsContiguous(buf.view(), 'C'))
                 {
-                     throw std::invalid_argument("Expected C-contiguous array-like");
+                    throw std::invalid_argument("Expected C-contiguous array-like");
                 }
             }
 


### PR DESCRIPTION
Partially addresses issue: https://github.com/rapidsai/build-planning/issues/82

Even though cuCIM currently `#include`s `<pybind11/numpy.h>`, the actual C++ code appears not to use NumPy. So this attempts to drop the header and the NumPy build dependency.