### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-lazy-fixtures>=1.0.0
 - pytest-xdist
 - pytest>=7.0.0,<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - pywavelets>=1.6
 - recommonmark
 - scikit-image>=0.19.0,<0.26.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - pytest-lazy-fixtures>=1.0.0
 - pytest-xdist
 - pytest>=7.0.0,<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - pywavelets>=1.6
 - recommonmark
 - scikit-image>=0.19.0,<0.26.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-lazy-fixtures>=1.0.0
 - pytest-xdist
 - pytest>=7.0.0,<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - pywavelets>=1.6
 - recommonmark
 - scikit-image>=0.19.0,<0.26.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - pytest-lazy-fixtures>=1.0.0
 - pytest-xdist
 - pytest>=7.0.0,<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - pywavelets>=1.6
 - recommonmark
 - scikit-image>=0.19.0,<0.26.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -210,10 +210,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.10"
-            packages:
-              - python=3.10
-          - matrix:
               py: "3.11"
             packages:
               - python=3.11
@@ -227,7 +223,7 @@ dependencies:
               - python=3.13
           - matrix:
             packages:
-              - python>=3.10,<3.14
+              - python>=3.11,<3.14
   rapids_build_setuptools:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -27,7 +27,7 @@ license-files = [
     "LICENSE",
     "LICENSE-3rdparty.md",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "click",
     "cupy-cuda13x>=13.6.0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/246

Finishes the work of dropping Python 3.10 support.

This project stopped building / testing against Python 3.10 as of https://github.com/rapidsai/shared-workflows/pull/494
This PR updates configuration and docs to reflect that.

## Followups before merging

Check that there are no remaining uses like this:

```shell
git grep -E '3\.10'
git grep '310'
git grep 'py310'
```
