### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -240,7 +240,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
           - setuptools>=61.0.0
   run:
     common:

--- a/python/cucim/MANIFEST.in
+++ b/python/cucim/MANIFEST.in
@@ -1,7 +1,6 @@
 # https://packaging.python.org/guides/using-manifest-in/
 include .editorconfig
 
-include src/cucim/VERSION
 include CHANGELOG.md
 include CONTRIBUTING.md
 include LICENSE


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
