### PR TITLE
Fix path in update-version

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,5 +47,5 @@ for DEP in "${DEPENDENCIES[@]}"; do
   for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
-  sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" pyproject.toml
+  sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" python/cucim/pyproject.toml
 done


### PR DESCRIPTION
Updates `pyproject.toml` to the correct path.

Technically, the file has nothing that needs to be updated by this script, but virtually every repo includes updating their `pyproject.toml` files, so I think it's a good idea to include it anyway in case the file is changed in the future, there is less chance to forget to update this script as well.

Skipping CI because this script is not run in CI.