### PR TITLE
update vendored CUDA includes to match CuPy >= 13.3

### DIFF
--- a/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
+++ b/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
@@ -5,6 +5,7 @@ import cupy as cp
 from cucim.skimage._vendored import _ndimage_util as util
 from cucim.skimage._vendored._internal import _normalize_axis_index
 from cucim.skimage._vendored._ndimage_filters_core import (
+    CUPY_GTE_13_3_0,
     _ndimage_CAST_FUNCTION,
     _ndimage_includes,
 )
@@ -917,7 +918,10 @@ def _get_separable_conv_kernel(
         patch_per_block=patch_per_block,
         flip_kernel=flip_kernel,
     )
-    options = ("--std=c++11", "-DCUPY_USE_JITIFY")
+    if CUPY_GTE_13_3_0:
+        options = ("--std=c++11",)
+    else:
+        options = ("--std=c++11", "-DCUPY_USE_JITIFY")
     m = cp.RawModule(code=code, options=options)
     return m.get_function(func_name), block, patch_per_block
 


### PR DESCRIPTION
CuPy 13.3 removed dependence on jitify (see: https://github.com/cupy/cupy/pull/8473)

Make the same change in our vendored code (but only if CuPy >= 13.3). 
