### PR TITLE
add a copy of rapids-configure-conda-channels to the repo

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
+./ci/rapids-configure-conda-channels
 
 source rapids-configure-sccache
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
+./ci/rapids-configure-conda-channels
 
 source rapids-configure-sccache
 

--- a/ci/rapids-configure-conda-channels
+++ b/ci/rapids-configure-conda-channels
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Selectively removes conda channels from the system-wide conda configuration,
+# based on runtime context.
+#
+# Copied from 'rapidsai/gha-tools' as part of https://github.com/rapidsai/gha-tools/issues/145
+
+set -euo pipefail
+
+conda_channel_in_config() {
+  channel_id=${1:?err}
+  conda config --json --get channels \
+  | channel_id="${channel_id}" jq -r --exit-status '.get.channels | any(. == env.channel_id )'
+}
+
+# Only try to run 'conda config --remove' if the channel exists in the config.
+# This is here to avoid errors if this script is invoked multiple times in the same environment.
+remove_conda_channel() {
+  channel_id=${1:?err}
+  if conda_channel_in_config "${channel_id}" > /dev/null; then
+    conda config --system --remove channels "${channel_id}"
+  else
+    echo "[rapids-configure-conda-channels] channel '${channel_id}' not found via 'conda config --get channels'"
+  fi
+}
+
+# Remove release channel if build is not a release build
+if ! rapids-is-release-build; then
+  remove_conda_channel 'rapidsai'
+fi
+
+# Remove nightly channels if build is a release build
+if rapids-is-release-build; then
+  remove_conda_channel 'rapidsai-nightly'
+fi


### PR DESCRIPTION
This is the last project in RAPIDS that hasn't converted its conda builds from `conda-build` to `rattler-build`.

That's happening in https://github.com/rapidsai/cucim/pull/864, but that PR isn't yet close to passing.

In https://github.com/rapidsai/gha-tools/issues/145, I'm working on reducing complexity in `gha-tools` by removing unused tools. This repo is the last RAPIDS project using `rapids-configure-conda-channels`, and that usage won't be removed until #864 is complete.

To unblock that cleanup in `gha-tools`, this PR proposes checking in a copy of `rapids-configure-conda-channels` in this repo. That'll allow the work in `gha-tools` to proceed without being blocked by `cucim`'s migration to `rattler-build`.