### PR TITLE
Use strict priority in CI conda tests

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -11,6 +11,9 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
+
 rapids-dependency-file-generator \
     --output conda \
     --file-key docs \

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 rapids-logger "Create checks conda environment"
 . /opt/conda/etc/profile.d/conda.sh
+
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
 
 rapids-dependency-file-generator \
   --output conda \


### PR DESCRIPTION
## Description
This PR sets conda to use `strict` priority in CI tests.

Mixing channel priority is frequently a cause of unexpected errors. Our CI jobs should always use strict priority in order to enforce that conda packages come from local channels with the artifacts built in CI, not mixing with older nightly artifacts from the `rapidsai-nightly` channel or other sources.

xref: https://github.com/rapidsai/build-planning/issues/14
