### PR TITLE
Disable custom 2D separable filtering kernels on windows

### DIFF
--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1,5 +1,6 @@
 """A vendored subset of cupyx.scipy.ndimage._filters"""
 import math
+import platform
 import warnings
 
 import cupy
@@ -21,6 +22,8 @@ try:
     compile_errors = (ResourceLimitError, CompileException)
 except ImportError:
     compile_errors = (ResourceLimitError,)
+
+_is_not_windows = platform.system() != "Windows"
 
 
 def correlate(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
@@ -231,7 +234,7 @@ def _correlate_or_convolve1d(
     default_algorithm = False
     if algorithm is None:
         default_algorithm = True
-        if input.ndim == 2 and weights.size <= 256:
+        if input.ndim == 2 and weights.size <= 256 and _is_not_windows:
             algorithm = "shared_memory"
         else:
             algorithm = "elementwise"

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -234,7 +234,7 @@ def _correlate_or_convolve1d(
     default_algorithm = False
     if algorithm is None:
         default_algorithm = True
-        if input.ndim == 2 and weights.size <= 256 and _is_not_windows:
+        if _is_not_windows and input.ndim == 2 and weights.size <= 256:
             algorithm = "shared_memory"
         else:
             algorithm = "elementwise"

--- a/python/cucim/src/cucim/skimage/filters/tests/test_separable_filtering.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_separable_filtering.py
@@ -1,3 +1,5 @@
+import platform
+
 import cupy as cp
 import pytest
 
@@ -227,6 +229,13 @@ image_dtypes_tested = (
 )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason=(
+        "custom separable kernels disabled on Windows until dtype-related "
+        "test failures can be resolved"
+    ),
+)
 @pytest.mark.parametrize("axis", (0, 1))
 @pytest.mark.parametrize("image_dtype", image_dtypes_tested)
 @pytest.mark.parametrize(
@@ -246,6 +255,13 @@ def test_separable_image_and_kernel_dtypes(axis, image_dtype, kernel_dtype):
     )
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason=(
+        "custom separable kernels disabled on Windows until dtype-related "
+        "test failures can be resolved"
+    ),
+)
 @pytest.mark.parametrize("axis", (0, 1))
 @pytest.mark.parametrize("image_dtype", image_dtypes_tested)
 @pytest.mark.parametrize(


### PR DESCRIPTION
We currently bundle some custom 2D convolution kernels not present in CuPy. We have additional testing of these internel kernels, but I found that on the Windows platform a subset of these tests currently fail.

This MR disables auto-selection of these kernels on the Windows platform (will always fall back to CuPy's `cupyx.scipy.ndimage` kernels in this case). The test cases that are currently known to fail are skipped for now on Windows. Longer term it would be good to resolve the issues with the kernels, restore the test cases and enable use of these kernels on Windows.