### PR TITLE
Fix error in dependencies.yaml causing incomplete pyproject.toml generation

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -69,7 +69,7 @@ files:
       key: developer
     includes:
       - develop
-  py_develop:
+  py_docs:
     output: pyproject
     pyproject_dir: python/cucim
     extras:


### PR DESCRIPTION
The following section of the dependencies.yaml was being ignored:
```
  develop:
    common:
      - output_types: [conda, requirements, pyproject]
        packages:
          - pre-commit
          - black
          - ruff
          - isort
```
I noticed this because changing any values here and then running `rapids-dependency-file-generator` did not cause any corresponding change in the `pyproject.toml`.

The root cause is the files section was defining `py_develop` twice (lines 64 and 72). The first time pointed to the desired `develop:` section shown above, but the second, duplicate one pointed to the `docs:` section instead. I renamed the second file target to `py_docs` to avoid ignoring the developer dependencies section.

I tested locally by making changes to the develop: section to verify that they would now show up in the `pyproject.toml`.

Ideally we could have `rapids-dependency-file-generator` raise an error or print a warning if duplicate names like this were found.
