### PR TITLE
Backport "Drop CuPy pre-13.6.0 logic & fix CuPy 14 compatibility" to 26.02

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.1
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.1
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
@@ -52,7 +52,7 @@ requirements:
     - click
     - cuda-version ={{ cuda_version }}
     - cuda-cudart-dev
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0
     - libcucim ={{ version }}
     - python
     - pip
@@ -65,7 +65,7 @@ requirements:
     - cuda-cudart
     - numpy >=1.23,<3.0
     - click
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0
     - lazy_loader >=0.1
     - libcucim ={{ version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -245,7 +245,7 @@ dependencies:
           - scipy>=1.11.2
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=13.6.0
+          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0
           - libnvimgcodec>=0.7.0,<0.8.0
           - nvimgcodec>=0.7.0,<0.8.0
     specific:
@@ -254,12 +254,12 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0
               - nvidia-nvimgcodec-cu12>=0.7.0,<0.8.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0
               - nvidia-nvimgcodec-cu13>=0.7.0,<0.8.0
   test_python:
     common:

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -30,7 +30,7 @@ license-files = [
 requires-python = ">=3.10"
 dependencies = [
     "click",
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0",
     "lazy-loader>=0.4",
     "numpy>=1.23.4,<3.0",
     "nvidia-nvimgcodec-cu13>=0.7.0,<0.8.0",

--- a/python/cucim/src/cucim/core/operations/morphology/_pba_2d.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_pba_2d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -92,7 +92,6 @@ def _get_pack_kernel(int_type, marker=-32768):
         in_params="raw B arr",
         out_params="raw I out",
         operation=code,
-        options=("--std=c++11",),
     )
 
 
@@ -172,7 +171,6 @@ def _get_distance_kernel(int_type, dist_int_type):
         in_params="raw I y, raw I x",
         out_params="raw F dist",
         operation=operation,
-        options=("--std=c++11",),
     )
 
 
@@ -201,7 +199,6 @@ def _get_aniso_distance_kernel(int_type):
         in_params="raw I y, raw I x, raw F sampling",
         out_params="raw F dist",
         operation=operation,
-        options=("--std=c++11",),
     )
 
 

--- a/python/cucim/src/cucim/core/operations/morphology/_pba_3d.py
+++ b/python/cucim/src/cucim/core/operations/morphology/_pba_3d.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -126,7 +126,6 @@ def _get_encode3d_kernel(size_max, marker=-2147483648):
         in_params="raw B arr",
         out_params="raw I out",
         operation=code,
-        options=("--std=c++11",),
     )
 
 
@@ -173,7 +172,6 @@ def _get_decode3d_kernel(size_max):
         in_params="E encoded",
         out_params="I x, I y, I z",
         operation=code,
-        options=("--std=c++11",),
     )
 
 
@@ -260,7 +258,6 @@ def _get_distance_kernel(int_type, large_dist=False):
         in_params="I z, I y, I x",
         out_params="raw F dist",
         operation=operation,
-        options=("--std=c++11",),
     )
 
 
@@ -297,7 +294,6 @@ def _get_aniso_distance_kernel(int_type):
         in_params="I z, I y, I x, raw F sampling",
         out_params="raw F dist",
         operation=operation,
-        options=("--std=c++11",),
     )
 
 
@@ -333,7 +329,6 @@ def _get_decode_as_distance_kernel(size_max, large_dist=False, sampling=None):
         in_params=in_params,
         out_params="raw F dist",
         operation=code,
-        options=("--std=c++11",),
     )
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_filters_core.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Infrastructure, Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Networks, Inc.
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 
 """A vendored subset of cupyx.scipy.ndimage._filters_core"""
@@ -15,8 +15,6 @@ from cucim.skimage._vendored import (
     _internal as internal,
     _ndimage_util as _util,
 )
-
-CUPY_GTE_13_3_0 = parse(cupy.__version__) >= parse("13.3.0")
 
 
 def _origins_to_offsets(origins, w_shape):
