### PR TITLE
avoid potential CUDA out of bounds memory access in test case

### DIFF
--- a/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
+++ b/python/cucim/src/cucim/skimage/filters/tests/test_thresholding.py
@@ -637,6 +637,14 @@ def test_mean():
 @pytest.mark.parametrize("kwargs", [{}, {"nbins": 300000}])
 @pytest.mark.parametrize("dtype", [cp.uint8, cp.int16, cp.float16, cp.float32])
 def test_triangle_uniform_images(dtype, kwargs):
+    if dtype == cp.float16:
+        # Avoid potential NaN bin edges if nbins exceeds float16 range.
+        # (NaN in bin edges can cause out of bounds CUDA memory access in
+        # `cp.histogram`)
+        if "nbins" in kwargs:
+            kwargs["nbins"] = min(
+                kwargs["nbins"], int(np.finfo(np.float16).max)
+            )
     assert threshold_triangle(cp.zeros((10, 10), dtype=dtype), **kwargs) == 0
     assert threshold_triangle(cp.ones((10, 10), dtype=dtype), **kwargs) == 1
     assert threshold_triangle(cp.full((10, 10), 2, dtype=dtype), **kwargs) == 2


### PR DESCRIPTION
The test case modified in this PR was observed to cause a CUDA error for float16 dtype on CuPy's `main` branch when CUB is enabled.

```
FAILED cucim/skimage/filters/tests/test_thresholding.py::test_triangle_uniform_images[float16-kwargs1] - cupy_backends.cuda.api.driver.CUDADriverError: CUDA_ERROR_ILLEGAL_ADDRESS: an illegal memory access was encountered
```

The root cause of this is related to choosing an unreasonably large number of bins for the `float16` data type. Both NumPy and CuPy's histogram use a linspace call to determine bin edges. If the number of bins exceeds the representible range for float16 some of these bin edges may be NaN which is what was eventually causing the issue with out of bounds memory access.

e.g.
```python
np.linspace(np.asarray(-0.5, np.float16), np.asarray(0.5, np.float16), 300000)
```
results in
```
/home/grelee/mambaforge/envs/rapids-24.12-v2/lib/python3.12/site-packages/numpy/_core/function_base.py:157: RuntimeWarning: overflow encountered in cast
  step = delta / div
/home/grelee/mambaforge/envs/rapids-24.12-v2/lib/python3.12/site-packages/numpy/_core/function_base.py:162: RuntimeWarning: overflow encountered in cast
  y /= div
/home/grelee/mambaforge/envs/rapids-24.12-v2/lib/python3.12/site-packages/numpy/_core/function_base.py:162: RuntimeWarning: invalid value encountered in divide
  y /= div
Out[3]: array([-0.5, -0.5, -0.5, ...,  nan,  nan,  0.5], dtype=float16)
```

We should just choose a smaller number of bins in the float16 test case here as there is not a real-world use case for such a large number of bins with that data type. 