### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
-- cuda-version=12.8
+- cuda-version=12.9
 - cupy>=12.0.0
 - cxx-compiler
 - gcc_linux-aarch64=13.*
@@ -44,4 +44,4 @@ dependencies:
 - tifffile>=2022.8.12
 - pip:
   - opencv-python-headless>=4.6
-name: all_cuda-128_arch-aarch64
+name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
-- cuda-version=12.8
+- cuda-version=12.9
 - cupy>=12.0.0
 - cxx-compiler
 - gcc_linux-64=13.*
@@ -46,4 +46,4 @@ dependencies:
 - yasm
 - pip:
   - opencv-python-headless>=4.6
-name: all_cuda-128_arch-x86_64
+name: all_cuda-129_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64, aarch64]
     includes:
       - build


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.