### PR TITLE
[WIP] Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
+      wheel_type: python
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,6 +74,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
+      wheel_type: python
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 package_name="cucim"
 package_dir="python/cucim"
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR:-"final_dist"}
+
 CMAKE_BUILD_TYPE="release"
 
 source rapids-configure-sccache
@@ -56,10 +58,10 @@ rapids-pip-retry wheel \
 sccache --show-adv-stats
 
 mkdir -p final_dist
-python -m auditwheel repair -w final_dist dist/*
+python -m auditwheel repair -w "${wheel_dir}" dist/*
 # shellcheck disable=SC2010
-ls -1 final_dist | grep -vqz 'none'
+ls -1 "${wheel_dir}" | grep -vqz 'none'
 
-../../ci/validate_wheel.sh final_dist
+../../ci/validate_wheel.sh "${wheel_dir}"
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${wheel_dir}"


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)