### PR TITLE
Update vendored ndimage code with axes support

### DIFF
--- a/python/cucim/src/cucim/skimage/_shared/filters.py
+++ b/python/cucim/src/cucim/skimage/_shared/filters.py
@@ -124,12 +124,12 @@ def gaussian(
         raise ValueError(sigma_msg)
 
     if channel_axis is not None:
-        # do not filter across channels
-        if not isinstance(sigma, Iterable):
-            sigma = [sigma] * (image.ndim - 1)
-        if len(sigma) == image.ndim - 1:
-            sigma = list(sigma)
-            sigma.insert(channel_axis % image.ndim, 0)
+        axes = tuple(
+            ax for ax in range(image.ndim) if ax != channel_axis % image.ndim
+        )
+    else:
+        axes = tuple(range(image.ndim))
+
     image = convert_to_float(image, preserve_range)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
@@ -147,7 +147,13 @@ def gaussian(
     else:
         out_img = out
     ndi.gaussian_filter(
-        image, sigma, output=out_img, mode=mode, cval=cval, truncate=truncate
+        image,
+        sigma,
+        output=out_img,
+        mode=mode,
+        cval=cval,
+        truncate=truncate,
+        axes=axes,
     )
     if out_img is not None and out_copied:
         image[...] = out_img

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -188,13 +188,14 @@ def convolve1d(
 def _correlate_or_convolve(
     input, weights, output, mode, cval, origin, convolution=False
 ):
-    origins, int_type = _filters_core._check_nd_args(
+    axes, weights, origins, modes, int_type = _filters_core._check_nd_args(
         input, weights, mode, origin
     )
     if weights.size == 0:
         return cupy.zeros_like(input)
 
-    _util._check_cval(mode, cval, _util._is_integer_output(output, input))
+    for mode in modes:
+        _util._check_cval(mode, cval, _util._is_integer_output(output, input))
 
     if convolution:
         weights = weights[tuple([slice(None, None, -1)] * weights.ndim)]
@@ -211,7 +212,9 @@ def _correlate_or_convolve(
         input, weights, use_cucim_casting=True
     )  # noqa
     offsets = _filters_core._origins_to_offsets(origins, weights.shape)
-    kernel = _get_correlate_kernel(mode, weights.shape, int_type, offsets, cval)
+    kernel = _get_correlate_kernel(
+        modes, weights.shape, int_type, offsets, cval
+    )
     output = _filters_core._call_kernel(
         kernel, input, weights, output, weights_dtype=weights_dtype
     )
@@ -280,13 +283,13 @@ def _correlate_or_convolve1d(
 
 
 @cupy.memoize(for_each_device=True)
-def _get_correlate_kernel(mode, w_shape, int_type, offsets, cval):
+def _get_correlate_kernel(modes, w_shape, int_type, offsets, cval):
     return _filters_core._generate_nd_kernel(
         "correlate",
         "W sum = (W)0;",
         "sum += cast<W>({value}) * wval;",
         "y = cast<Y>(sum);",
-        mode,
+        modes,
         w_shape,
         int_type,
         offsets,
@@ -296,7 +299,15 @@ def _get_correlate_kernel(mode, w_shape, int_type, offsets, cval):
 
 
 def _run_1d_correlates(
-    input, params, get_weights, output, mode, cval, origin=0, **filter_kwargs
+    input,
+    axes,
+    params,
+    get_weights,
+    output,
+    modes,
+    cval,
+    origin=0,
+    **filter_kwargs,
 ):
     """
     Enhanced version of _run_1d_filters that uses correlate1d as the filter
@@ -313,9 +324,10 @@ def _run_1d_correlates(
     return _filters_core._run_1d_filters(
         [None if w is None else correlate1d for w in wghts],
         input,
+        axes,
         wghts,
         output,
-        mode,
+        modes,
         cval,
         origin,
         **filter_kwargs,
@@ -377,6 +389,7 @@ def uniform_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
     *,
     algorithm=None,
 ):
@@ -388,15 +401,25 @@ def uniform_filter(
             dimension. A single value applies to all axes.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output. Default is is same dtype as the input.
-        mode (str): The array borders are handled according to the given mode
-            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
-            ``'wrap'``). Default is ``'reflect'``.
+        mode (str or sequence of str): The array borders are handled according
+            to the given mode (``'reflect'``, ``'constant'``, ``'nearest'``,
+            ``'mirror'``, ``'wrap'``). Default is ``'reflect'``. By passing a
+            sequence of modes with length equal to the number of ``axes`` along
+            which the input array is being filtered, different modes can be
+            specified along each axis. For more details on the supported modes,
+            see :func:`scipy.ndimage.uniform_filter`.
         cval (scalar): Value to fill past edges of input if mode is
             ``'constant'``. Default is ``0.0``.
         origin (int or sequence of int): The origin parameter controls the
             placement of the filter, relative to the center of the current
             element of the input. Default of ``0`` is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size``,
+            ``mode`` and/or ``origin`` must match the length of ``axes``. The
+            ith entry in any of these tuples corresponds to the ith entry in
+            ``axes``. Default is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -408,7 +431,12 @@ def uniform_filter(
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    sizes = _util._fix_sequence_arg(size, input.ndim, "size", int)
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    sizes = _util._fix_sequence_arg(size, num_axes, "size", int)
+    origins = _util._fix_sequence_arg(origin, num_axes, "origin", int)
+    modes = _util._fix_sequence_arg(mode, num_axes, "mode", str)
+
     weights_dtype = cupy.promote_types(input.dtype, cupy.float32)
 
     def get(size):
@@ -419,7 +447,15 @@ def uniform_filter(
         )  # noqa
 
     return _run_1d_correlates(
-        input, sizes, get, output, mode, cval, origin, algorithm=algorithm
+        input,
+        axes,
+        sizes,
+        get,
+        output,
+        modes,
+        cval,
+        origins,
+        algorithm=algorithm,
     )
 
 
@@ -463,6 +499,10 @@ def gaussian_filter1d(
     .. seealso:: :func:`scipy.ndimage.gaussian_filter1d`
 
     .. note::
+        The Gaussian kernel will have size ``2*radius + 1`` along each axis. If
+        `radius` is None, a default ``radius = round(truncate * sigma)`` will
+        be used.
+
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
@@ -483,6 +523,8 @@ def gaussian_filter(
     mode="reflect",
     cval=0.0,
     truncate=4.0,
+    radius=None,
+    axes=None,
     *,
     algorithm=None,
 ):
@@ -498,13 +540,28 @@ def gaussian_filter(
             single value applies to all axes.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output. Default is is same dtype as the input.
-        mode (str): The array borders are handled according to the given mode
-            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
-            ``'wrap'``). Default is ``'reflect'``.
+        mode (str or sequence of str): The array borders are handled according
+            to the given mode (``'reflect'``, ``'constant'``, ``'nearest'``,
+            ``'mirror'``, ``'wrap'``). Default is ``'reflect'``. By passing a
+            sequence of modes with length equal to the number of ``axes`` along
+            which the input array is being filtered, different modes can be
+            specified along each axis. For more details on the supported modes,
+            see :func:`scipy.ndimage.gaussian_filter`.
         cval (scalar): Value to fill past edges of input if mode is
             ``'constant'``. Default is ``0.0``.
         truncate (float): Truncate the filter at this many standard deviations.
             Default is ``4.0``.
+        radius (int, sequence of int, or None): Radius of the Gaussian kernel.
+            The radius are given for each axis as a sequence, or as a single
+            number, in which case it is equal for all axes. If specified, the
+            size of the kernel along each axis will be ``2*radius + 1``, and
+            `truncate` is ignored. Default is ``None``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``sigma``,
+            ``order``, ``mode`` and/or ``radius`` must match the length of
+            ``axes``. The ith entry in any of these tuples corresponds to the
+            ith entry in ``axes``. Default is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -512,28 +569,55 @@ def gaussian_filter(
     .. seealso:: :func:`scipy.ndimage.gaussian_filter`
 
     .. note::
+        The Gaussian kernel will have size ``2*radius + 1`` along each axis. If
+        `radius` is None, a default ``radius = round(truncate * sigma)`` will
+        be used.
+
         When the output data type is integral (or when no output is provided
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    sigmas = _util._fix_sequence_arg(sigma, input.ndim, "sigma", float)
-    orders = _util._fix_sequence_arg(order, input.ndim, "order", int)
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+
+    sigmas = _util._fix_sequence_arg(sigma, num_axes, "sigma", float)
+    sigma_threshold = 1e-15
+    if num_axes == 0 or all(s < sigma_threshold for s in sigmas):
+        if output is None:
+            return input.copy()
+        else:
+            output = _util._get_output(output, input)
+            output[:] = input
+            return output
+    orders = _util._fix_sequence_arg(order, num_axes, "order", int)
+    modes = _util._fix_sequence_arg(mode, num_axes, "mode", str)
+    radiuses = _util._fix_sequence_arg(radius, num_axes, "radius")
     truncate = float(truncate)
     weights_dtype = cupy.promote_types(input, cupy.float32)
 
-    def get(param, dtype=weights_dtype):
-        sigma, order = param
-        radius = int(truncate * float(sigma) + 0.5)
+    # omit any axes with sigma ~= 0.0
+    params = [
+        (axes[ii], sigmas[ii], orders[ii], modes[ii], radiuses[ii])
+        for ii in range(num_axes)
+        if sigmas[ii] > sigma_threshold
+    ]
+    axes, sigmas, orders, modes, radiuses = zip(*params)
+
+    def get(param):
+        _, sigma, order, _, radius = param
+        if radius is None:
+            radius = int(truncate * float(sigma) + 0.5)
         if radius <= 0:
             return None
-        return _gaussian_kernel1d(sigma, order, radius, dtype)
+        return _gaussian_kernel1d(sigma, order, radius, dtype=weights_dtype)
 
     return _run_1d_correlates(
         input,
-        list(zip(sigmas, orders)),
+        axes,
+        params,
         get,
         output,
-        mode,
+        modes,
         cval,
         0,
         algorithm=algorithm,
@@ -638,17 +722,20 @@ def _prewitt_or_sobel(input, axis, output, mode, cval, weights, algorithm):
 
     weights_dtype = cupy.promote_types(input.dtype, cupy.float32)
 
-    def get(is_diff, dtype=weights_dtype):
+    def get(is_diff):
         return (
-            cupy.array([-1, 0, 1], dtype=dtype) if is_diff else weights
+            cupy.array([-1, 0, 1], dtype=weights_dtype) if is_diff else weights
         )  # noqa
 
+    axes = tuple(range(input.ndim))
+    modes = (mode,) * input.ndim
     return _run_1d_correlates(
         input,
+        axes,
         [a == axis for a in range(input.ndim)],
         get,
         output,
-        mode,
+        modes,
         cval,
         algorithm=algorithm,
     )
@@ -952,6 +1039,7 @@ def minimum_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
     """Multi-dimensional minimum filter.
 
@@ -965,15 +1053,25 @@ def minimum_filter(
             elements within this shape will get passed to the filter function.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output. Default is is same dtype as the input.
-        mode (str): The array borders are handled according to the given mode
-            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
-            ``'wrap'``). Default is ``'reflect'``.
+        mode (str or sequence of str): The array borders are handled according
+            to the given mode (``'reflect'``, ``'constant'``, ``'nearest'``,
+            ``'mirror'``, ``'wrap'``). Default is ``'reflect'``. By passing a
+            sequence of modes with length equal to the number of ``axes`` along
+            which the input array is being filtered, different modes can be
+            specified along each axis. For more details on the supported modes,
+            see :func:`scipy.ndimage.minimum_filter`.
         cval (scalar): Value to fill past edges of input if mode is
             ``'constant'``. Default is ``0.0``.
         origin (int or sequence of int): The origin parameter controls the
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size``,
+            ``mode`` and/or ``origin`` must match the length of ``axes``. The
+            ith entry in any of these tuples corresponds to the ith entry in
+            ``axes``. Default is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -981,7 +1079,16 @@ def minimum_filter(
     .. seealso:: :func:`scipy.ndimage.minimum_filter`
     """
     return _min_or_max_filter(
-        input, size, footprint, None, output, mode, cval, origin, "min"
+        input,
+        size,
+        footprint,
+        None,
+        output,
+        mode,
+        cval,
+        origin,
+        "min",
+        axes,
     )
 
 
@@ -993,6 +1100,7 @@ def maximum_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
     """Multi-dimensional maximum filter.
 
@@ -1006,15 +1114,25 @@ def maximum_filter(
             elements within this shape will get passed to the filter function.
         output (cupy.ndarray, dtype or None): The array in which to place the
             output. Default is is same dtype as the input.
-        mode (str): The array borders are handled according to the given mode
-            (``'reflect'``, ``'constant'``, ``'nearest'``, ``'mirror'``,
-            ``'wrap'``). Default is ``'reflect'``.
+        mode (str or sequence of str): The array borders are handled according
+            to the given mode (``'reflect'``, ``'constant'``, ``'nearest'``,
+            ``'mirror'``, ``'wrap'``). Default is ``'reflect'``. By passing a
+            sequence of modes with length equal to the number of ``axes`` along
+            which the input array is being filtered, different modes can be
+            specified along each axis. For more details on the supported modes,
+            see :func:`scipy.ndimage.minimum_filter`.
         cval (scalar): Value to fill past edges of input if mode is
             ``'constant'``. Default is ``0.0``.
         origin (int or sequence of int): The origin parameter controls the
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size``,
+            ``mode`` and/or ``origin`` must match the length of ``axes``. The
+            ith entry in any of these tuples corresponds to the ith entry in
+            ``axes``. Default is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -1022,12 +1140,30 @@ def maximum_filter(
     .. seealso:: :func:`scipy.ndimage.maximum_filter`
     """
     return _min_or_max_filter(
-        input, size, footprint, None, output, mode, cval, origin, "max"
+        input,
+        size,
+        footprint,
+        None,
+        output,
+        mode,
+        cval,
+        origin,
+        "max",
+        axes,
     )
 
 
 def _min_or_max_filter(
-    input, size, ftprnt, structure, output, mode, cval, origin, func
+    input,
+    size,
+    ftprnt,
+    structure,
+    output,
+    mode,
+    cval,
+    origin,
+    func,
+    axes,
 ):
     # structure is used by morphology.grey_erosion() and grey_dilation()
     # and not by the regular min/max filters
@@ -1036,8 +1172,19 @@ def _min_or_max_filter(
         size = ftprnt
         ftprnt = None
 
+    axes, ftprnt, origins, modes, int_type = _filters_core._check_nd_args(
+        input,
+        ftprnt,
+        mode,
+        origin,
+        "footprint",
+        sizes=size,
+        axes=axes,
+        raise_on_zero_size_weight=True,
+    )
+    num_axes = len(axes)
     sizes, ftprnt, structure = _filters_core._check_size_footprint_structure(
-        input.ndim, size, ftprnt, structure
+        num_axes, size, ftprnt, structure
     )
     if cval is cupy.nan:
         raise NotImplementedError("NaN cval is unsupported")
@@ -1048,16 +1195,14 @@ def _min_or_max_filter(
         return _filters_core._run_1d_filters(
             [fltr if size > 1 else None for size in sizes],
             input,
+            axes,
             sizes,
             output,
-            mode,
+            modes,
             cval,
-            origin,
+            origins,
         )
 
-    origins, int_type = _filters_core._check_nd_args(
-        input, ftprnt, mode, origin, "footprint", sizes=sizes
-    )
     if structure is not None and structure.ndim != input.ndim:
         raise RuntimeError("structure array has incorrect shape")
 
@@ -1149,12 +1294,12 @@ def _min_or_max_1d(
     ftprnt, origin = _filters_core._convert_1d_args(
         input.ndim, ftprnt, origin, axis
     )
-    origins, int_type = _filters_core._check_nd_args(
-        input, ftprnt, mode, origin, "footprint"
+    axes, ftprnt, origins, modes, int_type = _filters_core._check_nd_args(
+        input, ftprnt, mode, origin, "footprint", axes=None
     )
     offsets = _filters_core._origins_to_offsets(origins, ftprnt.shape)
     kernel = _get_min_or_max_kernel(
-        mode,
+        modes,
         ftprnt.shape,
         func,
         offsets,
@@ -1226,6 +1371,7 @@ def rank_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
     """Multi-dimensional rank filter.
 
@@ -1250,6 +1396,12 @@ def rank_filter(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size`` and/or
+            ``origin`` must match the length of ``axes``. The ith entry in any
+            of these tuples corresponds to the ith entry in ``axes``. Default
+            is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -1266,6 +1418,7 @@ def rank_filter(
         mode,
         cval,
         origin,
+        axes,
     )
 
 
@@ -1277,6 +1430,7 @@ def median_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
     """Multi-dimensional median filter.
 
@@ -1299,6 +1453,12 @@ def median_filter(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size`` and/or
+            ``origin`` must match the length of ``axes``. The ith entry in any
+            of these tuples corresponds to the ith entry in ``axes``. Default
+            is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -1306,7 +1466,15 @@ def median_filter(
     .. seealso:: :func:`scipy.ndimage.median_filter`
     """
     return _rank_filter(
-        input, lambda fs: fs // 2, size, footprint, output, mode, cval, origin
+        input,
+        lambda fs: fs // 2,
+        size,
+        footprint,
+        output,
+        mode,
+        cval,
+        origin,
+        axes,
     )
 
 
@@ -1319,6 +1487,7 @@ def percentile_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
     """Multi-dimensional percentile filter.
 
@@ -1343,6 +1512,12 @@ def percentile_filter(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): If None, ``input`` is filtered along all
+            axes. Otherwise, ``input`` is filtered along the specified axes.
+            When ``axes`` is specified, any tuples used for ``size`` and/or
+            ``origin`` must match the length of ``axes``. The ith entry in any
+            of these tuples corresponds to the ith entry in ``axes``. Default
+            is ``None``.
 
     Returns:
         cupy.ndarray: The result of the filtering.
@@ -1365,7 +1540,7 @@ def percentile_filter(
             return int(float(fs) * percentile / 100.0)
 
     return _rank_filter(
-        input, get_rank, size, footprint, output, mode, cval, origin
+        input, get_rank, size, footprint, output, mode, cval, origin, axes
     )
 
 
@@ -1378,15 +1553,17 @@ def _rank_filter(
     mode="reflect",
     cval=0.0,
     origin=0,
+    axes=None,
 ):
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    default_footprint = footprint is None
     sizes, footprint, _ = _filters_core._check_size_footprint_structure(
-        input.ndim, size, footprint, None, force_footprint=False
+        num_axes, size, footprint, None, force_footprint=False
     )
     if cval is cupy.nan:
         raise NotImplementedError("NaN cval is unsupported")
-    origins, int_type = _filters_core._check_nd_args(
-        input, footprint, mode, origin, "footprint", sizes=sizes
-    )
+
     has_weights = True
     if sizes is not None:
         has_weights = False
@@ -1394,15 +1571,46 @@ def _rank_filter(
         if filter_size == 0:
             return cupy.zeros_like(input)
         footprint_shape = tuple(sizes)
-    elif footprint.size == 0:
-        return cupy.zeros_like(input)
+        (
+            axes,
+            footprint,
+            origins,
+            modes,
+            int_type,
+        ) = _filters_core._check_nd_args(
+            input,
+            None,
+            mode,
+            origin,
+            "footprint",
+            axes=axes,
+            sizes=footprint_shape,
+        )
     else:
-        footprint_shape = footprint.shape
-        filter_size = int(footprint.sum())
-        if filter_size == footprint.size:
-            # can omit passing the footprint if it is all ones
-            sizes = footprint.shape
-            has_weights = False
+        # generate explicit footprint matching axes size
+        # _, footprint, _ = _filters_core._check_size_footprint_structure(
+        #    num_axes, size, footprint, None, force_footprint=True)
+
+        if footprint.size == 0:
+            return cupy.zeros_like(input)
+        (
+            axes,
+            footprint,
+            origins,
+            modes,
+            int_type,
+        ) = _filters_core._check_nd_args(
+            input, footprint, mode, origin, "footprint", axes=axes
+        )
+        if default_footprint:
+            filter_size = footprint.size
+        else:
+            footprint_shape = footprint.shape
+            filter_size = int(footprint.sum())
+            if filter_size == footprint.size:
+                # can omit passing the footprint if it is all ones
+                sizes = footprint.shape
+                has_weights = False
 
     if not has_weights:
         footprint = None
@@ -1424,10 +1632,11 @@ def _rank_filter(
                 None,
                 None,
                 output,
-                mode,
+                modes,
                 cval,
                 origins,
                 min_max_op,
+                axes,
             )
         else:
             return _min_or_max_filter(
@@ -1436,16 +1645,17 @@ def _rank_filter(
                 footprint,
                 None,
                 output,
-                mode,
+                modes,
                 cval,
                 origins,
                 min_max_op,
+                axes,
             )
     offsets = _filters_core._origins_to_offsets(origins, footprint_shape)
     kernel = _get_rank_kernel(
         filter_size,
         rank,
-        mode,
+        modes,
         footprint_shape,
         offsets,
         float(cval),
@@ -1485,7 +1695,7 @@ def _get_shell_gap(filter_size):
 
 @cupy._util.memoize(for_each_device=True)
 def _get_rank_kernel(
-    filter_size, rank, mode, w_shape, offsets, cval, int_type, has_weights
+    filter_size, rank, modes, w_shape, offsets, cval, int_type, has_weights
 ):
     s_rank = min(rank, filter_size - rank - 1)
     # The threshold was set based on the measurements on a V100
@@ -1536,7 +1746,7 @@ def _get_rank_kernel(
         f"int iv = 0;\nX values[{array_size}];",
         "values[iv++] = {value};" + found_post,
         post,
-        mode,
+        modes,
         w_shape,
         int_type,
         offsets,

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -2,6 +2,7 @@
 import math
 import platform
 import warnings
+from collections.abc import Iterable
 
 import cupy
 import numpy
@@ -26,7 +27,57 @@ except ImportError:
 _is_not_windows = platform.system() != "Windows"
 
 
-def correlate(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
+def _expand_origin(ndim_image, axes, origin):
+    num_axes = len(axes)
+    origins = _util._fix_sequence_arg(origin, num_axes, "origin", int)
+    if num_axes < ndim_image:
+        # set origin = 0 for any axes not being filtered
+        origins_temp = [
+            0,
+        ] * ndim_image
+        for o, ax in zip(origins, axes):
+            origins_temp[ax] = o
+        origins = origins_temp
+    return origins
+
+
+def _expand_footprint(ndim_image, axes, footprint, footprint_name="footprint"):
+    num_axes = len(axes)
+    if num_axes < ndim_image:
+        if footprint.ndim != num_axes:
+            raise RuntimeError(
+                f"{footprint_name}.ndim ({footprint.ndim}) "
+                f"must match len(axes) ({num_axes})"
+            )
+
+        footprint = cupy.expand_dims(
+            footprint, tuple(ax for ax in range(ndim_image) if ax not in axes)
+        )
+    return footprint
+
+
+def _expand_mode(ndim_image, axes, mode):
+    num_axes = len(axes)
+    if not isinstance(mode, str) and isinstance(mode, Iterable):
+        # set mode = 'constant' for any axes not being filtered
+        modes = _util._fix_sequence_arg(mode, num_axes, "mode", str)
+        modes_temp = ["constant"] * ndim_image
+        for m, ax in zip(modes, axes):
+            modes_temp[ax] = m
+        mode = modes_temp
+    return mode
+
+
+def correlate(
+    input,
+    weights,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+    *,
+    axes=None,
+):
     """Multi-dimensional correlate.
 
     The array is correlated with the given kernel.
@@ -46,6 +97,11 @@ def correlate(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None, optional):  If None, `input` is filtered
+            along all axes. Otherwise, `input` is filtered along the specified
+            axes. When `axes` is specified, any tuples used for `mode` or
+            `origin` must match the length of `axes`. The ith entry in any of
+            these tuples corresponds to the ith entry in `axes`.
 
     Returns:
         cupy.ndarray: The result of correlate.
@@ -57,10 +113,21 @@ def correlate(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
         and input is integral) the results may not perfectly match the results
         from SciPy due to floating-point rounding of intermediate results.
     """
-    return _correlate_or_convolve(input, weights, output, mode, cval, origin)
+    return _correlate_or_convolve(
+        input, weights, output, mode, cval, origin, False, axes
+    )
 
 
-def convolve(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
+def convolve(
+    input,
+    weights,
+    output=None,
+    mode="reflect",
+    cval=0.0,
+    origin=0,
+    *,
+    axes=None,
+):
     """Multi-dimensional convolution.
 
     The array is convolved with the given kernel.
@@ -80,6 +147,11 @@ def convolve(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None, optional):  If None, `input` is filtered
+            along all axes. Otherwise, `input` is filtered along the specified
+            axes. When `axes` is specified, any tuples used for `mode` or
+            `origin` must match the length of `axes`. The ith entry in any of
+            these tuples corresponds to the ith entry in `axes`.
 
     Returns:
         cupy.ndarray: The result of convolution.
@@ -92,7 +164,7 @@ def convolve(input, weights, output=None, mode="reflect", cval=0.0, origin=0):
         from SciPy due to floating-point rounding of intermediate results.
     """
     return _correlate_or_convolve(
-        input, weights, output, mode, cval, origin, True
+        input, weights, output, mode, cval, origin, True, axes
     )
 
 
@@ -186,10 +258,10 @@ def convolve1d(
 
 
 def _correlate_or_convolve(
-    input, weights, output, mode, cval, origin, convolution=False
+    input, weights, output, mode, cval, origin, convolution=False, axes=None
 ):
     axes, weights, origins, modes, int_type = _filters_core._check_nd_args(
-        input, weights, mode, origin
+        input, weights, mode, origin, axes=axes
     )
     if weights.size == 0:
         return cupy.zeros_like(input)
@@ -221,6 +293,17 @@ def _correlate_or_convolve(
     return output
 
 
+def _unsupported_shmem_cval(cval, dtype):
+    """returns True if the cval + dtype combination is unsupported for the
+    shared memory kernels."""
+    return (
+        # shared_memory kernels fail to compile for non-finite cval
+        not numpy.isfinite(cval)
+        # incorrect output for negative cval and unsigned integer input
+        or (cval < 0 and dtype.kind == "u")
+    )
+
+
 def _correlate_or_convolve1d(
     input,
     weights,
@@ -241,7 +324,15 @@ def _correlate_or_convolve1d(
             algorithm = "shared_memory"
         else:
             algorithm = "elementwise"
-    elif algorithm not in ["shared_memory", "elementwise"]:
+    elif algorithm == "shared_memory":
+        if mode == "constant" and _unsupported_shmem_cval(cval, input.dtype):
+            # shared_memory case can fail to compile on NaN cval and
+            warnings.warn(
+                f"{cval=} and {input.dtype=} is unsupported for algorithm "
+                "'shared_memory', falling back to elementwise"
+            )
+            algorithm = "elementwise"
+    elif algorithm != "elementwise":
         raise ValueError(
             "algorithm must be 'shared_memory', 'elementwise' or None"
         )
@@ -1203,11 +1294,17 @@ def _min_or_max_filter(
             origins,
         )
 
-    if structure is not None and structure.ndim != input.ndim:
-        raise RuntimeError("structure array has incorrect shape")
-
     if ftprnt.size == 0:
         return cupy.zeros_like(input)
+
+    # expand origins ,footprint and structure if num_axes < input.ndim
+    ftprnt = _expand_footprint(input.ndim, axes, ftprnt)
+    origins = _expand_origin(input.ndim, axes, origin)
+    if structure is not None:
+        structure = _expand_footprint(
+            input.ndim, axes, structure, footprint_name="structure"
+        )
+
     offsets = _filters_core._origins_to_offsets(origins, ftprnt.shape)
     kernel = _get_min_or_max_kernel(
         mode,
@@ -1555,7 +1652,8 @@ def _rank_filter(
     origin=0,
     axes=None,
 ):
-    axes = _util._check_axes(axes, input.ndim)
+    ndim = input.ndim
+    axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)
     default_footprint = footprint is None
     sizes, footprint, _ = _filters_core._check_size_footprint_structure(
@@ -1587,12 +1685,9 @@ def _rank_filter(
             sizes=footprint_shape,
         )
     else:
-        # generate explicit footprint matching axes size
-        # _, footprint, _ = _filters_core._check_size_footprint_structure(
-        #    num_axes, size, footprint, None, force_footprint=True)
-
         if footprint.size == 0:
             return cupy.zeros_like(input)
+
         (
             axes,
             footprint,
@@ -1602,6 +1697,7 @@ def _rank_filter(
         ) = _filters_core._check_nd_args(
             input, footprint, mode, origin, "footprint", axes=axes
         )
+
         if default_footprint:
             filter_size = footprint.size
         else:
@@ -1628,7 +1724,7 @@ def _rank_filter(
         if sizes is not None:
             return _min_or_max_filter(
                 input,
-                sizes[0],
+                sizes,  #  [0],
                 None,
                 None,
                 output,
@@ -1652,6 +1748,13 @@ def _rank_filter(
                 axes,
             )
     offsets = _filters_core._origins_to_offsets(origins, footprint_shape)
+    if num_axes < ndim and not has_weights:
+        offsets = tuple(_expand_origin(ndim, axes, offsets))
+        modes = tuple(_expand_mode(ndim, axes, modes))
+        footprint_shape_temp = [1] * ndim
+        for s, ax in zip(footprint_shape, axes):
+            footprint_shape_temp[ax] = s
+        footprint_shape = tuple(footprint_shape_temp)
     kernel = _get_rank_kernel(
         filter_size,
         rank,

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -278,7 +278,14 @@ def _correlate_or_convolve1d(
     default_algorithm = False
     if algorithm is None:
         default_algorithm = True
-        if _is_not_windows and input.ndim == 2 and weights.size <= 256:
+        if (
+            _is_not_windows
+            and input.ndim == 2
+            and weights.size <= 256
+            and not (
+                cval < 0 and mode == "constant" and input.dtype.kind == "u"
+            )
+        ):
             algorithm = "shared_memory"
         else:
             algorithm = "elementwise"

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters.py
@@ -1350,9 +1350,11 @@ def _min_or_max_filter(
     if ftprnt.size == 0:
         return cupy.zeros_like(input)
 
-    # expand origins ,footprint and structure if num_axes < input.ndim
-    ftprnt = _expand_footprint(input.ndim, axes, ftprnt)
-    origins = _expand_origin(input.ndim, axes, origin)
+    if num_axes < input.ndim:
+        # expand origins ,footprint and structure if num_axes < input.ndim
+        ftprnt = _expand_footprint(input.ndim, axes, ftprnt)
+        origins = _expand_origin(input.ndim, axes, origin)
+
     if structure is not None:
         structure = _expand_footprint(
             input.ndim, axes, structure, footprint_name="structure"

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -83,27 +83,12 @@ def _check_nd_args(
         _util._check_mode(mode)
     origins = _util._fix_sequence_arg(origin, num_axes, "origin", int)
     if isinstance(weights, cupy.ndarray) and num_axes < input.ndim:
-        # In case of explicit footprint, we insert a singletone dimension
-        # on all non-filtered axes and insert values for origins, modes on any
-        # non-filtered axes.
-
-        # set origin = 0 on any axis not being filtered
-        origins_temp = [
-            0,
-        ] * input.ndim
-        for o, ax in zip(origins, axes):
-            origins_temp[ax] = o
-        origins = origins_temp
-
-        modes_temp = ["constant"] * input.ndim
-        for m, ax in zip(modes, axes):
-            modes_temp[ax] = m
-        modes = modes_temp
-
-        # insert singleton dimension on footprint for non-filtered axes
-        weights = cupy.expand_dims(
-            weights, tuple(ax for ax in range(input.ndim) if ax not in axes)
+        # expand origins ,footprint and structure if num_axes < input.ndim
+        weights = _util._expand_footprint(
+            input.ndim, axes, weights, footprint_name="weights"
         )
+        origins = _util._expand_origin(input.ndim, axes, origins)
+        modes = _util._expand_mode(input.ndim, axes, modes)
 
         # now filter all axes
         axes = tuple(range(input.ndim))

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -67,9 +67,46 @@ def _convert_1d_args(ndim, weights, origin, axis):
 
 
 def _check_nd_args(
-    input, weights, mode, origin, wghts_name="filter weights", sizes=None
+    input,
+    weights,
+    mode,
+    origin,
+    wghts_name="filter weights",
+    sizes=None,
+    axes=None,
+    raise_on_zero_size_weight=False,
 ):
-    _util._check_mode(mode)
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    modes = _util._fix_sequence_arg(mode, num_axes, "origin", str)
+    for mode in modes:
+        _util._check_mode(mode)
+    origins = _util._fix_sequence_arg(origin, num_axes, "origin", int)
+    if isinstance(weights, cupy.ndarray) and num_axes < input.ndim:
+        # In case of explicit footprint, we insert a singletone dimension
+        # on all non-filtered axes and insert values for origins, modes on any
+        # non-filtered axes.
+
+        # set origin = 0 on any axis not being filtered
+        origins_temp = [
+            0,
+        ] * input.ndim
+        for o, ax in zip(origins, axes):
+            origins_temp[ax] = o
+        origins = origins_temp
+
+        modes_temp = ["constant"] * input.ndim
+        for m, ax in zip(modes, axes):
+            modes_temp[ax] = m
+        modes = modes_temp
+
+        # insert singleton dimension on footprint for non-filtered axes
+        weights = cupy.expand_dims(
+            weights, tuple(ax for ax in range(input.ndim) if ax not in axes)
+        )
+
+        # now filter all axes
+        axes = tuple(range(input.ndim))
     if weights is not None:
         # Weights must always be less than 2 GiB
         if weights.nbytes >= (1 << 31):
@@ -77,20 +114,27 @@ def _check_nd_args(
                 "weights must be 2 GiB or less, use FFTs instead"
             )
         weight_dims = [x for x in weights.shape if x != 0]
+        if raise_on_zero_size_weight and any(w == 0 for w in weights.shape):
+            raise ValueError("All-zero footprint is not supported")
         if len(weight_dims) != input.ndim:
             raise RuntimeError(f"{wghts_name} array has incorrect shape")
     elif sizes is None:
         raise ValueError("must specify either weights array or sizes")
     else:
+        if numpy.isscalar(sizes):
+            sizes = (sizes,) * num_axes
+        if len(sizes) != num_axes:
+            raise ValueError("sizes must match len(axes)")
         weight_dims = sizes
     origins = _util._fix_sequence_arg(origin, len(weight_dims), "origin", int)
     for origin, width in zip(origins, weight_dims):
         _util._check_origin(origin, width)
-    return tuple(origins), _util._get_inttype(input)
+    int_type = _util._get_inttype(input)
+    return axes, weights, tuple(origins), tuple(modes), int_type
 
 
 def _run_1d_filters(
-    filters, input, args, output, mode, cval, origin=0, **filter_kwargs
+    filters, input, axes, args, output, modes, cval, origin=0, **filter_kwargs
 ):
     """
     Runs a series of 1D filters forming an nd filter. The filters must be a
@@ -99,10 +143,12 @@ def _run_1d_filters(
     filter. Individual filters can be None causing that axis to be skipped.
     """
     output = _util._get_output(output, input)
-    modes = _util._fix_sequence_arg(mode, input.ndim, "mode", _util._check_mode)
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    modes = _util._fix_sequence_arg(modes, num_axes, "mode", _util._check_mode)
     # for filters, "wrap" is a synonym for "grid-wrap".
     modes = ["grid-wrap" if m == "wrap" else m for m in modes]
-    origins = _util._fix_sequence_arg(origin, input.ndim, "origin", int)
+    origins = _util._fix_sequence_arg(origin, num_axes, "origin", int)
     n_filters = sum(filter is not None for filter in filters)
     if n_filters == 0:
         output[:] = input
@@ -111,11 +157,9 @@ def _run_1d_filters(
     temp = (
         _util._get_output(output.dtype, input) if n_filters > 1 else None
     )  # noqa
-    iterator = zip(filters, args, modes, origins)
-    for axis, (fltr, arg, mode, origin) in enumerate(iterator):
-        if fltr is None:
-            continue
-        else:
+    iterator = zip(axes, filters, args, modes, origins)
+    for axis, fltr, arg, mode, origin in iterator:
+        if fltr is not None:
             break
     if n_filters % 2 == 0:
         fltr(input, arg, axis, temp, mode, cval, origin, **filter_kwargs)
@@ -125,7 +169,7 @@ def _run_1d_filters(
         if n_filters == 1:
             return output
         input, output = output, temp
-    for axis, (fltr, arg, mode, origin) in enumerate(iterator, start=axis + 1):
+    for axis, fltr, arg, mode, origin in iterator:
         if fltr is None:
             continue
         fltr(input, arg, axis, output, mode, cval, origin, **filter_kwargs)
@@ -230,7 +274,7 @@ def _generate_nd_kernel(
     pre,
     found,
     post,
-    mode,
+    modes,
     w_shape,
     int_type,
     offsets,
@@ -259,8 +303,15 @@ def _generate_nd_kernel(
         in_params += ", raw M mask"
     out_params = "Y y"
 
-    # for filters, "wrap" is a synonym for "grid-wrap"
-    mode = "grid-wrap" if mode == "wrap" else mode
+    constant_mode = False
+    if isinstance(modes, str):
+        modes = "grid-wrap" if modes == "wrap" else modes
+        modes = (modes,) * ndim
+        num_unique_modes = 1
+    else:
+        modes = tuple("grid-wrap" if m == "wrap" else m for m in modes)
+        num_unique_modes = len(set(modes))
+    constant_mode = num_unique_modes == 1 and modes[0] == "constant"
 
     # CArray: remove xstride_{j}=... from string
     size = (
@@ -290,7 +341,7 @@ def _generate_nd_kernel(
             loops.append(f"{{ {int_type} ix_{j} = ind_{j} * xstride_{j};")
         else:
             boundary = _util._generate_boundary_condition_ops(
-                mode, f"ix_{j}", f"xsize_{j}", int_type
+                modes[j], f"ix_{j}", f"xsize_{j}", int_type
             )
             # CArray: last line of string becomes inds[{j}] = ix_{j};
             loops.append(
@@ -305,7 +356,7 @@ def _generate_nd_kernel(
 
     # CArray: string becomes 'x[inds]', no format call needed
     value = f"(*(X*)&data[{expr}])"
-    if mode == "constant":
+    if constant_mode:
         cond = " || ".join([f"(ix_{j} < 0)" for j in range(ndim)])
 
     if cval is numpy.nan:
@@ -318,7 +369,7 @@ def _generate_nd_kernel(
     if binary_morphology:
         found = found.format(cond=cond, value=value)
     else:
-        if mode == "constant":
+        if constant_mode:
             value = f"(({cond}) ? cast<{ctype}>({cval}) : {value})"
         found = found.format(value=value)
 
@@ -353,7 +404,11 @@ def _generate_nd_kernel(
         end_loops="}" * ndim,
     )
 
-    mode_str = mode.replace("-", "_")  # avoid potential hyphen in kernel name
+    # avoid potential hyphen in kernel name
+    if num_unique_modes > 1:
+        mode_str = "_".join(m.replace("-", "_") for m in modes)
+    else:
+        mode_str = modes[0].replace("-", "_")
     name = "cupyx_scipy_ndimage_{}_{}d_{}_w{}".format(
         name, ndim, mode_str, "_".join([f"{x}" for x in w_shape])
     )

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -126,7 +126,6 @@ def _check_nd_args(
         if len(sizes) != num_axes:
             raise ValueError("sizes must match len(axes)")
         weight_dims = sizes
-    origins = _util._fix_sequence_arg(origin, len(weight_dims), "origin", int)
     for origin, width in zip(origins, weight_dims):
         _util._check_origin(origin, width)
     int_type = _util._get_inttype(input)

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_morphology.py
@@ -832,7 +832,16 @@ def grey_erosion(
         raise ValueError("size, footprint or structure must be specified")
 
     return _filters._min_or_max_filter(
-        input, size, footprint, structure, output, mode, cval, origin, "min"
+        input,
+        size,
+        footprint,
+        structure,
+        output,
+        mode,
+        cval,
+        origin,
+        "min",
+        None,
     )
 
 
@@ -901,7 +910,16 @@ def grey_dilation(
             origin[i] -= 1
 
     return _filters._min_or_max_filter(
-        input, size, footprint, structure, output, mode, cval, origin, "max"
+        input,
+        size,
+        footprint,
+        structure,
+        output,
+        mode,
+        cval,
+        origin,
+        "max",
+        None,
     )
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
@@ -137,6 +137,47 @@ def _get_inttype(input):
     return "int" if nbytes < (1 << 31) else "ptrdiff_t"
 
 
+def _expand_origin(ndim_image, axes, origin):
+    num_axes = len(axes)
+    origins = _fix_sequence_arg(origin, num_axes, "origin", int)
+    if num_axes < ndim_image:
+        # set origin = 0 for any axes not being filtered
+        origins_temp = [
+            0,
+        ] * ndim_image
+        for o, ax in zip(origins, axes):
+            origins_temp[ax] = o
+        origins = origins_temp
+    return origins
+
+
+def _expand_footprint(ndim_image, axes, footprint, footprint_name="footprint"):
+    num_axes = len(axes)
+    if num_axes < ndim_image:
+        if footprint.ndim != num_axes:
+            raise RuntimeError(
+                f"{footprint_name}.ndim ({footprint.ndim}) "
+                f"must match len(axes) ({num_axes})"
+            )
+
+        footprint = cupy.expand_dims(
+            footprint, tuple(ax for ax in range(ndim_image) if ax not in axes)
+        )
+    return footprint
+
+
+def _expand_mode(ndim_image, axes, mode):
+    num_axes = len(axes)
+    if not isinstance(mode, str) and isinstance(mode, Iterable):
+        # set mode = 'constant' for any axes not being filtered
+        modes = _fix_sequence_arg(mode, num_axes, "mode", str)
+        modes_temp = ["constant"] * ndim_image
+        for m, ax in zip(modes, axes):
+            modes_temp[ax] = m
+        mode = modes_temp
+    return mode
+
+
 def _generate_boundary_condition_ops(
     mode, ix, xsize, int_t="int", float_ix=False, separate=False
 ):

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_util.py
@@ -109,8 +109,8 @@ def _check_axes(axes, ndim):
     elif cupy.isscalar(axes):
         axes = (operator.index(axes),)
     elif isinstance(axes, Iterable):
+        axes = tuple(operator.index(ax) for ax in axes)
         for ax in axes:
-            axes = tuple(operator.index(ax) for ax in axes)
             if ax < -ndim or ax > ndim - 1:
                 raise AxisError(f"specified axis: {ax} is out of range")
         axes = tuple(ax % ndim if ax < 0 else ax for ax in axes)

--- a/python/cucim/src/cucim/skimage/_vendored/ndimage.py
+++ b/python/cucim/src/cucim/skimage/_vendored/ndimage.py
@@ -2,6 +2,7 @@
 # measurements
 # fourier filters
 # additional filters
+from cupyx.scipy.ndimage import distance_transform_edt  # NOQA
 from cupyx.scipy.ndimage import fourier_ellipsoid  # NOQA
 from cupyx.scipy.ndimage import fourier_gaussian  # NOQA
 from cupyx.scipy.ndimage import fourier_shift  # NOQA
@@ -9,6 +10,7 @@ from cupyx.scipy.ndimage import fourier_uniform  # NOQA
 from cupyx.scipy.ndimage import generic_filter  # NOQA
 from cupyx.scipy.ndimage import generic_filter1d  # NOQA
 from cupyx.scipy.ndimage import label  # NOQA
+from cupyx.scipy.ndimage import value_indices  # NOQA
 
 from cucim.skimage._vendored._ndimage_filters import convolve  # NOQA
 from cucim.skimage._vendored._ndimage_filters import convolve1d  # NOQA
@@ -71,9 +73,15 @@ from cucim.skimage._vendored._ndimage_morphology import (  # NOQA
 
 
 try:
+    # `sum_labels` is only available as `sum` in older releases of CuPy
     from cupyx.scipy.ndimage import sum_labels  # NOQA
 except ImportError:
     from cupyx.scipy.ndimage import sum as sum_labels  # NOQA
+try:
+    from cupyx.scipy.ndimage import sum  # NOQA
+except ImportError:
+    # `sum` is deprecated and may be removed in a future version of CuPy
+    pass
 
 from cupyx.scipy.ndimage import center_of_mass  # NOQA
 from cupyx.scipy.ndimage import extrema  # NOQA

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_morphology.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_morphology.py
@@ -1,0 +1,131 @@
+"""Testing axes support that is not currently present in CuPy/SciPy."""
+
+import cupy as cp
+import numpy as np
+import pytest
+import scipy.ndimage as ndi_cpu
+
+from cucim.skimage._vendored import ndimage as ndi
+
+
+@pytest.mark.parametrize("border_value", [0, 1])
+@pytest.mark.parametrize("origin", [(0, 0), (-1, 0)])
+@pytest.mark.parametrize("expand_axis", [0, 1, 2])
+@pytest.mark.parametrize(
+    "func",
+    [
+        "binary_erosion",
+        "binary_dilation",
+        "binary_opening",
+        "binary_closing",
+        "binary_hit_or_miss",
+        "binary_propagation",
+        "binary_fill_holes",
+    ],
+)
+def test_binary_axes(func, expand_axis, origin, border_value):
+    struct = [[0, 1, 0], [1, 1, 1], [0, 1, 0]]
+
+    data = np.array(
+        [
+            [0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 1, 1, 0, 1, 0],
+            [0, 1, 0, 1, 1, 0, 1],
+            [0, 1, 1, 1, 1, 1, 0],
+            [0, 0, 1, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0],
+        ],
+        bool,
+    )
+    if func == "binary_hit_or_miss":
+        kwargs = dict(origin1=origin, origin2=origin)
+    else:
+        kwargs = dict(origin=origin)
+    border_supported = func not in ["binary_hit_or_miss", "binary_fill_holes"]
+    if border_supported:
+        kwargs["border_value"] = border_value
+    elif border_value != 0:
+        pytest.skip("border_value !=0 unsupported by this function")
+
+    scipy_func = getattr(ndi_cpu, func)
+    expected = scipy_func(data, struct, **kwargs)
+
+    # copy data and expected results to GPU
+    data = cp.asarray(data)
+    expected = cp.asarray(expected)
+    struct = cp.asarray(struct)
+
+    # replicate data and expected result along a new axis
+    n_reps = 5
+    expected = cp.stack([expected] * n_reps, axis=expand_axis)
+    data = cp.stack([data] * n_reps, axis=expand_axis)
+
+    # filter all axes except expand_axis
+    axes = [0, 1, 2]
+    axes.remove(expand_axis)
+    out = cp.zeros(data.shape, bool)
+    cucim_func = getattr(ndi, func)
+    cucim_func(data, struct, output=out, axes=axes, **kwargs)
+    cp.testing.assert_array_almost_equal(out, expected)
+
+
+@pytest.mark.parametrize("origin", [(0, 0), (-1, 0)])
+@pytest.mark.parametrize("expand_axis", [0, 1, 2])
+@pytest.mark.parametrize("mode", ["reflect", "constant"])
+@pytest.mark.parametrize("footprint_mode", ["size", "footprint", "structure"])
+@pytest.mark.parametrize(
+    "func",
+    [
+        "grey_erosion",
+        "grey_dilation",
+        "grey_opening",
+        "grey_closing",
+        "morphological_laplace",
+        "morphological_gradient",
+        "white_tophat",
+        "black_tophat",
+    ],
+)
+def test_grey_axes(func, expand_axis, origin, footprint_mode, mode):
+    data = np.array(
+        [
+            [0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 4, 0, 0, 0],
+            [0, 0, 2, 1, 0, 2, 0],
+            [0, 3, 0, 6, 5, 0, 1],
+            [0, 4, 5, 3, 3, 4, 0],
+            [0, 0, 9, 3, 0, 0, 0],
+            [0, 0, 0, 2, 0, 0, 0],
+        ]
+    )
+    kwargs = dict(origin=origin, mode=mode)
+    if footprint_mode == "size":
+        kwargs["size"] = (2, 3)
+    else:
+        kwargs["footprint"] = np.asarray([[1, 0, 1], [1, 1, 0]])
+    if footprint_mode == "structure":
+        kwargs["structure"] = np.ones_like(kwargs["footprint"])
+    scipy_func = getattr(ndi_cpu, func)
+    expected = scipy_func(data, **kwargs)
+
+    # copy data and expected results to GPU
+    data = cp.asarray(data)
+    expected = cp.asarray(expected)
+    if "footprint" in kwargs:
+        kwargs["footprint"] = cp.asarray(kwargs["footprint"])
+    if "structure" in kwargs:
+        kwargs["structure"] = cp.asarray(kwargs["structure"])
+
+    # replicate data and expected result along a new axis
+    n_reps = 5
+    expected = cp.stack([expected] * n_reps, axis=expand_axis)
+    data = cp.stack([data] * n_reps, axis=expand_axis)
+
+    # filter all axes except expand_axis
+    axes = [0, 1, 2]
+    axes.remove(expand_axis)
+    out = cp.zeros(expected.shape, dtype=expected.dtype)
+    cucim_func = getattr(ndi, func)
+    cucim_func(data, output=out, axes=axes, **kwargs)
+    cp.testing.assert_array_almost_equal(out, expected)

--- a/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
+++ b/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
@@ -986,8 +986,8 @@ def _shmem_convolve1d(
     convolution=False,
 ):
     ndim = image.ndim
-    if weights.ndim != 1:
-        raise ValueError("expected 1d weight array")
+    if weights.ndim != 1 or weights.shape[0] < 1:
+        raise RuntimeError("expected a 1d weights array with non-zero size")
     axis = _normalize_axis_index(axis, ndim)
     origin = util._check_origin(origin, weights.size)
     if weights.size == 0:

--- a/python/cucim/src/cucim/skimage/filters/tests/test_gaussian.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_gaussian.py
@@ -19,13 +19,15 @@ def test_negative_sigma():
 def test_null_sigma():
     a = cp.zeros((3, 3))
     a[1, 1] = 1.0
-    assert cp.all(gaussian(a, 0) == a)
+    d = cp.cuda.Device()
+    d.synchronize()
+    cp.testing.assert_array_equal(gaussian(a, sigma=0), a)
 
 
 def test_default_sigma():
     a = cp.zeros((3, 3))
     a[1, 1] = 1.0
-    assert cp.all(gaussian(a) == gaussian(a, sigma=1))
+    cp.testing.assert_array_equal(gaussian(a), gaussian(a, sigma=1))
 
 
 def test_energy_decrease():


### PR DESCRIPTION
I contributed user-specified `axes` support to the scipy.ndimage API (for filtering and morphology functions). SciPy 0.15 is the first public release with these changes.

I originally developed this GPU port of the code in a local cuCIM branch, but submitted it upstream to CuPy and got it merged there before opening this MR. See cupy/cupy#8858 (will first appear in CuPy 14.0).

The test cases here were created before I created the CuPy MR and were later updated/integrated into CuPy's existing style in the MR there. I think we may as well keep the extra tests here as a sanity check that the vendored code continues to work as expected.

## Additional testing
A few miscellaneous other updates were copied over from CuPy so that the full `cupyx.scipy.ndimage`  test suite patches with the vendored ndimage from cuCIM when applying the following patch to CuPy's test suite (monkey-patches the module to use the one from cuCIM)

```diff
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_distance_transform.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_distance_transform.py
index 97b041c0c..92abce3cb 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_distance_transform.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_distance_transform.py
@@ -6,6 +6,8 @@ import pytest
 import cupy
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     import scipy.ndimage  # NOQA
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
index 78cb7c4d0..24726965f 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -8,6 +8,8 @@ from cupy.cuda import runtime
 from cupy import testing
 from cupy.exceptions import AxisError
 import cupyx.scipy.ndimage  # NOQA
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     import scipy.ndimage  # NOQA
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
index 5a897a4b8..361b612bb 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -8,6 +8,8 @@ from cupy.exceptions import AxisError
 import cupyx.scipy.fft  # NOQA
 import cupyx.scipy.fftpack  # NOQA
 import cupyx.scipy.ndimage  # NOQA
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     # scipy.fft only available since SciPy 1.4.0
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
index 3308b28c4..16668c53b 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -6,6 +6,8 @@ from cupy.cuda import runtime
 from cupy import testing
 import cupyx.scipy.ndimage
 from cupyx.scipy.ndimage import _util
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     import scipy
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
index e1c06db15..203c3fc29 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -10,6 +10,8 @@ from cupy import testing
 from cupy import _util
 from cupy._core import _accelerator
 import cupyx.scipy.ndimage  # NOQA
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     import scipy
diff --git a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
index 8bbcc63d8..6ee5ec86c 100644
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -4,6 +4,8 @@ import pytest
 
 from cupy import testing
 import cupyx.scipy.ndimage  # NOQA
+from cucim.skimage._vendored import ndimage as ndi
+cupyx.scipy.ndimage = ndi
 
 try:
     import scipy.ndimage  # NOQA
```