### PR TITLE
run: fix compatibility with PEP-0632 for supporting Python >=3.12

### DIFF
--- a/run
+++ b/run
@@ -350,9 +350,9 @@ build_local_cucim_() {
     pushd "${source_folder}" > /dev/null
 
     local python_library
-    python_library=$(python3 -c "import distutils.sysconfig as sysconfig, os; print(os.path.join(sysconfig.get_config_var('LIBDIR'), sysconfig.get_config_var('LDLIBRARY')))")
+    python_library=$(python3 -c "import sysconfig, os; print(os.path.join(sysconfig.get_config_var('LIBDIR'), sysconfig.get_config_var('LDLIBRARY')))")
     local python_include_dir
-    python_include_dir=$(python3 -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")
+    python_include_dir=$(python3 -c "import sysconfig; print(sysconfig.get_path('include'))")
 
     ${CMAKE_CMD} -S "${source_folder}" -B "${build_folder}" -G "Unix Makefiles" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \


### PR DESCRIPTION
In PEP 632 [1] it is stated that distutils is deprecated in Python 3.10 and 3.11 and will no longer be installed in Python 3.12

run make use of distutils.sysconfig to find the location of the Python .so and include path. PEP 632 recommends replacement with sysconfig.

Today when attempting to build cucim with Python 3.12.3 build_local_cucim_() fails with:

+ local build_folder=/cucim/python/build-debug
+ local CMAKE_CMD=cmake
+ pushd /cucim/python
+ local python_library ++ python3 -c 'import distutils.sysconfig as sysconfig, os; print(os.path.join(sysconfig.get_config_var('\''LIBDIR'\''), sysconfig.get_config_var('\''LDLIBRARY'\'')))' Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'distutils'
+ python_library=

This test was also tested on Python 3.11 for backwards compatibility.

[1] https://peps.python.org/pep-0632/

<!--

Thank you for contributing to cuCIM :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
