### PR TITLE
tighten wheel size limits, enforce PEP 639 metadata, other small changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # To install the git pre-commit hook run:
@@ -28,7 +28,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.2.1
+    rev: v1.3.3
     hooks:
       - id: verify-copyright
         name: verify-copyright-cucim
@@ -573,6 +573,7 @@ repos:
             cpp/plugins/cucim[.]kit[.]cuslide/src/cuslide/jpeg/libjpeg_turbo[.]cpp$
           )
       - id: verify-alpha-spec
+      - id: verify-pyproject-license
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.20.0
     hooks:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -11,6 +11,8 @@ CMAKE_BUILD_TYPE="release"
 
 source rapids-configure-sccache
 source rapids-date-string
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 rapids-generate-version > ./VERSION

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -117,8 +117,8 @@ select = [
     "distro-too-large-compressed",
 ]
 
-# PyPI limit is 100 MiB, fail CI before we get too close to that
-max_allowed_size_compressed = '75M'
+# PyPI hard limit is 1GiB, but try to keep these as small as possible
+max_allowed_size_compressed = '20Mi'
 
 [tool.pytest.ini_options]
 # If a pytest section is found in one of the possible config files


### PR DESCRIPTION
## Description

Proposes a batch of miscellaneous build / packaging / CI changes.

## Changes

### Tightens wheel size limits

Contributes to https://github.com/rapidsai/build-planning/issues/219

To ensure surprising package-size growth is caught in CI, this PR tightens the limits in the following ways:

* setting all limits to `{compressed_size} + 10Mi`, rounded to the nearest 5Mi

### Enforces PEP 639 license metadata in `pyproject.toml`

Contributes to https://github.com/rapidsai/pre-commit-hooks/issues/95