### PR TITLE
fix(conda): specify `python-gil` for conda recipe

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -55,6 +55,7 @@ requirements:
     - cupy >=13.6.0,!=14.0.0
     - libcucim ={{ version }}
     - python
+    - python-gil
     - pip
     - rapids-build-backend >=0.4.0,<0.5.0
     - scikit-image >=0.23.2,<0.27.0
@@ -69,6 +70,7 @@ requirements:
     - lazy_loader >=0.1
     - libcucim ={{ version }}
     - python
+    - python-gil
     - scikit-image >=0.23.2,<0.27.0
     - scipy >=1.6
   run_constrained:


### PR DESCRIPTION
Builds are failing (e.g. https://github.com/rapidsai/cucim/actions/runs/23230625912/job/67601928465) on the `main` branch because `conda` is trying to use a free-threaded Python variant.  Adding an explicit `python-gil` to the conda recipe to stop this.

Example solver error:

```
WARNING: failed to get package records, retrying.  exception was: Unsatisfiable dependencies for platform linux-aarch64: {MatchSpec("python==3.14.0rc1=h8f01225_2_cp314t"), MatchSpec("_python_rc")}
Encountered problems while solving:
  - nothing provides _python_rc needed by python-3.14.0rc1-h8f01225_2_cp314t

Could not solve for environment specs
The following packages are incompatible
├─ cuda-version =12.9 * is requested and can be installed;
├─ cupy >=13.6.0,!=14.0.0 * is installable with the potential options
│  ├─ cupy 13.6.0 would require
│  │  └─ cupy-core ==13.6.0 py39he4d69f8_0, which requires
│  │     └─ python >=3.9,<3.10.0a0 *_cpython, which can be installed;
│  ├─ cupy [13.6.0|14.0.1] would require
│  │  └─ cupy-core [==13.6.0 py310h967c7ba_0|==13.6.0 py310h967c7ba_1|==13.6.0 py310h967c7ba_2|==14.0.1 py310h967c7ba_0], which requires
│  │     └─ python >=3.10,<3.11.0a0 *, which can be installed;
│  ├─ cupy [13.6.0|14.0.1] would require
│  │  └─ cuda-version >=13,<14.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ cupy 13.6.0 would require
│  │  └─ cuda-version >=11,<12.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ cupy [13.6.0|14.0.1] would require
│  │  └─ cupy-core [==13.6.0 py311h6a7bbfe_0|==13.6.0 py311h6a7bbfe_1|==13.6.0 py311h6a7bbfe_2|==14.0.1 py311h6a7bbfe_0], which requires
│  │     └─ python >=3.11,<3.12.0a0 *, which can be installed;
│  ├─ cupy [13.6.0|14.0.1] would require
│  │  └─ cupy-core [==13.6.0 py312hdcd7d0a_0|==13.6.0 py312hdcd7d0a_1|==13.6.0 py312hdcd7d0a_2|==14.0.1 py312hdcd7d0a_0], which requires
│  │     └─ python_abi =3.12 *_cp312, which requires
│  │        └─ python =3.12 *_cpython, which can be installed;
│  ├─ cupy [13.6.0|14.0.1] would require
│  │  └─ cupy-core [==13.6.0 py313h6b3a76b_0|==13.6.0 py313h6b3a76b_1|==13.6.0 py313h6b3a76b_2|==14.0.1 py313h6b3a76b_0], which requires
│  │     └─ python_abi =3.13 *_cp313 with the potential options
│  │        ├─ python_abi 3.13 would require
│  │        │  └─ python =3.13 *_cpython, which can be installed;
│  │        └─ python_abi 3.13 would require
│  │           └─ python =3.13 *_cp313, which can be installed;
│  ├─ cupy 13.6.0 would require
│  │  └─ python_abi =3.14 *_cp314, which requires
│  │     └─ python =3.14 *_cp314, which can be installed;
│  └─ cupy 14.0.1 would require
│     ├─ cupy-core ==14.0.1 py314h96e0c3d_0, which requires
│     │  └─ scipy >=1.10,<1.17 *, which can be installed;
│     └─ python_abi =3.14 *_cp314, which cannot be installed (as previously explained);
├─ python =3.14 * is not installable because there are no viable options
│  ├─ python [3.14.0|3.14.1|3.14.2|3.14.3] conflicts with any installable versions previously reported;
│  ├─ python [3.14.0|3.14.1|3.14.2|3.14.3] would require
│  │  └─ python_abi =3.14 *_cp314, which cannot be installed (as previously explained);
│  └─ python [3.14.0rc1|3.14.0rc2|3.14.0rc3] would require
│     └─ _python_rc =* *, which does not exist (perhaps a missing channel);
└─ scikit-image >=0.19.0,<0.25.0 * is installable with the potential options
   ├─ scikit-image [0.19.0|0.19.1|...|0.24.0] would require
   │  └─ python_abi =3.10 *_cp310, which can be installed;
   ├─ scikit-image [0.19.3|0.20.0|...|0.24.0] would require
   │  └─ python_abi =3.11 *_cp311, which can be installed;
   ├─ scikit-image 0.20.0 would require
   │  ├─ python_abi ==3.8 *_pypy38_pp73, which can be installed;
   │  └─ scipy >=1.8,<1.9.2 *, which conflicts with any installable versions previously reported;
   ├─ scikit-image 0.20.0 would require
   │  ├─ python_abi =3.8 *_cp38, which can be installed;
   │  └─ scipy >=1.8,<1.9.2 *, which conflicts with any installable versions previously reported;
   ├─ scikit-image 0.20.0 would require
   │  ├─ python_abi ==3.9 *_pypy39_pp73, which can be installed;
   │  └─ scipy >=1.8,<1.9.2 *, which conflicts with any installable versions previously reported;
   ├─ scikit-image 0.20.0 would require
   │  ├─ python_abi =3.9 *_cp39, which can be installed;
   │  └─ scipy >=1.8,<1.9.2 *, which conflicts with any installable versions previously reported;
   ├─ scikit-image [0.19.3|0.21.0] would require
   │  └─ python_abi ==3.8 *_pypy38_pp73, which can be installed;
   ├─ scikit-image [0.19.0|0.19.1|0.19.2|0.19.3|0.21.0] would require
   │  └─ python_abi =3.8 *_cp38, which can be installed;
   ├─ scikit-image [0.19.0|0.19.1|...|0.24.0] would require
   │  └─ python_abi =3.9 *_cp39, which can be installed;
   ├─ scikit-image [0.19.3|0.21.0|0.22.0|0.24.0] would require
   │  └─ python_abi ==3.9 *_pypy39_pp73, which can be installed;
   ├─ scikit-image [0.22.0|0.23.2|0.24.0] would require
   │  └─ python_abi =3.12 *_cp312, which can be installed (as previously explained);
   ├─ scikit-image 0.24.0 would require
   │  └─ python_abi =3.13 *_cp313, which can be installed (as previously explained);
   ├─ scikit-image [0.19.0|0.19.1|0.19.2|0.19.3] would require
   │  └─ python >=3.7,<3.8.0a0 * but there are no viable options
   │     ├─ python [3.7.1|3.7.10|...|3.7.9] conflicts with any installable versions previously reported;
   │     └─ python 3.7.1 would require
   │        └─ openssl >=1.0.2p,<1.0.3a *, which does not exist (perhaps a missing channel);
   └─ scikit-image [0.19.0|0.19.1|0.19.2|0.19.3] would require
      └─ python_abi ==3.7 *_pypy37_pp73, which can be installed.
```