### PR TITLE
remove cuspatial references

### DIFF
--- a/python/cucim/src/cucim/skimage/feature/corner.py
+++ b/python/cucim/src/cucim/skimage/feature/corner.py
@@ -4,6 +4,7 @@ from itertools import combinations_with_replacement
 
 import cupy as cp
 import numpy as np
+
 # TODO: use CuPy's KDTree once it becomes available
 # xref: https://github.com/rapidsai/cucim/issues/732
 from scipy import spatial


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/197

* removes references to `cuspatial` in some TODO comments... those are outdated because they refer to things possibly being added to `cuspatial` in the future, and that library's no longer being actively maintained
* fixes `pre-commit` checks

## Notes for Reviewers

### How I tested this

Looked for references like this:

```shell
git grep -i -E 'cuproj|cuspatial'
```