### PR TITLE
Refactor: Enhance GPU Memory Leak Test for `read_region`

### DIFF
--- a/python/cucim/tests/performance/clara/test_read_region_memory_usage.py
+++ b/python/cucim/tests/performance/clara/test_read_region_memory_usage.py
@@ -36,20 +36,81 @@ def test_read_region_cuda_memleak(testimg_tiff_stripe_4096x4096_256_jpeg):
 
     img = open_image_cucim(testimg_tiff_stripe_4096x4096_256_jpeg)
 
-    mem_usage_history = [get_used_gpu_memory_mib()]
+    mem_usage_history = [
+        get_used_gpu_memory_mib()
+    ]  # Memory before loop (image loaded)
 
-    for i in range(10):
-        _ = img.read_region(device="cuda")
+    num_iterations = 10
+    warmup_iterations = (
+        3  # Number of iterations to run before establishing a baseline
+    )
+
+    for i in range(num_iterations):
+        region_data = img.read_region(device="cuda")
+        # Explicitly delete the CuPy array
+        del region_data
+        # Force CuPy to free unused blocks from its memory pool
+        cp.get_default_memory_pool().free_all_blocks()
         mem_usage_history.append(get_used_gpu_memory_mib())
 
-    print(mem_usage_history)
+    print(f"Full memory usage history (MiB): {mem_usage_history}")
 
-    # The difference in memory usage should be less than 180MB.
-    # Note: Since we cannot measure GPU memory usage for a process,
-    #       we use a rough number.
-    #       (experimentally measured, assuming that each image load
-    #        consumes around 50MB of GPU memory).
-    assert mem_usage_history[5] - mem_usage_history[9] < 180.0
+    # mem_usage_history[0] is before any read_region calls
+    # mem_usage_history[k] is after the k-th iteration (read_region, del,
+    # free_all_blocks)
+
+    # Baseline memory after warmup_iterations (e.g., after 3rd iteration)
+    # Ensure warmup_iterations is less than num_iterations
+    if warmup_iterations >= num_iterations:
+        pytest.fail(
+            "warmup_iterations must be less than num_iterations for this test "
+            "logic"
+        )
+
+    # Memory after the warmup period (e.g., after 3rd call, so index 3)
+    mem_after_warmup = mem_usage_history[warmup_iterations]
+    # Memory after all iterations (e.g., after 10th call, so index 10)
+    mem_at_end = mem_usage_history[num_iterations]
+
+    # Calculate the increase in memory after the warmup period
+    memory_increase_after_warmup = mem_at_end - mem_after_warmup
+
+    print(
+        f"Memory after warmup ({warmup_iterations} iterations): "
+        f"{mem_after_warmup:.2f} MiB"
+    )
+    print(f"Memory at end ({num_iterations} iterations): {mem_at_end:.2f} MiB")
+    print(
+        f"Memory increase after warmup: {memory_increase_after_warmup:.2f} MiB"
+    )
+
+    # The increase in memory after the warm-up phase and explicit freeing
+    # should be minimal, ideally close to zero for a perfectly clean operation.
+    # This threshold (leak_threshold_mib, e.g., 30.0 MiB) defines an acceptable
+    # upper bound for the *cumulative* memory increase observed over the
+    # (num_iterations - warmup_iterations) test iterations.
+    # It accounts for potential minor non-reclaimable memory that might
+    # accumulate due to factors like fragmentation, persistent driver/runtime
+    # overheads, or small, consistent allocation patterns within the tested
+    # function, even with explicit attempts to free memory.
+    #
+    # For instance, a 30.0 MiB threshold over 7 active test iterations
+    # (10 total iterations - 3 warmup iterations) allows for an average of
+    # roughly 4.3 MiB of such net memory growth per iteration during the
+    # measurement phase.
+    # This approach is significantly different from a previous version of this
+    # test, which used a 180MB threshold for a non-cumulative comparison
+    # (i.e., `memory_at_iteration_5 - memory_at_iteration_9`), which could
+    # be affected by transient spikes rather than sustained growth.
+    # If the `read_region` operation has a consistent memory leak (i.e., memory
+    # that is allocated and not freed properly on an ongoing basis), the
+    # `memory_increase_after_warmup` is expected to exceed this threshold.
+    leak_threshold_mib = 30.0
+    assert memory_increase_after_warmup < leak_threshold_mib, (
+        f"Memory increase ({memory_increase_after_warmup:.2f} MiB) "
+        f"exceeded threshold ({leak_threshold_mib} MiB) "
+        f"over {num_iterations - warmup_iterations} iterations after warmup."
+    )
 
 
 def test_read_region_cpu_memleak(testimg_tiff_stripe_4096x4096_256):


### PR DESCRIPTION
**Problem:**

The existing GPU memory leak test, `test_read_region_cuda_memleak`, has been observed to fail sporadically (as noted in https://github.com/rapidsai/build-infra/issues/228#issuecomment-2852570027). The previous logic, which compared memory usage at iteration 5 against iteration 9 (`mem_usage_history[5] - mem_usage_history[9]`), was susceptible to transient memory fluctuations caused by Python's garbage collection timing and CuPy's memory pool management, rather than necessarily indicating a persistent memory leak.

**Solution:**

This PR refactors `test_read_region_cuda_memleak` to improve its stability and accuracy in detecting genuine GPU memory leaks:

1.  **Explicit Memory Management:**
    *   The CuPy array returned by `img.read_region(device="cuda")` is now explicitly deleted (`del region_data`) within each test loop iteration.
    *   `cp.get_default_memory_pool().free_all_blocks()` is called immediately after deletion to encourage prompt reclamation of GPU memory by the CuPy memory pool.

2.  **Revised Assertion Strategy:**
    *   The test now includes a "warm-up" phase (a few initial iterations) to allow for any one-time memory allocations or cache population.
    *   Memory usage is recorded before the warm-up (`mem_after_warmup`) and at the very end of all iterations (`mem_at_end`).
    *   The core assertion now checks if the *cumulative* memory increase (`mem_at_end - mem_after_warmup`) over the subsequent test iterations exceeds a defined `leak_threshold_mib` (currently set to 30MB over 7 active iterations). This directly targets sustained memory growth, which is characteristic of a leak.

3.  **Improved Clarity:**
    *   Comments within the test have been updated to clearly explain the new methodology, the purpose of the warm-up phase, and the rationale behind the chosen leak threshold.

**Benefits:**

*   **Increased Test Stability:** By explicitly managing memory and using a cumulative check, the test should be far less prone to flakiness caused by system noise or GC timing.
*   **More Accurate Leak Detection:** The new logic more accurately reflects how a memory leak would manifest (i.e., sustained growth over time despite attempts to free resources).
*   **Clearer Test Intent:** The refactored code and comments make the test's purpose and methodology easier to understand.

This change aims to provide a more reliable and meaningful assessment of GPU memory usage for the `read_region` operation.

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
