### PR TITLE
Consistently raise error on non-CuPy input to regionprops functions

### DIFF
--- a/python/cucim/src/cucim/skimage/measure/_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops.py
@@ -319,7 +319,12 @@ class RegionProperties:
         extra_properties=None,
         spacing=None,
     ):
+        if not isinstance(label_image, cp.ndarray):
+            raise ValueError("label_image image must be a cupy.ndarray")
+
         if intensity_image is not None:
+            if not isinstance(intensity_image, cp.ndarray):
+                raise ValueError("intensity_image image must be a cupy.ndarray")
             ndim = label_image.ndim
             if not (
                 intensity_image.shape[:ndim] == label_image.shape
@@ -1127,6 +1132,13 @@ def regionprops_table(
     4      5       112.50        113.0        114.0
 
     """
+    if not isinstance(label_image, cp.ndarray):
+        raise ValueError("label_image must be a cupy.ndarray")
+    if intensity_image is not None and not isinstance(
+        intensity_image, cp.ndarray
+    ):
+        raise ValueError("intensity_image must be a cupy.ndarray")
+
     regions = regionprops(
         label_image,
         intensity_image=intensity_image,
@@ -1412,6 +1424,12 @@ def regionprops(
     array(42)
 
     """  # noqa
+    if not isinstance(label_image, cp.ndarray):
+        raise ValueError("label_image must be a cupy.ndarray")
+    if intensity_image is not None and not isinstance(
+        intensity_image, cp.ndarray
+    ):
+        raise ValueError("intensity_image must be a cupy.ndarray")
 
     if label_image.ndim not in (2, 3):
         raise TypeError("Only 2-D and 3-D images supported.")

--- a/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
+++ b/python/cucim/src/cucim/skimage/measure/tests/test_regionprops.py
@@ -132,6 +132,14 @@ def test_all_props_3d():
             pass
 
 
+def test_all_props_error_on_numpy_input():
+    with pytest.raises(ValueError):
+        regionprops(cp.asnumpy(SAMPLE), INTENSITY_SAMPLE)
+
+    with pytest.raises(ValueError):
+        regionprops(SAMPLE, cp.asnumpy(INTENSITY_SAMPLE))
+
+
 def test_num_pixels():
     num_pixels = regionprops(SAMPLE)[0].num_pixels
     assert num_pixels == 72
@@ -1219,6 +1227,17 @@ def test_regionprops_table_no_regions():
     assert len(out["bbox+1"]) == 0
     assert len(out["bbox+2"]) == 0
     assert len(out["bbox+3"]) == 0
+
+
+def test_regionprops_table_error_on_numpy_input():
+    with pytest.raises(ValueError):
+        regionprops_table(
+            cp.asnumpy(SAMPLE), INTENSITY_SAMPLE, properties=["intensity_mean"]
+        )
+    with pytest.raises(ValueError):
+        regionprops_table(
+            SAMPLE, cp.asnumpy(INTENSITY_SAMPLE), properties=["intensity_mean"]
+        )
 
 
 def test_column_dtypes_complete():


### PR DESCRIPTION
closes #789

Update regionprops APIs to consistently raise a `ValueError` on non-CuPy image inputs