### PR TITLE
Enable merge barriers

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -8,3 +8,4 @@ release_drafter: true
 external_contributors: false
 recently_updated: true
 forward_merger: true
+merge_barriers: true


### PR DESCRIPTION
Enable the `merge_barriers` setting in `.github/ops-bot.yaml` to enable the new merge barriers plugin.
