### PR TITLE
Adding GH_TOKEN pass-through to summarize job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,14 +1,11 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   pr-builder:
     needs:
@@ -86,7 +83,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4
@@ -96,3 +92,5 @@ jobs:
     steps:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
+    env:
+      GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This adds an env var to pass the github token through to the telemetry summary shared action. The token is necessary to check if the base artifact exists. See https://github.com/rapidsai/shared-actions/pull/56 for more information.

The whitespace changes here were introduced from using yq with rapids-reviser to add this field. If the whitespace changes are undesirable, I will revert them.