### PR TITLE
make conda installs in CI stricter

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-export RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)"
-
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -7,6 +7,8 @@ export RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)"
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+RAPIDS_VERSION="$(rapids-version)"
+
 rapids-dependency-file-generator \
     --output conda \
     --file-key docs \
@@ -24,7 +26,8 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 rapids-mamba-retry install \
     --channel "${CPP_CHANNEL}" \
     --channel "${PYTHON_CHANNEL}" \
-    cucim libcucim
+    "cucim=${RAPIDS_VERSION}" \
+    "libcucim=${RAPIDS_VERSION}"
 
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
@@ -35,4 +38,4 @@ mkdir -p "${RAPIDS_DOCS_DIR}/cucim/"html
 mv _html/* "${RAPIDS_DOCS_DIR}/cucim/html"
 popd
 
-rapids-upload-docs
+RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)" rapids-upload-docs


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/106

Proposes specifying the RAPIDS version in `conda install` calls that install CI artifacts, to reduce the risk of CI jobs picking up artifacts from other releases.