### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -21,7 +21,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "click",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
