### PR TITLE
make test_load_image_metadata test case insensitive to key order

### DIFF
--- a/python/cucim/tests/unit/clara/test_load_image_metadata.py
+++ b/python/cucim/tests/unit/clara/test_load_image_metadata.py
@@ -1,8 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import json
 import math
 
 import pytest
@@ -65,7 +66,9 @@ def test_load_image_metadata(testimg_tiff_stripe_32x24_16):
     assert isinstance(metadata, dict)
     assert len(metadata) == 2  # 'cucim' and 'tiff'
     # A raw metadata string.
-    assert img.raw_metadata == '{"axes": "YXC", "shape": [24, 32, 3]}'
+    assert json.loads(img.raw_metadata) == json.loads(
+        '{"axes": "YXC", "shape": [24, 32, 3]}'
+    )
 
 
 def test_load_image_resolution_metadata(


### PR DESCRIPTION
One test case is currently comparing image metadata using a string comparison that is sensitive to key order.

I think we only care that the same keys and values are present, but not the order, so this MR uses `json.loads` to convert the string to a Python `dict`.