### PR TITLE
refactored update-version.sh to handle new branching strategy

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -7,8 +7,66 @@
 #########################
 
 ## Usage
-# bash update-version.sh <new_version>
+# Primary interface: ./ci/release/update-version.sh --run-context=main|release <new_version>
+# Fallback: Environment variable support for automation needs
+# NOTE: Must be run from the root of the repository
+#
+# CLI args take precedence when both are provided
+# If neither RUN_CONTEXT nor --run-context is provided, defaults to main
+#
+# Examples:
+#   ./ci/release/update-version.sh --run-context=main 25.12.00
+#   ./ci/release/update-version.sh --run-context=release 25.12.00
+#   RAPIDS_RUN_CONTEXT=main ./ci/release/update-version.sh 25.12.00
 
+# Verify we're running from the repository root
+if [[ ! -f "VERSION" ]] || [[ ! -f "ci/release/update-version.sh" ]] || [[ ! -d "python" ]]; then
+    echo "Error: This script must be run from the root of the cucim repository"
+    echo ""
+    echo "Usage:"
+    echo "  cd /path/to/cucim"
+    echo "  ./ci/release/update-version.sh --run-context=main|release <new_version>"
+    echo ""
+    echo "Example:"
+    echo "  ./ci/release/update-version.sh --run-context=main 25.12.00"
+    exit 1
+fi
+
+# Parse command line arguments
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --run-context=*)
+      CLI_RUN_CONTEXT="${1#*=}"
+      shift
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Restore positional parameters
+set -- "${POSITIONAL_ARGS[@]}"
+
+# Determine RUN_CONTEXT with precedence: CLI > Environment > Default
+if [[ -n "${CLI_RUN_CONTEXT:-}" ]]; then
+    RUN_CONTEXT="${CLI_RUN_CONTEXT}"
+    echo "Using run-context from CLI: ${RUN_CONTEXT}"
+elif [[ -n "${RAPIDS_RUN_CONTEXT:-}" ]]; then
+    RUN_CONTEXT="${RAPIDS_RUN_CONTEXT}"
+    echo "Using RUN_CONTEXT from environment: ${RUN_CONTEXT}"
+else
+    RUN_CONTEXT="main"
+    echo "Using default run-context: ${RUN_CONTEXT}"
+fi
+
+# Validate RUN_CONTEXT
+if [[ "${RUN_CONTEXT}" != "main" && "${RUN_CONTEXT}" != "release" ]]; then
+    echo "Error: Invalid run-context '${RUN_CONTEXT}'. Must be 'main' or 'release'"
+    exit 1
+fi
 
 # Format is YY.MM.PP - no leading 'v' or trailing 'a'
 NEXT_FULL_TAG=$1
@@ -26,7 +84,14 @@ NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
 
-echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
+# Determine branch name based on context
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    RAPIDS_BRANCH_NAME="main"
+    echo "Preparing development branch update ${CURRENT_TAG} => ${NEXT_FULL_TAG} (targeting main branch)"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    RAPIDS_BRANCH_NAME="release/${NEXT_SHORT_TAG}"
+    echo "Preparing release branch update ${CURRENT_TAG} => ${NEXT_FULL_TAG} (targeting release/${NEXT_SHORT_TAG} branch)"
+fi
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
@@ -38,10 +103,21 @@ echo "${NEXT_FULL_TAG}" > VERSION
 
 sed_runner "s#cucim.kit.cuslide@${CURRENT_LONG_TAG}.so#cucim.kit.cuslide@${NEXT_FULL_TAG}.so#g" cucim.code-workspace
 
+# CI files - context-aware branch references
 for FILE in .github/workflows/*.yaml; do
-  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "/shared-workflows/ s|@.*|@${RAPIDS_BRANCH_NAME}|g" "${FILE}"
   sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
+
+# Notebook references - context-aware
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+  # In main context, keep notebooks on main (no changes needed)
+  :
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+  # In release context, use release branch for notebook links (word boundaries to avoid partial matches)
+  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/Using_Cache.ipynb
+  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/Supporting_Aperio_SVS_Format.ipynb
+fi
 
 DEPENDENCIES=(
   cucim


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224