@@ -217,24 +215,13 @@ def _call_kernel(
     return output
 
 
-if CUPY_GTE_13_3_0:
-    _includes = r"""
+_ndimage_includes = r"""
 #include <cupy/cuda_workaround.h>  // provide std:: coverage
-"""
-else:
-    _includes = r"""
-#include <type_traits>  // let Jitify handle this
-"""
-
-_ndimage_includes = (
-    _includes
-    + r"""
 #include <cupy/math_constants.h>
 
 template<> struct std::is_floating_point<float16> : std::true_type {};
 template<> struct std::is_signed<float16> : std::true_type {};
 """
-)
 
 
 _ndimage_CAST_FUNCTION = """
@@ -410,10 +397,6 @@ def _generate_nd_kernel(
         name += "_with_mask"
     preamble = _ndimage_includes + _ndimage_CAST_FUNCTION + preamble
 
-    if CUPY_GTE_13_3_0:
-        options += ("--std=c++11",)
-    else:
-        options += ("--std=c++11", "-DCUPY_USE_JITIFY")
     return cupy.ElementwiseKernel(
         in_params,
         out_params,

--- a/python/cucim/src/cucim/skimage/feature/_hessian_det_appx.py
+++ b/python/cucim/src/cucim/skimage/feature/_hessian_det_appx.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2009-2022 the scikit-image team
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 import math
@@ -67,7 +67,6 @@ def _get_hessian_det_appx_kernel(dtype, large_int) -> cp.RawModule:
 
     return cp.RawModule(
         code=_preamble + _code,
-        options=("--std=c++11",),
         name_expressions=["_hessian_matrix_det"],
     )
 

--- a/python/cucim/src/cucim/skimage/feature/blob.py
+++ b/python/cucim/src/cucim/skimage/feature/blob.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2009-2022 the scikit-image team
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 import math
@@ -77,7 +77,6 @@ def _get_prune_blob_rawmodule(dtype, large_int) -> cp.RawModule:
 
     return cp.RawModule(
         code=_preamble + _code,
-        options=("--std=c++11",),
         name_expressions=["_prune_blobs"],
     )
 

--- a/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
+++ b/python/cucim/src/cucim/skimage/filters/_separable_filtering.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2009-2022 the scikit-image team
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 import math
@@ -9,7 +9,6 @@ import cupy as cp
 from cucim.skimage._vendored import _ndimage_util as util
 from cucim.skimage._vendored._internal import _normalize_axis_index
 from cucim.skimage._vendored._ndimage_filters_core import (
-    CUPY_GTE_13_3_0,
     _ndimage_CAST_FUNCTION,
     _ndimage_includes,
 )
@@ -922,11 +921,7 @@ def _get_separable_conv_kernel(
         patch_per_block=patch_per_block,
         flip_kernel=flip_kernel,
     )
-    if CUPY_GTE_13_3_0:
-        options = ("--std=c++11",)
-    else:
-        options = ("--std=c++11", "-DCUPY_USE_JITIFY")
-    m = cp.RawModule(code=code, options=options)
+    m = cp.RawModule(code=code)
     return m.get_function(func_name), block, patch_per_block
 
 

--- a/python/cucim/src/cucim/skimage/measure/_regionprops_gpu_utils.py
+++ b/python/cucim/src/cucim/skimage/measure/_regionprops_gpu_utils.py
@@ -1,25 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
 
 import cupy as cp
-from packaging.version import parse
 
 from cucim.skimage._vendored import ndimage as ndi
 from cucim.skimage.util import map_array
 
-CUPY_GTE_13_3_0 = parse(cp.__version__) >= parse("13.3.0")
-
 # Need some default includes so uint32_t, uint64_t, etc. are defined
 
-if CUPY_GTE_13_3_0:
-    _includes = r"""
+_includes = r"""
 #include <cupy/cuda_workaround.h>  // provide std:: coverage
-"""
-else:
-    _includes = r"""
-#include <type_traits>  // let Jitify handle this
 """
 
 

--- a/python/cucim/tests/unit/clara/test_load_image_metadata.py
+++ b/python/cucim/tests/unit/clara/test_load_image_metadata.py
@@ -1,8 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import json
 import math
 
 import pytest
@@ -65,7 +66,9 @@ def test_load_image_metadata(testimg_tiff_stripe_32x24_16):
     assert isinstance(metadata, dict)
     assert len(metadata) == 2  # 'cucim' and 'tiff'
     # A raw metadata string.
-    assert img.raw_metadata == '{"axes": "YXC", "shape": [24, 32, 3]}'
+    assert json.loads(img.raw_metadata) == json.loads(
+        '{"axes": "YXC", "shape": [24, 32, 3]}'
+    )
 
 
 def test_load_image_resolution_metadata(


### PR DESCRIPTION
Following the new RAPIDS hotfix process (docs still in progress at https://github.com/rapidsai/docs/pull/716), this backports the following changes to cuCIM 26.02:

* #1031
* #1035

See #1036 for more details.

## Notes for Reviewers

Once this is merged, I'll release the new state of `release/26.02` as cuCIM 26.02.01.