### PR TITLE
Use SPDX license identifiers in pyproject.toml, bump build dependency floors

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - rapids-build-backend >=0.4.0,<0.5.0
     - scikit-image >=0.19.0,<0.25.0
     - scipy >=1.6
-    - setuptools>=80.9.0
+    - setuptools >=80.9.0
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     - cuda-cudart


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/152

Proposes the following changes, to prevent builds breaking when Python build backends
start to require configuration consistent with PEP 639 ([link](https://peps.python.org/pep-0639/)):

* using SPDX identifiers in `[project].license`
* moving `[tool.setuptools].license-files` to `[project].license-files`
* removing `License ::` trove classifiers

These changes require `setuptools>=77.0.0` and this project pins to an even newer version, so this should be safe.

https://github.com/rapidsai/cucim/blob/ec077cae16a5eb5fca48fb874360feb5f5671971/python/cucim/pyproject.toml#L9