### PR TITLE
Fix test failures due to deprecated Pillow Image.fromarray 'mode' parameter

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/tests/test_color_jitter.py
+++ b/python/cucim/src/cucim/core/operations/color/tests/test_color_jitter.py
@@ -26,7 +26,7 @@ def test_color_jitter_bad_params():
         arr1 = arr.flatten()
         ccl.color_jitter(arr1, 0.25, 0.75, 0.25, 0.04)
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         ccl.color_jitter(img, 0.25, 0.75, 0.25, 0.04)
 
 

--- a/python/cucim/src/cucim/core/operations/intensity/tests/test_normalize.py
+++ b/python/cucim/src/cucim/core/operations/intensity/tests/test_normalize.py
@@ -41,7 +41,7 @@ def test_norm_param():
     with pytest.raises(ValueError):
         its.normalize_data(arr, 10.0, 0, 255, "invalid")
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         its.normalize_data(img, 10.0, 0, 255)
 
 

--- a/python/cucim/src/cucim/core/operations/intensity/tests/test_scaling.py
+++ b/python/cucim/src/cucim/core/operations/intensity/tests/test_scaling.py
@@ -29,7 +29,7 @@ def test_scale_param():
     with pytest.raises(ValueError):
         its.scale_intensity_range(arr, 0.0, 255.0, 1.0, 1.0, False)
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         its.scale_intensity_range(img, 0.0, 255.0, -1.0, 1.0, False)
 
 

--- a/python/cucim/src/cucim/core/operations/intensity/tests/test_zoom.py
+++ b/python/cucim/src/cucim/core/operations/intensity/tests/test_zoom.py
@@ -35,7 +35,7 @@ def test_zoom_param():
         arr1 = arr.flatten()
         its.zoom(arr1, [1.1, 1.1])
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         its.zoom(img, [1.1, 1.1])
 
 

--- a/python/cucim/src/cucim/core/operations/spatial/tests/test_flip.py
+++ b/python/cucim/src/cucim/core/operations/spatial/tests/test_flip.py
@@ -27,7 +27,7 @@ def get_flipped_data():
 def test_flip_param():
     arr = get_input_arr()
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         spt.image_flip(img, (1, 2))
 
 

--- a/python/cucim/src/cucim/core/operations/spatial/tests/test_rotate90.py
+++ b/python/cucim/src/cucim/core/operations/spatial/tests/test_rotate90.py
@@ -27,7 +27,7 @@ def get_rotated_data():
 def test_rotate90_param():
     arr = get_input_arr()
     with pytest.raises(TypeError):
-        img = Image.fromarray(arr.T, "RGB")
+        img = Image.fromarray(arr.T)
         spt.image_rotate_90(img, 1, [1, 2])
 
 


### PR DESCRIPTION
Closes #900
Closes #899

A small number of test cases were passing an "RGB" 'mode' argument to Pillow's [fromarray](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.fromarray). That argument [has been deprecated since Pillow 11.3](https://pillow.readthedocs.io/en/stable/deprecations.html#image-fromarray-mode-parameter) and will be removed in a future release.

The test cases continue to work in local testing without specifying that deprecated parameter.