### PR TITLE
fix(conda): specify `python-gil` for conda recipe (#1056)

### DIFF
--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -55,6 +55,7 @@ requirements:
     - cupy >=13.6.0,!=14.0.0
     - libcucim ={{ version }}
     - python
+    - python-gil
     - pip
     - rapids-build-backend >=0.4.0,<0.5.0
     - scikit-image >=0.23.2,<0.27.0
@@ -69,6 +70,7 @@ requirements:
     - lazy_loader >=0.1
     - libcucim ={{ version }}
     - python
+    - python-gil
     - scikit-image >=0.23.2,<0.27.0
     - scipy >=1.6
   run_constrained:


### PR DESCRIPTION
Backport of #1056 to ensure that conda/mamba don't try to grab free-threaded Python builds when solving.
