### PR TITLE
CuPy 14.0 compatibility

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/compat.py
+++ b/python/cucim/src/cucim/skimage/_shared/compat.py
@@ -1,5 +1,6 @@
 """Compatibility helpers for dependencies."""
 
+import cupy as cp
 import numpy as np
 from packaging.version import parse
 
@@ -21,10 +22,9 @@ NP_COPY_IF_NEEDED = False if NUMPY_LT_2_0_0 else None
 
 
 # check CuPy instead of SciPy
-# as of CuPy 13.0, tol is still being used instead of rtol as in latest SciPy
-# CUPY_LT_14 = parse(cp.__version__) < parse("14.0")
+CUPY_LT_14 = parse(cp.__version__) < parse("14.0.0a1")
 
 # Starting in SciPy v1.12, 'scipy.sparse.linalg.cg' keyword argument `tol` is
-# deprecated in favor of `rtol`.
-# As of CuPy 13.0, it is still always using 'tol''
-SCIPY_CG_TOL_PARAM_NAME = "tol"  # if CUPY_LT_14 else "rtol"
+# deprecated in favor of `rtol`. The corresponding change in cupyx.scipy.sparse
+# was made in v14.0
+SCIPY_CG_TOL_PARAM_NAME = "tol" if CUPY_LT_14 else "rtol"

--- a/python/cucim/src/cucim/skimage/color/delta_e.py
+++ b/python/cucim/src/cucim/skimage/color/delta_e.py
@@ -348,7 +348,8 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1, *, channel_axis=-1):
     c1_4 = C1**4
     F = cp.sqrt(c1_4 / (c1_4 + 1900))
 
-    SL = cp.where(L1 < 16, 0.511, 0.040975 * L1 / (1.0 + 0.01765 * L1))
+    scalar_val = cp.float32(0.511) if lab1.dtype == cp.float32 else 0.511
+    SL = cp.where(L1 < 16, scalar_val, 0.040975 * L1 / (1.0 + 0.01765 * L1))
     SC = 0.638 + 0.0638 * C1 / (1.0 + 0.0131 * C1)
     SH = SC * (F * T + 1 - F)
 

--- a/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
+++ b/python/cucim/src/cucim/skimage/feature/tests/test_corner.py
@@ -264,8 +264,8 @@ def test_structure_tensor_eigenvalues(dtype):
 
 
 def test_structure_tensor_eigenvalues_3d():
-    cube9 = cp.ones((9,) * 3, dtype=cp.uint8)
-    cube7 = cp.ones((7,) * 3, dtype=cp.uint8)
+    cube9 = cp.ones((9,) * 3, dtype=cp.int16)
+    cube7 = cp.ones((7,) * 3, dtype=cp.int16)
     image = pad(cube9, 5, mode="constant") * 1000
     boundary = (
         pad(cube9, 5, mode="constant") - pad(cube7, 6, mode="constant")

--- a/python/cucim/src/cucim/skimage/filters/thresholding.py
+++ b/python/cucim/src/cucim/skimage/filters/thresholding.py
@@ -694,6 +694,7 @@ def threshold_li(
     elif callable(initial_guess):
         t_next = initial_guess(image)
     elif cp.isscalar(initial_guess):  # convert to new, positive image range
+        image_min = float(image_min)
         t_next = initial_guess - image_min
         image_max = cp.max(image) + image_min
         if not 0 < t_next < cp.max(image):

--- a/python/cucim/src/cucim/skimage/registration/_optical_flow.py
+++ b/python/cucim/src/cucim/skimage/registration/_optical_flow.py
@@ -311,7 +311,7 @@ def _ilk(
     # is the solution of the ndim x ndim linear system
     # A[i, j] * X = b[i, j]
     A = cp.zeros(reference_image.shape + (ndim, ndim), dtype=dtype)
-    b = cp.zeros(reference_image.shape + (ndim,), dtype=dtype)
+    b = cp.zeros(reference_image.shape + (ndim, 1), dtype=dtype)
 
     grid = cp.meshgrid(
         *[cp.arange(n, dtype=dtype) for n in reference_image.shape],
@@ -337,7 +337,7 @@ def _ilk(
             A[..., i, j] = A[..., j, i] = filter_func(grad[i] * grad[j])
 
         for i in range(ndim):
-            b[..., i] = filter_func(grad[i] * error_image)
+            b[..., i, 0] = filter_func(grad[i] * error_image)
 
         # Don't consider badly conditioned linear systems
         idx = abs(cp.linalg.det(A)) < 1e-14
@@ -345,7 +345,7 @@ def _ilk(
         b[idx] = 0
 
         # Solve the local linear systems
-        flow = cp.moveaxis(cp.linalg.solve(A, b), ndim, 0)
+        flow = cp.moveaxis(cp.linalg.solve(A, b)[..., 0], ndim, 0)
 
     return flow
 

--- a/python/cucim/src/cucim/skimage/transform/integral.py
+++ b/python/cucim/src/cucim/skimage/transform/integral.py
@@ -148,10 +148,10 @@ def integrate(ii, start, end):
 
         # CuPy Backend: TODO: check efficiency here
         if scalar_output:
-            S += sign * ii[tuple(corner_points[0])] if (not bad[0]) else 0
+            S += sign * int(ii[tuple(corner_points[0])]) if (not bad[0]) else 0
         else:
             for r in range(rows):
                 # add only good rows
                 if not bad[r]:
-                    S[r] += sign * ii[tuple(corner_points[r])]
+                    S[r] += sign * int(ii[tuple(corner_points[r])])
     return S


### PR DESCRIPTION
The upcoming CuPy 14.0 release has some breaking change in dtype handling, etc. due to changes made to mirror NumPy 2.0 behavior. 

Fortunately most of cuCIM was still working as is when I tested it locally. The changes made here are what was required for all tests to pass when using the current `main` branch of CuPy (14.0 is not yet released)
