### PR TITLE
Drop CUDA 11 references from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,15 +97,15 @@ If codespell is finding false positives in newly added code, the `ignore-words-l
 
 Compiler requirements:
 
-* `gcc`     version 9.0+
-* `nvcc`    version 11.0+
-* `cmake`   version 3.18.0+
+* `gcc`     version 13.0+
+* `nvcc`    version 12.0+
+* `cmake`   version 3.30.4+
 
 CUDA/GPU requirements:
 
-* CUDA 11.0+
-* NVIDIA driver 450.36+
-* Pascal architecture or better
+* CUDA 12.0+
+* NVIDIA driver 525.60+
+* Volta architecture or better
 
 You can obtain CUDA from [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads).
 
@@ -119,21 +119,21 @@ CUCIM_HOME=$(pwd)/cucim
 git clone https://github.com/rapidsai/cucim.git $CUCIM_HOME
 cd $CUCIM_HOME
 ```
-## Local Development using Conda Environment (for gcc 9.x and nvcc 11.0.x)
+## Local Development using Conda Environment (for gcc 13 and nvcc 12)
 
-Conda can be used to setup an environment which includes all of the necessary dependencies (as shown in `./conda/environments/all_cuda-118_arch-x86_64.yaml`) for building cuCIM.
+Conda can be used to setup an environment which includes all of the necessary dependencies (as shown in `./conda/environments/all_cuda-129_arch-x86_64.yaml`) for building cuCIM.
 
 Otherwise, you may need to install dependencies (such as yasm) through your OS's package manager (`apt`, `yum`, and so on).
 
 
 ### Creating the Conda Development Environment `cucim`
 
-Note that `./conda/environments/all_cuda-118_arch-x86_64.yaml` is currently set to use specific versions of gcc (gxx_linux-64) and CUDA (cudatoolkit & cudatoolkit-dev).
+Note that `./conda/environments/all_cuda-129_arch-x86_64.yaml` is currently set to pull in GCC and NVCC with the expected versions.
 
-If you want to change the version of gcc or CUDA toolkit package, please update `./conda/environments/all_cuda-118_arch-x86_64.yaml` before executing the following commands.
+If you want to change the version of GCC or CUDA, please update `./conda/environments/all_cuda-129_arch-x86_64.yaml` before executing the following commands.
 
 ```bash
-conda env create -n cucim -f ./conda/environments/all_cuda-118_arch-x86_64.yaml
+conda env create -n cucim -f ./conda/environments/all_cuda-129_arch-x86_64.yaml
 # activate the environment
 conda activate cucim
 ```
@@ -264,12 +264,6 @@ conda install -y -c ${CONDA_BLD_DIR} -c conda-forge \
 ## Building a package (for distribution. Including a wheel package for pip)
 
 **Wheel Build**
-
-If you are using CUDA 12.x, please update pyproject.toml as follows before building the wheel
-```bash
-sed -i "s/cupy-cuda11x/cupy-cuda12x/g" python/cucim/pyproject.toml
-```
-This will switch the CuPy dependency to one based on CUDA 12.x instead of 11.x.
 
 The wheel can then be built using:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cuCIM supports the following formats:
 conda create -n cucim -c rapidsai -c conda-forge cucim cuda-version=`<CUDA version>`
 ```
 
-`<CUDA version>` should be 11.2+ (e.g., `11.2`, `12.0`, etc.)
+`<CUDA version>` should be 12.0+ (e.g., `12.0`, etc.)
 
 #### [Conda (nightlies)](https://anaconda.org/rapidsai-nightly/cucim)
 
@@ -61,7 +61,7 @@ conda create -n cucim -c rapidsai -c conda-forge cucim cuda-version=`<CUDA versi
 conda create -n cucim -c rapidsai-nightly -c conda-forge cucim cuda-version=`<CUDA version>`
 ```
 
-`<CUDA version>` should be 11.2+ (e.g., `11.2`, `12.0`, etc.)
+`<CUDA version>` should be 12.0+ (e.g., `12.0`, etc.)
 
 ### [PyPI](https://pypi.org/project/cucim/)
 
@@ -69,12 +69,6 @@ Install for CUDA 12:
 
 ```bash
 pip install cucim-cu12
-```
-
-Alternatively install for CUDA 11:
-
-```bash
-pip install cucim-cu11
 ```
 
 ### Notebooks

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Operating System :: POSIX :: Linux",
     "Environment :: Console",
-    "Environment :: GPU :: NVIDIA CUDA :: 11",
     "Environment :: GPU :: NVIDIA CUDA :: 12",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: C++",


### PR DESCRIPTION
Partial fixes https://github.com/rapidsai/cucim/issues/904

Removes the remaining CUDA 11 doc references. Code is left unchanged.