### PR TITLE
Update fmt library to version 11.2.0 in CMake configuration

### DIFF
--- a/cpp/cmake/deps/fmt.cmake
+++ b/cpp/cmake/deps/fmt.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::fmt)
     FetchContent_Declare(
             deps-fmt
             GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.1.1
+            GIT_TAG 11.2.0
             GIT_SHALLOW TRUE
             EXCLUDE_FROM_ALL
     )

--- a/cpp/plugins/cucim.kit.cumed/cmake/deps/fmt.cmake
+++ b/cpp/plugins/cucim.kit.cumed/cmake/deps/fmt.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::fmt)
     FetchContent_Declare(
             deps-fmt
             GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.1.1
+            GIT_TAG 11.2.0
             GIT_SHALLOW TRUE
             EXCLUDE_FROM_ALL
     )

--- a/cpp/plugins/cucim.kit.cuslide/cmake/deps/fmt.cmake
+++ b/cpp/plugins/cucim.kit.cuslide/cmake/deps/fmt.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::fmt)
     FetchContent_Declare(
             deps-fmt
             GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.1.1
+            GIT_TAG 11.2.0
             GIT_SHALLOW TRUE
             EXCLUDE_FROM_ALL
     )

--- a/python/cmake/deps/fmt.cmake
+++ b/python/cmake/deps/fmt.cmake
@@ -17,7 +17,7 @@ if (NOT TARGET deps::fmt)
     FetchContent_Declare(
             deps-fmt
             GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.1.1
+            GIT_TAG 11.2.0
             GIT_SHALLOW TRUE
             EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
We're encountering the following error in CI/CD (https://github.com/rapidsai/cucim/actions/runs/16666894946) , possibly due to compiler updates:


```
\[100%] Built target cucim\_tests
In file included from /\_\_w/cucim/cucim/examples/cpp/tiff\_image/main.cpp:19:
/\_\_w/cucim/cucim/build-release/\_deps/deps-fmt-src/include/fmt/ranges.h:215:59: error: self-comparison always evaluates to true \[-Werror=tautological-compare]
215 |                                integer\_sequence\<bool, (Is == Is)...>);
\|                                                        \~\~\~^\~\~\~\~
cc1plus: all warnings being treated as errors
gmake\[2]: \*\*\* \[examples/cpp/CMakeFiles/tiff\_image.dir/build.make:79: examples/cpp/CMakeFiles/tiff\_image.dir/tiff\_image/main.cpp.o] Error 1
gmake\[1]: \*\*\* \[CMakeFiles/Makefile2:6754: examples/cpp/CMakeFiles/tiff\_image.dir/all] Error 2
gmake: \*\*\* \[Makefile:136: all] Error 2
Error: Process completed with exit code 2.
```

I checked the fmtlib source, and the line `(Is == Is)` exists in all [10.x versions](https://github.com/fmtlib/fmt/blob/10.2.1/include/fmt/ranges.h#L211) but was removed starting with [11.x](https://github.com/fmtlib/fmt/blob/11.0.0/include/fmt/ranges.h).

This PR addresses the issue by upgrading to a newer version of fmt.
