### PR TITLE
Drop CUDA 11 from CI Scripts

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -21,18 +21,8 @@ else
     DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libopenslide0
 fi
 
-if [[ ${CUDA_MAJOR_VERSION} == "11" ]]; then
-    # Omit I/O-related tests in ./python/cucim/tests due to known CUDA bug
-    # with dynamic loading of libcufile.
-    python -m pytest \
-      --junitxml="${RAPIDS_TESTS_DIR}/junit-cucim.xml" \
-      --numprocesses=8 \
-      --dist=worksteal \
-      ./python/cucim/src/
-else
-    python -m pytest \
-      --junitxml="${RAPIDS_TESTS_DIR}/junit-cucim.xml" \
-      --numprocesses=8 \
-      --dist=worksteal \
-      ./python/cucim
-fi
+python -m pytest \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-cucim.xml" \
+  --numprocesses=8 \
+  --dist=worksteal \
+  ./python/cucim


### PR DESCRIPTION
This PR contributes to the CUDA 11 deprecation effort by simplifying CI scripts across all RAPIDS repositories. As part of the broader RAPIDS 25.08 CUDA 11 removal (tracked in [build-planning#184](https://github.com/rapidsai/build-planning/issues/184)), this change removes all CUDA 11 conditional logic from GitHub Actions workflows / shell scripts.