### PR TITLE
build wheels without build isolation, print sccache stats in builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,6 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.12
   wheel-build:
-    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.12
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,46 +12,9 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      - checks
-      - conda-cpp-build
-      - conda-python-build
-      - conda-python-tests
-      - docs-build
       - wheel-build
-      - wheel-tests
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.12
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.12
-  conda-cpp-build:
-    needs: checks
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.12
-    with:
-      build_type: pull-request
-  conda-python-build:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.12
-    with:
-      build_type: pull-request
-  conda-python-tests:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.12
-    with:
-      build_type: pull-request
-  docs-build:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.12
-    with:
-      build_type: pull-request
-      node_type: "gpu-v100-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
   wheel-build:
     needs: checks
     secrets: inherit
@@ -59,10 +22,3 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
-  wheel-tests:
-    needs: wheel-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.12
-    with:
-      build_type: pull-request
-      script: ci/test_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,12 +12,57 @@ concurrency:
 jobs:
   pr-builder:
     needs:
+      - checks
+      - conda-cpp-build
+      - conda-python-build
+      - conda-python-tests
+      - docs-build
       - wheel-build
+      - wheel-tests
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.12
+  checks:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.12
+  conda-cpp-build:
+    needs: checks
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.12
+    with:
+      build_type: pull-request
+  conda-python-build:
+    needs: conda-cpp-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.12
+    with:
+      build_type: pull-request
+  conda-python-tests:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.12
+    with:
+      build_type: pull-request
+  docs-build:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.12
+    with:
+      build_type: pull-request
+      node_type: "gpu-v100-latest-1"
+      arch: "amd64"
+      container_image: "rapidsai/ci-conda:latest"
+      run_script: "ci/build_docs.sh"
   wheel-build:
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.12
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
+  wheel-tests:
+    needs: wheel-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.12
+    with:
+      build_type: pull-request
+      script: ci/test_wheel.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.13.11
+    rev: v1.16.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -17,6 +17,10 @@ rapids-logger "Begin cpp build"
 
 conda config --set path_conflict prevent
 
+sccache --zero-stats
+
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild conda/recipes/libcucim
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -20,11 +20,15 @@ conda config --set path_conflict prevent
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
+sccache --zero-stats
+
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cucim
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -21,7 +21,7 @@ rapids-dependency-file-generator \
   --output requirements \
   --file-key "py_build_${package_name}" \
   --file-key "py_rapids_build_${package_name}" \
-  --matrix "${matrix_selectors}" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
 | tee /tmp/requirements-build.txt
 
 rapids-logger "Installing build requirements"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 
 package_name="cucim"
 package_dir="python/cucim"
-package_src_dir="${package_dir}/src/${package_name}"
 
 CMAKE_BUILD_TYPE="release"
 
@@ -18,26 +17,15 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
 
-rapids-logger "Generating build requirements"
-matrix_selectors="cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true"
-
+# Install pip build dependencies (not yet using pyproject.toml)
 rapids-dependency-file-generator \
-  --output requirements \
-  --file-key "py_build_${package_name}" \
-  --matrix "${matrix_selectors}" \
-| tee /tmp/requirements-build.txt
+  --file-key "py_build" \
+  --output "requirements" \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee build_requirements.txt
 
-rapids-dependency-file-generator \
-  --output requirements \
-  --file-key "py_rapids_build_${package_name}" \
-  --matrix "${matrix_selectors}" \
-| tee -a /tmp/requirements-build.txt
+python -m pip install -r build_requirements.txt
 
-rapids-logger "Installing build requirements"
-python -m pip install \
-    -v \
-    --prefer-binary \
-    -r /tmp/requirements-build.txt
+sccache --zero-stats
 
 # First build the C++ lib using CMake via the run script
 ./run build_local all ${CMAKE_BUILD_TYPE}
@@ -46,11 +34,12 @@ sccache --show-adv-stats
 
 cd "${package_dir}"
 
+sccache --zero-stats
+
 rapids-logger "Building '${package_name}' wheel"
 python -m pip wheel \
     -w dist \
     -v \
-    --no-build-isolation \
     --no-deps \
     --disable-pip-version-check \
     .

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,14 +31,14 @@ files:
       - cuda_version
       - docs
       - py_version
-  py_build:
+  py_build_cucim:
     output: pyproject
     pyproject_dir: python/cucim
     extras:
       table: build-system
     includes:
       - rapids_build_setuptools
-  py_rapids_build:
+  py_rapids_build_cucim:
     output: pyproject
     pyproject_dir: python/cucim
     extras:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/108
Contributes to https://github.com/rapidsai/build-planning/issues/111

Proposes some small packaging/CI changes, matching similar changes being made across RAPIDS.

* removes the use of build isolation in wheel builds
* printing `sccache` stats to CI logs
* reducing `pip`'s verbosity in wheel building scripts
* using the RAPIDS conventions `py_build_{project}` and `py_rapids_build_{project}` in `dependencies.yaml`
* updating to the latest `rapids-dependency-file-generator` (v1.16.0)