### PR TITLE
remove pip.conf migration code in CI scripts

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -11,8 +11,6 @@ CMAKE_BUILD_TYPE="release"
 
 source rapids-configure-sccache
 source rapids-date-string
-RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
-export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 rapids-generate-version > ./VERSION

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,8 +4,6 @@
 
 set -eou pipefail
 
-RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
-export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"


### PR DESCRIPTION
## Description

Follow-up to changes for https://github.com/rapidsai/build-planning/issues/241

* removes `rapids-init-pip` feature flags now that those have become the default behavior (https://github.com/rapidsai/gha-tools/pull/242)
