### PR TITLE
Download build artifacts from GitHub for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
-      wheel-name: cucim
+      package-name: cucim
       package-type: python
   wheel-publish:
     needs: wheel-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
+      wheel-name: cucim
       package-type: python
   wheel-publish:
     needs: wheel-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,6 +74,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
+      wheel-name: cucim
       package-type: python
   wheel-tests:
     needs: wheel-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,7 +74,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
-      wheel-name: cucim
+      package-name: cucim
       package-type: python
   wheel-tests:
     needs: wheel-build

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -21,7 +21,7 @@ rapids-logger "Begin py build"
 # ref: https://github.com/rapidsai/cucim/issues/800#issuecomment-2529593457
 conda config --set path_conflict warn
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 sccache --zero-stats
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,10 +4,10 @@
 set -eou pipefail
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-RAPIDS_PY_WHEEL_NAME="cucim_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+PYTHON_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cucim_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-rapids-pip-retry install "$(echo ./dist/cucim*.whl)[test]"
+rapids-pip-retry install "$(echo ${PYTHON_WHEELHOUSE}/cucim*.whl)[test]"
 
 CUDA_MAJOR_VERSION=${RAPIDS_CUDA_VERSION:0:2}
 


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads to conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 
