### PR TITLE
Drop unused variable `CUDA_MAJOR_VERSION`

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -11,8 +11,6 @@ PYTHON_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cucim_${RAPIDS_PY_CUDA_SUFFIX}" rapids
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install "$(echo ${PYTHON_WHEELHOUSE}/cucim*.whl)[test]"
 
-CUDA_MAJOR_VERSION=${RAPIDS_CUDA_VERSION:0:2}
-
 if type -f yum > /dev/null 2>&1; then
     yum update -y
     yum install -y openslide


### PR DESCRIPTION
Previously `CUDA_MAJOR_VERSION` was used to special case CUDA 11 wheel builds. However that check went away in PR: https://github.com/rapidsai/cucim/pull/903

As a result, `shellcheck` now flags `CUDA_MAJOR_VERSION` as an unused variable

Fix this by dropping the unneeded `CUDA_MAJOR_VERSION` assignment