### PR TITLE
Update rapidsai/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.3.1
+    rev: v0.4.0
     hooks:
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator


### PR DESCRIPTION
This PR updates rapidsai/pre-commit-hooks to the version 0.4.0.
