### PR TITLE
Fix primitives benchmark code

### DIFF
--- a/benchmarks/primitives.cpp
+++ b/benchmarks/primitives.cpp
@@ -89,10 +89,10 @@ static void string_memcpy(benchmark::State& state)
         char * c_str = (char*) malloc(size + 1);
         memcpy(c_str, data.data(), size);
         c_str[size] = '\0';
-        free(c_str);
         // Make sure the variable is not optimized away by compiler
         benchmark::DoNotOptimize(c_str);
         benchmark::DoNotOptimize(size);
+        free(c_str);
     }
 }
 BENCHMARK(string_memcpy);
@@ -105,9 +105,9 @@ static void string_strcpy(benchmark::State& state)
         std::string data = "#########################################################################################################################################################################################";
         char * c_str = (char*) malloc(data.size() + 1);
         strcpy(c_str, data.data());
-        free(c_str);
         // Make sure the variable is not optimized away by compiler
         benchmark::DoNotOptimize(c_str);
+        free(c_str);
     }
 }
 BENCHMARK(string_strcpy);
@@ -120,9 +120,9 @@ static void string_strdup(benchmark::State& state)
     {
         std::string data = "#########################################################################################################################################################################################";
         char * c_str = strdup(data.data());
-        free(c_str);
         // Make sure the variable is not optimized away by compiler
         benchmark::DoNotOptimize(c_str);
+        free(c_str);
     }
 }
 BENCHMARK(string_strdup);
@@ -140,12 +140,12 @@ static void alloc_malloc(benchmark::State& state)
             arr[i] = (char*)malloc(10);
             arr[i][0] = i;
         }
+        // Make sure the variable is not optimized away by compiler
+        benchmark::DoNotOptimize(arr);
         for (int i = 0; i < 30000; i++)
         {
             free(arr[i]);
         }
-        // Make sure the variable is not optimized away by compiler
-        benchmark::DoNotOptimize(arr);
     }
 }
 BENCHMARK(alloc_malloc);//->Iterations(100);
@@ -163,12 +163,12 @@ static void alloc_pmr(benchmark::State& state)
             arr[i] = static_cast<char*>(cucim_malloc(10));
             arr[i][0] = i;
         }
+        // Make sure the variable is not optimized away by compiler
+        benchmark::DoNotOptimize(arr);
         for (int i = 0; i < 30000; i++)
         {
             cucim_free(arr[i]);
         }
-        // Make sure the variable is not optimized away by compiler
-        benchmark::DoNotOptimize(arr);
     }
 }
 BENCHMARK(alloc_pmr);//->Iterations(100);


### PR DESCRIPTION
The pointer variable is used after releasing memory with `free()`, which is a bug that needs to be addressed.

Without this fix, the benchmark code may fail to build or run correctly, resulting in the following error ([link](https://github.com/rapidsai/cucim/actions/runs/12753155354/job/35544254443?pr=811))
```
In function 'void benchmark::DoNotOptimize(Tp&) [with Tp = char*]',
    inlined from 'void string_strcpy(benchmark::State&)' at /opt/conda/conda-bld/work/benchmarks/primitives.cpp:110:33:
/opt/conda/conda-bld/work/build-release/_deps/deps-googlebenchmark-src/src/../include/benchmark/benchmark.h:322:3: error: pointer used after 'void free(void*)' [-Werror=use-after-free]
  322 |   asm volatile("" : "+m,r"(value) : : "memory");
      |   ^~~
```
It seems that the updated version of GCC is now capable of detecting this potential issue.  

This commit resolves the issue by ensuring the memory is released only after `benchmark::DoNotOptimize()` is called.

This PR handles a build issue related to #811
- #811 

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
