### PR TITLE
Fix a couple of performance issues in `peak_local_max` (improve performance of blob detectors and `corner_peaks`)

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/coord.py
+++ b/python/cucim/src/cucim/skimage/_shared/coord.py
@@ -101,6 +101,8 @@ def ensure_spacing(
         A subset of coord where a minimum spacing is guaranteed.
 
     """
+    if spacing == 1:
+        return coords
 
     output = coords
     if len(coords):

--- a/python/cucim/src/cucim/skimage/_shared/coord.py
+++ b/python/cucim/src/cucim/skimage/_shared/coord.py
@@ -101,8 +101,6 @@ def ensure_spacing(
         A subset of coord where a minimum spacing is guaranteed.
 
     """
-    if spacing == 1:
-        return coords
 
     output = coords
     if len(coords):

--- a/python/cucim/src/cucim/skimage/_shared/coord.py
+++ b/python/cucim/src/cucim/skimage/_shared/coord.py
@@ -40,7 +40,7 @@ def _ensure_spacing(coord, spacing, p_norm, max_out):
             # keep current point and the points at exactly spacing from it
             candidates.remove(idx)
             dist = distance.cdist(
-                [coord[idx]], coord[candidates], distance.minkowski, p=p_norm
+                [coord[idx]], coord[candidates], "minkowski", p=p_norm
             ).reshape(-1)
             candidates = [c for c, d in zip(candidates, dist) if d < spacing]
 

--- a/python/cucim/src/cucim/skimage/feature/peak.py
+++ b/python/cucim/src/cucim/skimage/feature/peak.py
@@ -31,9 +31,10 @@ def _get_high_intensity_peaks(image, mask, num_peaks, min_distance, p_norm):
     else:
         max_out = None
 
-    coord = ensure_spacing(
-        coord, spacing=min_distance, p_norm=p_norm, max_out=max_out
-    )
+    if min_distance > 1:
+        coord = ensure_spacing(
+            coord, spacing=min_distance, p_norm=p_norm, max_out=max_out
+        )
 
     if len(coord) > num_peaks:
         coord = coord[:num_peaks]
@@ -53,7 +54,7 @@ def _get_peak_mask(image, footprint, threshold, mask=None):
     out = image == image_max
 
     # no peak for a trivial image
-    image_is_trivial = np.all(out) if mask is None else np.all(out[mask])
+    image_is_trivial = cp.all(out) if mask is None else cp.all(out[mask])
     if image_is_trivial:  # synchronize
         out[:] = False
         if mask is not None:


### PR DESCRIPTION
It seems that we can get a large speedup in calls to `peak_local_max` when the default `min_distance=1` is specified. A bottleneck in that function can be the call to `ensure_spacing` which falls back to the CPU, but we don't need to call that function at all unless `min_distance>1` (no coordinates can be excluded if min_distance=1, so it is pointless to call it).

I proposed the same changes upstream in https://github.com/scikit-image/scikit-image/pull/7548. See additional comments and measurements made there.

There should be no change in behavior with this MR, it is purely a performance improvement.

