### PR TITLE
Remove nvidia and dask channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.16.0
+    rev: v1.19.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - click

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - click

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -85,7 +85,6 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - conda-forge
-  - nvidia
 dependencies:
   build:
     common:
@@ -274,7 +273,7 @@ dependencies:
           - pytest-lazy-fixtures>=1.0.0
           - pytest-xdist
           - tifffile>=2022.8.12
-          - pooch>=1.6.0  # needed to download scikit-image sample data
+          - pooch>=1.6.0 # needed to download scikit-image sample data
           - pywavelets>=1.6
       - output_types: [conda]
         packages:


### PR DESCRIPTION
Now that we have dropped support for CUDA 11 we no longer require the nvidia channel.
With the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/85, RAPIDS now only uses released versions of dask, so we no longer need the dask channel either.
Contributes to https://github.com/rapidsai/build-planning/issues/184
