### PR TITLE
Add `pip` to `cucim`'s `requirements/host`

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - cupy >=13.6.0
     - libcucim ={{ version }}
     - python
+    - pip
     - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - scikit-image >=0.19.0,<0.25.0a0
     - scipy >=1.6


### PR DESCRIPTION
The `cucim` Python package builds with `pip`

https://github.com/rapidsai/cucim/blob/42cf58f25b105dd2094cbd26c15ac2f498889211/conda/recipes/cucim/build.sh#L25

However the `pip` dependency was not listed explicitly in `requirements/host`. This fixes that issue