### PR TITLE
chore: remove extra trailing curly brace from conda build string

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}

--- a/conda/recipes/libcucim/meta.yaml
+++ b/conda/recipes/libcucim/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}


### PR DESCRIPTION
Debugging an unrelated issue I noticed an extra curly brace in the build string for both conda recipes.

Example extra brace:
```
🐚 mamba repoquery search cucim -c rapidsai-nightly
Getting repodata from channels...

rapidsai-nightly/noarch                             87.0kB @ 328.8kB/s  0.1s
conda-forge/noarch                                  23.5MB @  41.1MB/s  0.5s
conda-forge/linux-64                                49.0MB @  57.1MB/s  0.8s
rapidsai-nightly/linux-64                            2.8MB @   2.7MB/s  0.9s
 Name  Version     Build                                                        Channel          Subdir
──────────────────────────────────────────────────────────────────────────────────────────────────────────
 cucim 26.02.00a6  cuda12_py310_251124_ghge6a3044_gn6}_phc494990  (+ 15 builds) rapidsai-nightly linux-64
 cucim 26.02.00a4  cuda12_py310_251121_ghg26afd46_gn4}_phc494990  (+ 31 builds) rapidsai-nightly linux-64
 cucim 26.02.00a3  cuda12_py310_251118_ghgdae090f_gn3}_phc494990  (+ 31 builds) rapidsai-nightly linux-64
 cucim 25.12.00a27 cuda12_py310_251125_ghg2e3bc68_gn27}_phc494990 (+  7 builds) rapidsai-nightly linux-64
 cucim 25.12.00a26 cuda12_py310_251118_ghg3a8dfd7_gn26}_phc494990 (+ 55 builds) rapidsai-nightly linux-64
 cucim 25.10.00a29 cuda13_py310_251012_ghg514fb30_gn29}_phc494990 (+ 11 builds) rapidsai-nightly linux-64
```