### PR TITLE
Fix update-version.sh notebook sed commands

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -109,16 +109,6 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
-# Notebook references - context-aware
-if [[ "${RUN_CONTEXT}" == "main" ]]; then
-  # In main context, keep notebooks on main (no changes needed)
-  :
-elif [[ "${RUN_CONTEXT}" == "release" ]]; then
-  # In release context, use release branch for notebook links (word boundaries to avoid partial matches)
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/Using_Cache.ipynb
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/Supporting_Aperio_SVS_Format.ipynb
-fi
-
 DEPENDENCIES=(
   cucim
   libcucim


### PR DESCRIPTION
## Summary

Remove broken notebook sed commands from `update-version.sh` that incorrectly replaced text in notebooks during release context.

**The problem:** The regex `\bmain\b` matched ANY word "main", not just git branch references. In `Using_Cache.ipynb`, it incorrectly changed "main process's cache object" to "release/26.04 process's cache object".

**Additionally:** The notebooks don't have `main` branch URLs to update anyway - they have `branch-21.12` references. So these sed commands were:
1. Matching the wrong text ("main process" instead of branch URLs)
2. Looking for URLs that don't exist in these notebooks

## Test plan

- [x] Run `./ci/release/update-version.sh --run-context=release 26.04.00` and verify notebooks are unchanged
- [x] Run `./ci/release/update-version.sh --run-context=main 26.04.00` and verify expected changes only