### PR TITLE
Add shellcheck to pre-commit and fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+        files: ^ci/

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -27,7 +27,8 @@ rapids-mamba-retry install \
     "cucim=${RAPIDS_VERSION}" \
     "libcucim=${RAPIDS_VERSION}"
 
-export RAPIDS_DOCS_DIR="$(mktemp -d)"
+RAPIDS_DOCS_DIR="$(mktemp -d)"
+export RAPIDS_DOCS_DIR
 
 rapids-logger "Build Python docs"
 pushd docs

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -13,7 +13,7 @@ source rapids-date-string
 
 rapids-generate-version > ./VERSION
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 rapids-logger "Generating build requirements"
 
@@ -54,6 +54,7 @@ sccache --show-adv-stats
 
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*
+# shellcheck disable=SC2010
 ls -1 final_dist | grep -vqz 'none'
 
 ../../ci/validate_wheel.sh final_dist

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -12,22 +12,21 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}' | tr -d 'a')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
+CURRENT_MAJOR=$(echo "$CURRENT_TAG" | awk '{split($0, a, "."); print a[1]}')
+CURRENT_MINOR=$(echo "$CURRENT_TAG" | awk '{split($0, a, "."); print a[2]}')
+CURRENT_PATCH=$(echo "$CURRENT_TAG" | awk '{split($0, a, "."); print a[3]}' | tr -d 'a')
 CURRENT_LONG_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}
 
 #Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_MAJOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
 echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 # Centralized version file update

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,11 +3,11 @@
 
 set -eou pipefail
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 RAPIDS_PY_WHEEL_NAME="cucim_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install $(echo ./dist/cucim*.whl)[test]
+python -m pip install "$(echo ./dist/cucim*.whl)[test]"
 
 CUDA_MAJOR_VERSION=${RAPIDS_CUDA_VERSION:0:2}
 

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -10,11 +10,11 @@ rapids-logger "validate packages with 'pydistcheck'"
 # shellcheck disable=SC2116
 pydistcheck \
     --inspect \
-    "$(echo "${wheel_dir_relative_path}/*.whl")"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"
 
 rapids-logger "validate packages with 'twine'"
 
 # shellcheck disable=SC2116
 twine check \
     --strict \
-    "$(echo "${wheel_dir_relative_path}/*.whl")"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -7,12 +7,14 @@ wheel_dir_relative_path=$1
 
 rapids-logger "validate packages with 'pydistcheck'"
 
+# shellcheck disable=SC2116
 pydistcheck \
     --inspect \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}/*.whl")"
 
 rapids-logger "validate packages with 'twine'"
 
+# shellcheck disable=SC2116
 twine check \
     --strict \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}/*.whl")"


### PR DESCRIPTION
## Description                                                                                                
                                                                                                              
`shellcheck` is a fast, static analysis tool for shell scripts. It's good at
flagging up unused variables, unintentional glob expansions, and other potential
execution and security headaches that arise from the wonders of `bash` (and
other shlangs).                   
                                                                                                              
This PR adds a `pre-commit` hook to run `shellcheck` on all of the `sh-lang`
files in the `ci/` directory, and the changes requested by `shellcheck` to make
the existing files pass the check.                              
                                                                                                              
xref: rapidsai/build-planning#135