### PR TITLE
Use conda-build instead of conda-mambabuild

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -21,7 +21,7 @@ conda config --set path_conflict warn
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild conda/recipes/libcucim
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build conda/recipes/libcucim
 
 sccache --show-adv-stats
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -27,7 +27,7 @@ sccache --zero-stats
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cucim


### PR DESCRIPTION
This changes from `conda mambabuild` to `conda build`. Conda now uses the mamba solver so no performance regressions are expected.

This is a temporary change as we plan to migrate to `rattler-build` in the near future. However, this is needed sooner to drop `boa` and unblock Python 3.13 migrations.

xref: https://github.com/rapidsai/build-planning/issues/149
