### PR TITLE
allow path conflicts in conda builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -15,7 +15,9 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-conda config --set path_conflict prevent
+# this can be set back to 'prevent' once the xorg-* migrations are completed
+# ref: https://github.com/rapidsai/cucim/issues/800#issuecomment-2529593457
+conda config --set path_conflict warn
 
 sccache --zero-stats
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,7 +16,10 @@ rapids-print-env
 rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
-conda config --set path_conflict prevent
+
+# this can be set back to 'prevent' once the xorg-* migrations are completed
+# ref: https://github.com/rapidsai/cucim/issues/800#issuecomment-2529593457
+conda config --set path_conflict warn
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 


### PR DESCRIPTION
Nightly conda builds for 24.12 and 25.02 are currently failing because of file-clobbering issues with `xorg-*` packages. It looks like this is because those packages on conda-forge are in the middle of a migration.

That clobbering should generally be safe, and anyway is out of our control, so this PR proposes temporarily allowing it in CI.

See #800 for details.

## Notes for Reviewers

This is intentionally targeting `branch-24.12`, to get nightly builds working there. A few more are still needed to complete the 24.12 release.