### PR TITLE
Require CUDA 12.2+

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -21,29 +21,7 @@ conda config --set path_conflict warn
 
 sccache --zero-stats
 
-
-# TODO: Remove when CUDA 12.1 is dropped.
-# In most cases, the CTK has cuFile.
-# However the CTK only added cuFile for ARM in 12.2.
-# So for ARM users on CTK 12.0 & 12.1, relax the cuFile requirement.
-# On x86_64 or CTK 13 or ARM with CTK 12.2+, always require cuFile.
-cat > extra_variants.yaml <<EOF
-has_cufile:
-  - True
-EOF
-if [[ "$(arch)" == "aarch64" ]] && [[ "${RAPIDS_CUDA_VERSION%%.*}" == "12" ]]
-then
-  cat >> extra_variants.yaml <<EOF
-  - False
-EOF
-fi
-
-echo 'Contents of `extra_variants.yaml`:'
-cat extra_variants.yaml
-echo ''
-
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build \
-    -m extra_variants.yaml \
     conda/recipes/libcucim
 
 sccache --show-adv-stats

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -60,15 +60,12 @@ requirements:
     - nvtx-c >=3.1.0
     - openslide
   run:
-    {% if aarch64 and cuda_major == "12" %}
-    # Relax `libcufile` dependency for old CUDA 12 ARM installs
-    - {{ pin_compatible('cuda-version', lower_bound='12.0', upper_bound='12.2') }}  # [not has_cufile]
-    - {{ pin_compatible('cuda-version', lower_bound='12.2', upper_bound='13.0') }}  # [has_cufile]
-    - libcufile                                                                     # [has_cufile]
+    {% if cuda_major == "12" %}
+    - {{ pin_compatible('cuda-version', lower_bound='12.2', upper_bound='13.0a0') }}
     {% else %}
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-    - libcufile
     {% endif %}
+    - libcufile
     - cuda-cudart
     - libnvjpeg
   run_constrained:


### PR DESCRIPTION
Make CUDA 12.2 the new minimum. Drops logic related to CUDA 12.0 & 12.1. Thus simplifying the CUDA build and dependency logic.

<hr>

Part of issue:
* https://github.com/rapidsai/build-planning/issues/223