### PR TITLE
Optimize batch/multi-channel image interpolation (`cucim.skimage.transform.warp` and `cucim.skimage._vendored.ndimage`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,7 @@ repos:
             ^python/cucim/src/cucim/skimage/_vendored/ndimage[.]py$|
             ^python/cucim/src/cucim/skimage/_vendored/pad[.]py$|
             ^python/cucim/src/cucim/skimage/_vendored/signaltools[.]py$|
+            ^python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation[.]py$|
             ^python/cucim/src/cucim/skimage/_vendored/time[.]py$|
             ^python/cucim/src/cucim/skimage/filters/thresholding[.]py$|
             ^python/cucim/src/cucim/skimage/segmentation/_expand_labels[.]py$|
@@ -332,6 +333,7 @@ repos:
             python/cucim/src/cucim/skimage/_vendored/ndimage[.]py$|
             python/cucim/src/cucim/skimage/_vendored/pad[.]py$|
             python/cucim/src/cucim/skimage/_vendored/signaltools[.]py$|
+            python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation[.]py$|
             python/cucim/src/cucim/skimage/_vendored/time[.]py$
           )
       - id: verify-copyright

--- a/benchmarks/skimage/cucim_transform_bench.py
+++ b/benchmarks/skimage/cucim_transform_bench.py
@@ -29,67 +29,67 @@ def main(args):
     for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
         # _warps.py
         (
+            "resize",
+            dict(preserve_range=True),
+            dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
+            True,
+            True,
+        ),  # scale handled in loop below
+        (
+            "resize_local_mean",
+            dict(preserve_range=True),
+            {},
+            True,
+            True,
+        ),  # scale handled in loop below
+        (
+            "rescale",
+            dict(preserve_range=True),
+            dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
+            True,
+            True,
+        ),  # output_shape handled in loop below
+        (
             "rotate",
             dict(angle=15, preserve_range=True),
-            dict(order=[0, 1, 2, 3, 4, 5], mode=["reflect"], resize=[True]),
+            dict(order=[0, 1, 3, 5], mode=["reflect"], resize=[False, True]),
             True,
             False,
         ),
-        # (
-        #     "resize",
-        #     dict(preserve_range=True),
-        #     dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
-        #     True,
-        #     True,
-        # ),  # scale handled in loop below
-        # (
-        #     "resize_local_mean",
-        #     dict(preserve_range=True),
-        #     {},
-        #     True,
-        #     True,
-        # ),  # scale handled in loop below
-        # (
-        #     "rescale",
-        #     dict(preserve_range=True),
-        #     dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
-        #     True,
-        #     True,
-        # ),  # output_shape handled in loop below
-        # (
-        #     "downscale_local_mean",
-        #     dict(),
-        #     dict(),
-        #     True,
-        #     True,
-        # ),  # factors handled in loop below
-        # (
-        #     "swirl",
-        #     dict(strength=1, preserve_range=True),
-        #     dict(order=[0, 1, 3, 5], mode=["reflect"]),
-        #     False,
-        #     False,
-        # ),
-        # # TODO : warp? already indirectly benchmarked via swirl, etc
-        # ("warp_polar", dict(), dict(scaling=["linear", "log"]), True, False),
-        # # integral.py
-        # ("integral_image", dict(), dict(), False, True),
-        # # TODO: integrate
-        # # pyramids.py
-        # (
-        #     "pyramid_gaussian",
-        #     dict(max_layer=6, downscale=2, preserve_range=True),
-        #     dict(order=[0, 1, 3, 5]),
-        #     True,
-        #     True,
-        # ),
-        # (
-        #     "pyramid_laplacian",
-        #     dict(max_layer=6, downscale=2, preserve_range=True),
-        #     dict(order=[0, 1, 3, 5]),
-        #     True,
-        #     True,
-        # ),
+        (
+            "downscale_local_mean",
+            dict(),
+            dict(),
+            True,
+            True,
+        ),  # factors handled in loop below
+        (
+            "swirl",
+            dict(strength=1, preserve_range=True),
+            dict(order=[0, 1, 3, 5], mode=["reflect"]),
+            False,
+            False,
+        ),
+        # TODO : warp? already indirectly benchmarked via swirl, etc
+        ("warp_polar", dict(), dict(scaling=["linear", "log"]), True, False),
+        # integral.py
+        ("integral_image", dict(), dict(), False, True),
+        # TODO: integrate
+        # pyramids.py
+        (
+            "pyramid_gaussian",
+            dict(max_layer=6, downscale=2, preserve_range=True),
+            dict(order=[0, 1, 3, 5]),
+            True,
+            True,
+        ),
+        (
+            "pyramid_laplacian",
+            dict(max_layer=6, downscale=2, preserve_range=True),
+            dict(order=[0, 1, 3, 5]),
+            True,
+            True,
+        ),
     ]:
         if function_name != args.func_name:
             continue
@@ -105,7 +105,7 @@ def main(args):
         if shape[-1] == 3 and not allow_color:
             continue
 
-        ndim_spatial = ndim - 1 if shape[-1] == 3 else ndim
+        ndim_spatial = ndim - 1 if shape[-1] in [3, 4] else ndim
 
         if function_name in [
             "rescale",

--- a/benchmarks/skimage/cucim_transform_bench.py
+++ b/benchmarks/skimage/cucim_transform_bench.py
@@ -29,67 +29,67 @@ def main(args):
     for function_name, fixed_kwargs, var_kwargs, allow_color, allow_nd in [
         # _warps.py
         (
-            "resize",
-            dict(preserve_range=True),
-            dict(order=[0, 1, 3], mode=["reflect"], anti_aliasing=[True]),
-            True,
-            True,
-        ),  # scale handled in loop below
-        (
-            "resize_local_mean",
-            dict(preserve_range=True),
-            {},
-            True,
-            True,
-        ),  # scale handled in loop below
-        (
-            "rescale",
-            dict(preserve_range=True),
-            dict(order=[0, 1, 3], mode=["reflect"], anti_aliasing=[True]),
-            True,
-            True,
-        ),  # output_shape handled in loop below
-        (
             "rotate",
             dict(angle=15, preserve_range=True),
-            dict(order=[0, 1, 3], mode=["reflect"], resize=[False, True]),
-            False,
-            False,
-        ),
-        (
-            "downscale_local_mean",
-            dict(),
-            dict(),
+            dict(order=[0, 1, 2, 3, 4, 5], mode=["reflect"], resize=[True]),
             True,
-            True,
-        ),  # factors handled in loop below
-        (
-            "swirl",
-            dict(strength=1, preserve_range=True),
-            dict(order=[0, 1, 3], mode=["reflect"]),
-            False,
             False,
         ),
-        # TODO : warp? already indirectly benchmarked via swirl, etc
-        ("warp_polar", dict(), dict(scaling=["linear", "log"]), True, False),
-        # integral.py
-        ("integral_image", dict(), dict(), False, True),
-        # TODO: integrate
-        # pyramids.py
-        (
-            "pyramid_gaussian",
-            dict(max_layer=6, downscale=2, preserve_range=True),
-            dict(order=[0, 1, 3]),
-            True,
-            True,
-        ),
-        (
-            "pyramid_laplacian",
-            dict(max_layer=6, downscale=2, preserve_range=True),
-            dict(order=[0, 1, 3]),
-            True,
-            True,
-        ),
+        # (
+        #     "resize",
+        #     dict(preserve_range=True),
+        #     dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
+        #     True,
+        #     True,
+        # ),  # scale handled in loop below
+        # (
+        #     "resize_local_mean",
+        #     dict(preserve_range=True),
+        #     {},
+        #     True,
+        #     True,
+        # ),  # scale handled in loop below
+        # (
+        #     "rescale",
+        #     dict(preserve_range=True),
+        #     dict(order=[0, 1, 3, 5], mode=["reflect"], anti_aliasing=[True]),
+        #     True,
+        #     True,
+        # ),  # output_shape handled in loop below
+        # (
+        #     "downscale_local_mean",
+        #     dict(),
+        #     dict(),
+        #     True,
+        #     True,
+        # ),  # factors handled in loop below
+        # (
+        #     "swirl",
+        #     dict(strength=1, preserve_range=True),
+        #     dict(order=[0, 1, 3, 5], mode=["reflect"]),
+        #     False,
+        #     False,
+        # ),
+        # # TODO : warp? already indirectly benchmarked via swirl, etc
+        # ("warp_polar", dict(), dict(scaling=["linear", "log"]), True, False),
+        # # integral.py
+        # ("integral_image", dict(), dict(), False, True),
+        # # TODO: integrate
+        # # pyramids.py
+        # (
+        #     "pyramid_gaussian",
+        #     dict(max_layer=6, downscale=2, preserve_range=True),
+        #     dict(order=[0, 1, 3, 5]),
+        #     True,
+        #     True,
+        # ),
+        # (
+        #     "pyramid_laplacian",
+        #     dict(max_layer=6, downscale=2, preserve_range=True),
+        #     dict(order=[0, 1, 3, 5]),
+        #     True,
+        #     True,
+        # ),
     ]:
         if function_name != args.func_name:
             continue
@@ -121,7 +121,8 @@ def main(args):
         ]
 
         if function_name in ["rescale", "resize", "resize_local_mean"]:
-            scales = [0.75, 1.25]
+            # scales = [0.75, 1.25]
+            scales = [1.25]
             if function_name == "rescale":
                 var_kwargs["scale"] = [(s,) * ndim_spatial for s in scales]
             elif function_name.startswith("resize"):

--- a/benchmarks/skimage/cucim_transform_bench.py
+++ b/benchmarks/skimage/cucim_transform_bench.py
@@ -121,8 +121,7 @@ def main(args):
         ]
 
         if function_name in ["rescale", "resize", "resize_local_mean"]:
-            # scales = [0.75, 1.25]
-            scales = [1.25]
+            scales = [0.75, 1.25]
             if function_name == "rescale":
                 var_kwargs["scale"] = [(s,) * ndim_spatial for s in scales]
             elif function_name.startswith("resize"):

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -245,7 +245,7 @@ def _get_coord_zoom_and_shift_grid(
         else:
             ops.append(
                 f"""
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + ({float_type})0.5)
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}] + ({float_type})0.5)
               - (W)0.5{pre};"""
             )
     return ops

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -1201,7 +1201,7 @@ def _generate_interp_custom(
     return operation, name
 
 
-def use_loop_batch(batch_axes, ndim, yshape):
+def use_loop_batch(batch_axes, ndim, yshape, output_c_contiguous=True):
     """Whether batch optimization over the final axis should be applied.
 
     If the last axis (contiguous axis) is a batch axis, we can compute the
@@ -1213,7 +1213,8 @@ def use_loop_batch(batch_axes, ndim, yshape):
     degradation was observed at higher batch sizes.
     """
     return (
-        batch_axes == (ndim - 1,)
+        output_c_contiguous
+        and batch_axes == (ndim - 1,)
         and ndim > 1
         and yshape[-1] <= loop_batch_max_channels
     )
@@ -1231,12 +1232,15 @@ def _get_map_kernel(
     nprepad=0,
     float_dtype=cupy.double,
     batch_axes=None,
+    output_c_contiguous=True,
 ):
     in_params = "raw X x, raw W coords"
 
     # Optimize for contiguous batch axis at the end
     # Only enable when there's at least one spatial axis (ndim > 1)
-    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    loop_batch_axis = use_loop_batch(
+        batch_axes, ndim, yshape, output_c_contiguous
+    )
     if loop_batch_axis:
         out_params = "raw Y y"
         size = math.prod(yshape[:-1])
@@ -1281,12 +1285,15 @@ def _get_shift_kernel(
     nprepad=0,
     float_dtype=cupy.double,
     batch_axes=None,
+    output_c_contiguous=True,
 ):
     in_params = "raw X x, raw W shift"
 
     # Optimize for contiguous batch axis at the end
     # Only enable when there's at least one spatial axis (ndim > 1)
-    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    loop_batch_axis = use_loop_batch(
+        batch_axes, ndim, yshape, output_c_contiguous
+    )
     if loop_batch_axis:
         out_params = "raw Y y"
         size = math.prod(yshape[:-1])
@@ -1328,12 +1335,15 @@ def _get_zoom_shift_kernel(
     nprepad=0,
     float_dtype=cupy.double,
     batch_axes=None,
+    output_c_contiguous=True,
 ):
     in_params = "raw X x, raw W shift, raw W zoom"
 
     # Optimize for contiguous batch axis at the end
     # Only enable when there's at least one spatial axis (ndim > 1)
-    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    loop_batch_axis = use_loop_batch(
+        batch_axes, ndim, yshape, output_c_contiguous
+    )
     if loop_batch_axis:
         out_params = "raw Y y"
         size = math.prod(yshape[:-1])
@@ -1379,12 +1389,15 @@ def _get_zoom_kernel(
     nprepad=0,
     float_dtype=cupy.double,
     batch_axes=None,
+    output_c_contiguous=True,
 ):
     in_params = "raw X x, raw W zoom"
 
     # Optimize for contiguous batch axis at the end
     # Only enable when there's at least one spatial axis (ndim > 1)
-    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    loop_batch_axis = use_loop_batch(
+        batch_axes, ndim, yshape, output_c_contiguous
+    )
     if loop_batch_axis:
         out_params = "raw Y y"
         size = math.prod(yshape[:-1])
@@ -1425,12 +1438,15 @@ def _get_affine_kernel(
     nprepad=0,
     float_dtype=cupy.double,
     batch_axes=None,
+    output_c_contiguous=True,
 ):
     in_params = "raw X x, raw W mat"
 
     # Optimize for contiguous batch axis at the end
     # Only enable when there's at least one spatial axis (ndim > 1)
-    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    loop_batch_axis = use_loop_batch(
+        batch_axes, ndim, yshape, output_c_contiguous
+    )
     if loop_batch_axis:
         out_params = "raw Y y"
         size = math.prod(yshape[:-1])

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -548,6 +548,16 @@ def _unravel_loop_index(shape, uint_t="unsigned int", array_size=None):
     return "\n".join(code)
 
 
+def _generate_loop_batch_output_write(
+    value, integer_output, float_type, indent="                "
+):
+    if integer_output:
+        value = f"(Y)rint(({float_type})({value}))"
+    else:
+        value = f"(Y)({value})"
+    return f"{indent}y[out_base_idx + batch_idx] = {value};"
+
+
 def _generate_interp_custom(
     coord_func,
     ndim,
@@ -684,7 +694,7 @@ def _generate_interp_custom(
         {{
             #pragma unroll 4
             for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
-                y[out_base_idx + batch_idx] = {cval};
+{_generate_loop_batch_output_write(cval, integer_output, float_type)}
             }}
         }}
         else
@@ -757,26 +767,41 @@ def _generate_interp_custom(
             # Batch loop is innermost - iterate over batch elements
             if mode == "grid-constant":
                 _cond = " || ".join([f"(ic_{j} < 0)" for j in spatial_axes])
+                _cval_write = _generate_loop_batch_output_write(
+                    cval, integer_output, float_type, "                    "
+                )
+                _sample = (
+                    f"({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx]"
+                )
+                _sample_write = _generate_loop_batch_output_write(
+                    _sample, integer_output, float_type, "                    "
+                )
                 ops.append(
                     f"""
             if ({_cond}) {{
                 #pragma unroll 4
                 for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
-                    y[out_base_idx + batch_idx] = {cval};
+{_cval_write}
                 }}
             }} else {{
                 #pragma unroll 4
                 for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
-                    y[out_base_idx + batch_idx] = ({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx];
+{_sample_write}
                 }}
             }}"""  # noqa: E501
                 )
             else:
+                _sample = (
+                    f"({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx]"
+                )
+                _sample_write = _generate_loop_batch_output_write(
+                    _sample, integer_output, float_type
+                )
                 ops.append(
                     f"""
             #pragma unroll 4
             for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
-                y[out_base_idx + batch_idx] = ({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx];
+{_sample_write}
             }}"""  # noqa: E501
                 )
         else:

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -558,6 +558,10 @@ def _generate_loop_batch_output_write(
     return f"{indent}y[out_base_idx + batch_idx] = {value};"
 
 
+def _join_index_terms(terms):
+    return " + ".join(terms) if terms else "0"
+
+
 def _generate_interp_custom(
     coord_func,
     ndim,
@@ -629,10 +633,12 @@ def _generate_interp_custom(
     if loop_batch_axis:
         batch_size = yshape[-1]
         batch_axis = ndim - 1
+        outer_batch_axes = [j for j in batch_axes if j != batch_axis]
         reduced_yshape = yshape[:-1]
         ops.append(f"const {uint_t} batch_size = {batch_size};")
         ops.append(f"const {uint_t} out_base_idx = i * batch_size;")
     else:
+        outer_batch_axes = []
         reduced_yshape = yshape
 
     float_type = cupy._core._scalar.get_typename(float_dtype)
@@ -760,8 +766,11 @@ def _generate_interp_custom(
             {int_t} ic_{j} = cf_{j} * sx_{j};"""
             )
 
-        # Compute base index from spatial coords
-        _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+        # Compute base index from spatial coords and any non-looped batch axes.
+        _base_coord_idx = _join_index_terms(
+            [f"(({int_t})in_coord[{j}]) * sx_{j}" for j in outer_batch_axes]
+            + [f"ic_{j}" for j in spatial_axes]
+        )
 
         if loop_batch_axis:
             # Batch loop is innermost - iterate over batch elements
@@ -771,7 +780,7 @@ def _generate_interp_custom(
                     cval, integer_output, float_type, "                    "
                 )
                 _sample = (
-                    f"({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx]"
+                    f"({internal_dtype})x_ptr[{_base_coord_idx} + batch_idx]"
                 )
                 _sample_write = _generate_loop_batch_output_write(
                     _sample, integer_output, float_type, "                    "
@@ -792,7 +801,7 @@ def _generate_interp_custom(
                 )
             else:
                 _sample = (
-                    f"({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx]"
+                    f"({internal_dtype})x_ptr[{_base_coord_idx} + batch_idx]"
                 )
                 _sample_write = _generate_loop_batch_output_write(
                     _sample, integer_output, float_type
@@ -915,7 +924,10 @@ def _generate_interp_custom(
 
             # Compute spatial weight and base index
             _spatial_weight = " * ".join([f"w_{j}" for j in spatial_axes])
-            _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+            _base_coord_idx = _join_index_terms(
+                [f"(({int_t})in_coord[{j}]) * sx_{j}" for j in outer_batch_axes]
+                + [f"ic_{j}" for j in spatial_axes]
+            )
 
             # Innermost batch loop - with bounds check for grid-constant mode
             if mode == "grid-constant":
@@ -925,7 +937,7 @@ def _generate_interp_custom(
                 ops.append(
                     f"""
                     W spatial_weight = {_spatial_weight};
-                    {int_t} ic_base = {_spatial_coord_idx};
+                    {int_t} ic_base = {_base_coord_idx};
                     if ({_spatial_cond}) {{
                         #pragma unroll 4
                         for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
@@ -943,7 +955,7 @@ def _generate_interp_custom(
                 ops.append(
                     f"""
                     W spatial_weight = {_spatial_weight};
-                    {int_t} ic_base = {_spatial_coord_idx};
+                    {int_t} ic_base = {_base_coord_idx};
                     #pragma unroll 4
                     for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
                         {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
@@ -1095,7 +1107,10 @@ def _generate_interp_custom(
 
             # Compute spatial weight and base index
             _spatial_weight = " * ".join([f"w_{j}" for j in spatial_axes])
-            _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+            _base_coord_idx = _join_index_terms(
+                [f"(({int_t})in_coord[{j}]) * sx_{j}" for j in outer_batch_axes]
+                + [f"ic_{j}" for j in spatial_axes]
+            )
 
             # Innermost batch loop
             # For order > 1, we need bounds check for both constant and grid-constant modes
@@ -1106,7 +1121,7 @@ def _generate_interp_custom(
                 ops.append(
                     f"""
                     W spatial_weight = {_spatial_weight};
-                    {int_t} ic_base = {_spatial_coord_idx};
+                    {int_t} ic_base = {_base_coord_idx};
                     if ({_spatial_cond}) {{
                         #pragma unroll 4
                         for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
@@ -1124,7 +1139,7 @@ def _generate_interp_custom(
                 ops.append(
                     f"""
                     W spatial_weight = {_spatial_weight};
-                    {int_t} ic_base = {_spatial_coord_idx};
+                    {int_t} ic_base = {_base_coord_idx};
                     #pragma unroll 4
                     for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
                         {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
@@ -1240,8 +1255,10 @@ def use_loop_batch(batch_axes, ndim, yshape, output_c_contiguous=True):
     """
     return (
         output_c_contiguous
-        and batch_axes == (ndim - 1,)
+        and batch_axes is not None
+        and ndim - 1 in batch_axes
         and ndim > 1
+        and any(j not in batch_axes for j in range(ndim - 1))
         and yshape[-1] <= loop_batch_max_channels
     )
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -155,7 +155,7 @@ def _get_coord_zoom_and_shift(
 
             in_coord[ndim]: array containing the source coordinate
             zoom[ndim]: array containing the zoom for each axis
-            shift[ndim]: array containing the zoom for each axis
+            shift[ndim]: array containing the shift for each axis
 
         computes::
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 from __future__ import annotations
 
+import math
+from typing import NamedTuple
+
 import cupy
 import cupy._core.internal
 import numpy
@@ -14,6 +17,14 @@ from cucim.skimage._vendored import (
     _ndimage_util as _util,
 )
 
+
+class KernelInfo(NamedTuple):
+    """Kernel info returned by kernel getter functions."""
+
+    kernel: cupy.ElementwiseKernel
+    size: int | None  # None means use output array size
+
+
 math_constants_preamble = r"""
 // workaround for HIP: line begins with #include
 #include <cupy/math_constants.h>
@@ -21,8 +32,14 @@ math_constants_preamble = r"""
 
 spline_weights_inline = _spline_kernel_weights.spline_weights_inline
 
+# Empirical threshold above which using loop_batch_axis=True begins to become
+# disadvantageous.
+loop_batch_max_channels = 12
 
-def _get_coord_map(ndim, nprepad=0, float_type=None, batch_axes=None):
+
+def _get_coord_map(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Extract target coordinate from coords array (for map_coordinates).
 
     Args:
@@ -38,6 +55,9 @@ def _get_coord_map(ndim, nprepad=0, float_type=None, batch_axes=None):
             coordinate values in the ``coordinates`` array are ignored.
             This improves performance when only a subset of dimensions
             require interpolation.
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
 
@@ -59,15 +79,33 @@ def _get_coord_map(ndim, nprepad=0, float_type=None, batch_axes=None):
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the kernel loops over the last batch axis, so:
+    - The spatial coords are read once using out_base_idx (first batch element)
+    - The coords are assumed to be the same for all batch elements at the
+      same spatial position
+    - The last axis (batch axis) is not generated here - it's handled in the
+      batch loop
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
-    # only need ncoords if there are non-batch axes
-    if len(batch_axes) < ndim:
-        ops.append("ptrdiff_t ncoords = _ind.size();")
+
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+
+    # only need ncoords if there are non-batch axes to process
+    non_batch_axes_to_process = [
+        j for j in axes_to_process if j not in batch_axes
+    ]
+    if non_batch_axes_to_process:
+        if loop_batch_axis:
+            # When looping, ncoords =  spatial_size * batch_size
+            ops.append("ptrdiff_t ncoords = _ind.size() * batch_size;")
+        else:
+            ops.append("ptrdiff_t ncoords = _ind.size();")
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    for j in axes_to_process:
         if j in batch_axes:
             # batch axis: use identity (output index = input coordinate)
             ops.append(
@@ -75,14 +113,24 @@ def _get_coord_map(ndim, nprepad=0, float_type=None, batch_axes=None):
     W c_{j} = (W)in_coord[{j}]{pre};"""
             )
         else:
-            ops.append(
-                f"""
+            if loop_batch_axis:
+                # Read coords at out_base_idx (first batch element at this spatial pos)
+                # The spatial coords are the same for all batch elements
+                ops.append(
+                    f"""
+    W c_{j} = coords[out_base_idx + {j} * ncoords]{pre};"""
+                )
+            else:
+                ops.append(
+                    f"""
     W c_{j} = coords[i + {j} * ncoords]{pre};"""
-            )
+                )
     return ops
 
 
-def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
+def _get_coord_zoom_and_shift(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the center of the edge pixels.
@@ -96,6 +144,9 @@ def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None, batch_axes=None)
             to support the same function signature.
         batch_axes (tuple of int): Axes along which zoom == 1 and there is no
             shift (no interpolation required).
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
 
@@ -113,12 +164,17 @@ def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None, batch_axes=None)
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -133,7 +189,9 @@ def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None, batch_axes=None)
     return ops
 
 
-def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None, batch_axes=None):
+def _get_coord_zoom_and_shift_grid(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the outer edges of the grid pixels.
@@ -147,6 +205,9 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None, batch_axes=
             to support the same function signature.
         batch_axes (tuple of int): Axes along which zoom == 1 and there is no
             shift (no interpolation required).
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
 
@@ -164,12 +225,17 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None, batch_axes=
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -185,7 +251,9 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None, batch_axes=
     return ops
 
 
-def _get_coord_zoom(ndim, nprepad=0, float_type=None, batch_axes=None):
+def _get_coord_zoom(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a zoom.
 
     This version zooms from the center of the edge pixels.
@@ -199,6 +267,9 @@ def _get_coord_zoom(ndim, nprepad=0, float_type=None, batch_axes=None):
             to support the same function signature.
         batch_axes (tuple of int): Axes along which zoom == 1 (no interpolation
             required).
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
 
@@ -219,12 +290,17 @@ def _get_coord_zoom(ndim, nprepad=0, float_type=None, batch_axes=None):
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -239,7 +315,9 @@ def _get_coord_zoom(ndim, nprepad=0, float_type=None, batch_axes=None):
     return ops
 
 
-def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double", batch_axes=None):
+def _get_coord_zoom_grid(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a zoom (grid_mode=True version).
 
     This version zooms from the outer edges of the grid pixels.
@@ -253,6 +331,9 @@ def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double", batch_axes=None):
             to support the same function signature.
         batch_axes (tuple of int): Axes along which zoom == 1 (no interpolation
             required).
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
         Assumes the following variables have been initialized on the device::
@@ -270,12 +351,17 @@ def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double", batch_axes=None):
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -291,7 +377,9 @@ def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double", batch_axes=None):
     return ops
 
 
-def _get_coord_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
+def _get_coord_shift(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a shift.
 
     Args:
@@ -302,6 +390,9 @@ def _get_coord_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
             because all `coord_func` passed to `_generate_interp_custom` have
             to support the same function signature.
         batch_axes (tuple of int): Axes along which there is no shift.
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
         Assumes the following variables have been initialized on the device::
@@ -317,12 +408,17 @@ def _get_coord_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -337,7 +433,9 @@ def _get_coord_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
     return ops
 
 
-def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
+def _get_coord_affine(
+    ndim, nprepad=0, float_type=None, batch_axes=None, loop_batch_axis=False
+):
     """Compute target coordinate based on a homogeneous transformation matrix.
 
     The homogeneous matrix has shape (ndim, ndim + 1). It corresponds to
@@ -356,6 +454,9 @@ def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
             coordinate). For these axes, interpolation is skipped. This
             improves performance when only a subset of dimensions require
             interpolation.
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Note:
         Assumes the following variables have been initialized on the device::
@@ -372,13 +473,23 @@ def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
 
             c_j = in_coord[j]
 
+    When loop_batch_axis=True, the last axis is handled separately in the
+    batch loop, so no c_j is generated for it here.
+
     """
     if batch_axes is None:
         batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     ncol = ndim + 1
-    for j in range(ndim):
+    # When loop_batch_axis is True, skip the last axis (it's the batch axis)
+    axes_to_process = range(ndim - 1) if loop_batch_axis else range(ndim)
+    # When loop_batch_axis is True, skip multiplying by in_coord for batch axis
+    # since it's not initialized yet (it's set in the batch loop)
+    # For batch axes, the matrix column should be 0 for non-batch rows anyway
+    coord_axes = range(ndim - 1) if loop_batch_axis else range(ndim)
+
+    for j in axes_to_process:
         if j in batch_axes:
             # identity transform for batch axes
             ops.append(
@@ -390,7 +501,7 @@ def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
                 f"""
             W c_{j} = (W)0.0;"""
             )
-            for k in range(ndim):
+            for k in coord_axes:
                 ops.append(
                     f"""
             c_{j} += mat[{ncol * j + k}] * (W)in_coord[{k}];"""
@@ -402,15 +513,23 @@ def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
     return ops
 
 
-def _unravel_loop_index(shape, uint_t="unsigned int"):
+def _unravel_loop_index(shape, uint_t="unsigned int", array_size=None):
     """
     declare a multi-index array in_coord and unravel the 1D index, i into it.
     This code assumes that the array is a C-ordered array.
+
+    Args:
+        shape: tuple of dimension sizes to unravel
+        uint_t: unsigned integer type to use
+        array_size: size of in_coord array (defaults to len(shape), but can be
+            larger if additional dimensions will be set separately)
     """
     ndim = len(shape)
+    if array_size is None:
+        array_size = ndim
     code = [
         f"""
-        {uint_t} in_coord[{ndim}];
+        {uint_t} in_coord[{array_size}];
         {uint_t} s, t, idx = i;"""
     ]
     for j in range(ndim - 1, 0, -1):
@@ -442,6 +561,7 @@ def _generate_interp_custom(
     float_dtype=cupy.float64,
     omit_in_coord=False,
     batch_axes=None,
+    loop_batch_axis=False,
 ):
     """
     Args:
@@ -467,6 +587,9 @@ def _generate_interp_custom(
             dimensions where no interpolation is needed (zoom == 1 and
             shift == 0). For these axes, the identity transform is used and
             interpolation is skipped.
+        loop_batch_axis (bool): If True, the last axis is a contiguous batch
+            axis and the kernel will loop over it internally. This requires
+            using raw output and reduces kernel launch overhead.
 
     Returns:
         operation (str): code body for the ElementwiseKernel
@@ -475,17 +598,34 @@ def _generate_interp_custom(
     if batch_axes is None:
         batch_axes = ()
 
-    ops = []
-    float_type = cupy._core._scalar.get_typename(float_dtype)
-    internal_dtype = float_type if integer_output else "Y"
-    ops.append(f"{internal_dtype} out = 0.0;")
-
     if large_int:
         uint_t = "size_t"
         int_t = "ptrdiff_t"
     else:
         uint_t = "unsigned int"
         int_t = "int"
+
+    ops = []
+
+    # indicate the input and output arrays don't overlap so the compiler
+    # can use LDG (read-only cache) instead of potentially slow LD cache.
+    # x is guaranteed C-contiguous by (_filter_input / ascontiguousarray)
+    ops.append("const X* __restrict__ x_ptr = &x[0];")
+
+    # When looping over the last batch axis, we process all batch elements
+    # in a single kernel thread. Spatial coordinates are computed once,
+    # and the batch loop is placed as the innermost loop.
+    if loop_batch_axis:
+        batch_size = yshape[-1]
+        batch_axis = ndim - 1
+        reduced_yshape = yshape[:-1]
+        ops.append(f"const {uint_t} batch_size = {batch_size};")
+        ops.append(f"const {uint_t} out_base_idx = i * batch_size;")
+    else:
+        reduced_yshape = yshape
+
+    float_type = cupy._core._scalar.get_typename(float_dtype)
+    internal_dtype = float_type if integer_output else "Y"
 
     # determine strides for x along each axis
     for j in range(ndim):
@@ -494,13 +634,27 @@ def _generate_interp_custom(
     for j in range(ndim - 1, 0, -1):
         ops.append(f"const {uint_t} sx_{j - 1} = sx_{j} * xsize_{j};")
 
-    if not omit_in_coord:
-        # create in_coords array to store the unraveled indices
-        ops.append(_unravel_loop_index(yshape, uint_t))
+    if loop_batch_axis:
+        # Only unravel to ndim-1 dimensions (spatial only)
+        if not omit_in_coord:
+            ops.append(_unravel_loop_index(reduced_yshape, uint_t, ndim))
+        # Don't start batch loop here - it will be the innermost loop
+    else:
+        if not omit_in_coord:
+            ops.append(_unravel_loop_index(reduced_yshape, uint_t))
+
+    if not loop_batch_axis:
+        ops.append(f"{internal_dtype} out = 0.0;")
 
     # compute the transformed (target) coordinates, c_j
-    # coord_func uses identity transform for any batch (untransformed) axes
-    ops = ops + coord_func(ndim, nprepad, float_type=float_type, batch_axes=batch_axes)
+    # For loop_batch_axis, this only computes spatial coords (batch coord set later)
+    ops = ops + coord_func(
+        ndim,
+        nprepad,
+        float_type=float_type,
+        batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
+    )
 
     if cval is numpy.nan:
         cval = "(Y)CUDART_NAN"
@@ -513,167 +667,312 @@ def _generate_interp_custom(
 
     if mode == "constant":
         # use cval if coordinate is outside the bounds of x
-        _cond = " || ".join(
-            [f"(c_{j} < 0) || (c_{j} > xsize_{j} - 1)" for j in range(ndim)]
-        )
-        ops.append(
-            f"""
+        if loop_batch_axis:
+            # Only check spatial bounds (batch bounds are always valid)
+            spatial_axes = [j for j in range(ndim) if j != batch_axis]
+            _cond = " || ".join(
+                [
+                    f"(c_{j} < 0) || (c_{j} > xsize_{j} - 1)"
+                    for j in spatial_axes
+                ]
+            )
+            # If spatial out of bounds, fill all batch elements with cval
+            ops.append(
+                f"""
+        if ({_cond})
+        {{
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = {cval};
+            }}
+        }}
+        else
+        {{"""
+            )
+        else:
+            _cond = " || ".join(
+                [f"(c_{j} < 0) || (c_{j} > xsize_{j} - 1)" for j in range(ndim)]
+            )
+            ops.append(
+                f"""
         if ({_cond})
         {{
             out = {cval};
         }}
         else
         {{"""
-        )
+            )
 
     if order == 0:
         if mode == "wrap":
+            # mode 'wrap' requires this to work
+            ops.append(f"{float_type} dcoord;")
+
+        # Compute spatial indices (outside batch loop)
+        spatial_axes = [j for j in range(ndim) if j not in batch_axes]
+        for j in spatial_axes:
+            # determine nearest neighbor
+            if mode == "wrap":
+                ops.append(
+                    f"""
+                dcoord = c_{j};"""
+                )
+            else:
+                ops.append(
+                    f"""
+                {int_t} cf_{j} = ({int_t})floor(({float_type})c_{j}
+                                                + ({float_type})0.5);"""
+                )
+
+            # handle boundary
+            if mode != "constant":
+                if mode == "wrap":
+                    ixvar = "dcoord"
+                    float_ix = True
+                else:
+                    ixvar = f"cf_{j}"
+                    float_ix = False
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        mode, ixvar, f"xsize_{j}", int_t, float_ix
+                    )
+                )
+                if mode == "wrap":
+                    ops.append(
+                        f"""
+                {int_t} cf_{j} = ({int_t})floor(dcoord + ({float_type})0.5);"""
+                    )
+
+            # sum over ic_j will give the raveled coordinate in the input
             ops.append(
-                f"{float_type} dcoord;"
-            )  # mode 'wrap' requires this to work
-        for j in range(ndim):
-            if j in batch_axes:
-                # batch axis: use identity, no interpolation needed
+                f"""
+            {int_t} ic_{j} = cf_{j} * sx_{j};"""
+            )
+
+        # Compute base index from spatial coords
+        _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+
+        if loop_batch_axis:
+            # Batch loop is innermost - iterate over batch elements
+            if mode == "grid-constant":
+                _cond = " || ".join([f"(ic_{j} < 0)" for j in spatial_axes])
+                ops.append(
+                    f"""
+            if ({_cond}) {{
+                #pragma unroll 4
+                for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                    y[out_base_idx + batch_idx] = {cval};
+                }}
+            }} else {{
+                #pragma unroll 4
+                for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                    y[out_base_idx + batch_idx] = ({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx];
+                }}
+            }}"""  # noqa: E501
+                )
+            else:
+                ops.append(
+                    f"""
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = ({internal_dtype})x_ptr[{_spatial_coord_idx} + batch_idx];
+            }}"""  # noqa: E501
+                )
+        else:
+            # Original non-looped code path
+            for j in batch_axes:
                 ops.append(
                     f"""
             {int_t} cf_{j} = ({int_t})in_coord[{j}];
             {int_t} ic_{j} = cf_{j} * sx_{j};"""
                 )
-            else:
-                # determine nearest neighbor
-                if mode == "wrap":
-                    ops.append(
-                        f"""
-                    dcoord = c_{j};"""
-                    )
-                else:
-                    ops.append(
-                    f"""{int_t} cf_{j} = (
-                            {int_t})floor(({float_type})c_{j}
-                                          + ({float_type})0.5);"""
-                    )
-
-                # handle boundary
-                if mode != "constant":
-                    if mode == "wrap":
-                        ixvar = "dcoord"
-                        float_ix = True
-                    else:
-                        ixvar = f"cf_{j}"
-                        float_ix = False
-                    ops.append(
-                        _util._generate_boundary_condition_ops(
-                            mode, ixvar, f"xsize_{j}", int_t, float_ix
-                        )
-                    )
-                    if mode == "wrap":
-                        ops.append(
-                            f"""
-                    {int_t} cf_{j} = ({int_t})floor(dcoord
-                                      + ({float_type})0.5);"""
-                        )
-
-                # sum over ic_j will give the raveled coordinate in the input
+            _coord_idx = " + ".join([f"ic_{j}" for j in range(ndim)])
+            if mode == "grid-constant":
+                _cond = " || ".join([f"(ic_{j} < 0)" for j in range(ndim)])
                 ops.append(
                     f"""
-                {int_t} ic_{j} = cf_{j} * sx_{j};"""
-                )
-        _coord_idx = " + ".join([f"ic_{j}" for j in range(ndim)])
-        if mode == "grid-constant":
-            _cond = " || ".join([f"(ic_{j} < 0)" for j in range(ndim)])
-            ops.append(
-                f"""
             if ({_cond}) {{
                 out = {cval};
             }} else {{
-                out = ({internal_dtype})x[{_coord_idx}];
+                out = ({internal_dtype})x_ptr[{_coord_idx}];
             }}"""
-            )
-        else:
-            ops.append(
-                f"""
-            out = ({internal_dtype})x[{_coord_idx}];"""
-            )
-
-    elif order == 1:
-        for j in range(ndim):
-            if j in batch_axes:
-                # batch axis: use identity, no interpolation needed
-                # just set w_{j} = 1.0 and ic_{j} = in_coord[{j}] * sx_{j}
-                ops.append(
-                    f"""
-            W w_{j} = (W)1.0;
-            {int_t} ic_{j} = (({int_t})in_coord[{j}]) * sx_{j};
-            {{  // dummy scope for batch axis {j}"""
                 )
             else:
-                # get coordinates for linear interpolation along axis j
                 ops.append(
                     f"""
-                {int_t} cf_{j} = ({int_t})floor((double)c_{j});
-                {int_t} cc_{j} = cf_{j} + 1;
-                {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
-                """
+            out = ({internal_dtype})x_ptr[{_coord_idx}];"""
                 )
 
+    elif order == 1:
+        spatial_axes = [j for j in range(ndim) if j not in batch_axes]
+
+        # Compute interpolation setup for spatial axes (outside any batch loop)
+        for j in spatial_axes:
+            # get coordinates for linear interpolation along axis j
+            ops.append(
+                f"""
+            {int_t} cf_{j} = ({int_t})floor(({float_type})c_{j});
+            {int_t} cc_{j} = cf_{j} + 1;
+            {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
+            """
+            )
+
+            if mode == "wrap":
+                ops.append(
+                    f"""
+                {float_type} dcoordf_{j} = c_{j};
+                {float_type} dcoordc_{j} = c_{j} + 1;"""
+                )
+            else:
+                # handle boundaries for extension modes.
+                ops.append(
+                    f"""
+                {int_t} cf_bounded_{j} = cf_{j};
+                {int_t} cc_bounded_{j} = cc_{j};"""
+                )
+
+            if mode != "constant":
+                if mode == "wrap":
+                    ixvar = f"dcoordf_{j}"
+                    float_ix = True
+                else:
+                    ixvar = f"cf_bounded_{j}"
+                    float_ix = False
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        mode, ixvar, f"xsize_{j}", int_t, float_ix
+                    )
+                )
+
+                ixvar = f"dcoordc_{j}" if mode == "wrap" else f"cc_bounded_{j}"
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        mode, ixvar, f"xsize_{j}", int_t, float_ix
+                    )
+                )
                 if mode == "wrap":
                     ops.append(
                         f"""
-                    {float_type} dcoordf = c_{j};
-                    {float_type} dcoordc = c_{j} + ({float_type})1.0;"""
-                    )
-                else:
-                    # handle boundaries for extension modes.
-                    ops.append(
-                        f"""
-                    {int_t} cf_bounded_{j} = cf_{j};
-                    {int_t} cc_bounded_{j} = cc_{j};"""
+                    {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf_{j});
+                    {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf_{j} + ({float_type})1.0);
+                    """
                     )
 
-                if mode != "constant":
-                    if mode == "wrap":
-                        ixvar = "dcoordf"
-                        float_ix = True
-                    else:
-                        ixvar = f"cf_bounded_{j}"
-                        float_ix = False
-                    ops.append(
-                        _util._generate_boundary_condition_ops(
-                            mode, ixvar, f"xsize_{j}", int_t, float_ix
-                        )
-                    )
+        if loop_batch_axis:
+            # Optimized path: spatial interpolation loops outside, batch loop innermost
+            # Initialize output array for all batch elements
+            ops.append(
+                f"""
+            {internal_dtype} out_batch[{batch_size}];
+            #pragma unroll 4
+            for ({uint_t} b = 0; b < batch_size; b++) {{ out_batch[b] = 0.0; }}"""
+            )
 
-                    ixvar = "dcoordc" if mode == "wrap" else f"cc_bounded_{j}"
-                    ops.append(
-                        _util._generate_boundary_condition_ops(
-                            mode, ixvar, f"xsize_{j}", int_t, float_ix
-                        )
-                    )
-                    if mode == "wrap":
-                        ops.append(
-                            f"""
-                        {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);;
-                        {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf
-                                                  + ({float_type})1.0);;
-                        """
-                        )
-
+            # Generate nested loops for spatial interpolation
+            for j in spatial_axes:
                 ops.append(
                     f"""
-                for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
+            for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
+                {{
+                    W w_{j};
+                    {int_t} ic_{j};
+                    if (s_{j} == 0)
                     {{
-                        W w_{j};
-                        {int_t} ic_{j};
-                        if (s_{j} == 0)
-                        {{
-                            w_{j} = (W)cc_{j} - c_{j};
-                            ic_{j} = cf_bounded_{j} * sx_{j};
-                        }} else
-                        {{
-                            w_{j} = c_{j} - (W)cf_{j};
-                            ic_{j} = cc_bounded_{j} * sx_{j};
-                        }}"""
+                        w_{j} = (W)cc_{j} - c_{j};
+                        ic_{j} = cf_bounded_{j} * sx_{j};
+                    }} else
+                    {{
+                        w_{j} = c_{j} - (W)cf_{j};
+                        ic_{j} = cc_bounded_{j} * sx_{j};
+                    }}"""
                 )
+
+            # Compute spatial weight and base index
+            _spatial_weight = " * ".join([f"w_{j}" for j in spatial_axes])
+            _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+
+            # Innermost batch loop - with bounds check for grid-constant mode
+            if mode == "grid-constant":
+                _spatial_cond = " || ".join(
+                    [f"(ic_{j} < 0)" for j in spatial_axes]
+                )
+                ops.append(
+                    f"""
+                    W spatial_weight = {_spatial_weight};
+                    {int_t} ic_base = {_spatial_coord_idx};
+                    if ({_spatial_cond}) {{
+                        #pragma unroll 4
+                        for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                            out_batch[batch_idx] += {cval} * ({internal_dtype})spatial_weight;
+                        }}
+                    }} else {{
+                        #pragma unroll 4
+                        for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                            {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
+                            out_batch[batch_idx] += val * ({internal_dtype})spatial_weight;
+                        }}
+                    }}"""
+                )
+            else:
+                ops.append(
+                    f"""
+                    W spatial_weight = {_spatial_weight};
+                    {int_t} ic_base = {_spatial_coord_idx};
+                    #pragma unroll 4
+                    for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                        {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
+                        out_batch[batch_idx] += val * ({internal_dtype})spatial_weight;
+                    }}"""
+                )
+
+            # Close spatial interpolation loops
+            ops.append("}" * len(spatial_axes))
+
+            # Write results for all batch elements
+            if integer_output:
+                ops.append(
+                    f"""
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = (Y)rint(({float_type})out_batch[batch_idx]);
+            }}"""
+                )
+            else:
+                ops.append(
+                    f"""
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = (Y)out_batch[batch_idx];
+            }}"""
+                )
+        else:
+            # Original non-looped code path
+            for j in range(ndim):
+                if j in batch_axes:
+                    ops.append(
+                        f"""
+            W w_{j} = (W)1.0;
+            {int_t} ic_{j} = (({int_t})in_coord[{j}]) * sx_{j};
+            {{  // dummy scope for batch axis {j}"""
+                    )
+                elif j in spatial_axes:
+                    # spatial axes already have their setup code, just add the loop
+                    ops.append(
+                        f"""
+            for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
+                {{
+                    W w_{j};
+                    {int_t} ic_{j};
+                    if (s_{j} == 0)
+                    {{
+                        w_{j} = (W)cc_{j} - c_{j};
+                        ic_{j} = cf_bounded_{j} * sx_{j};
+                    }} else
+                    {{
+                        w_{j} = c_{j} - (W)cf_{j};
+                        ic_{j} = cc_bounded_{j} * sx_{j};
+                    }}"""
+                    )
     elif order > 1:
         if mode == "grid-constant":
             spline_mode = "constant"
@@ -682,88 +981,176 @@ def _generate_interp_custom(
         else:
             spline_mode = _spline_prefilter_core._get_spline_mode(mode)
 
+        spatial_axes = [j for j in range(ndim) if j not in batch_axes]
+
         # wx, wy are temporary variables used during spline weight computation
-        # (only needed for non-batch axes)
-        non_batch_axes = [j for j in range(ndim) if j not in batch_axes]
-        if non_batch_axes:
+        if spatial_axes:
             ops.append(
                 f"""
             W wx, wy;
             {int_t} start;"""
             )
-        for j in range(ndim):
-            if j in batch_axes:
-                # batch axis: use identity, no interpolation needed
-                # just set w_{j} = 1.0 and ic_{j} = in_coord[{j}] * sx_{j}
+
+        # Compute spline weights and indices for spatial axes (outside batch loop)
+        for j in spatial_axes:
+            # determine weights along the current axis
+            ops.append(
+                f"""
+            W weights_{j}[{order + 1}];"""
+            )
+            ops.append(
+                spline_weights_inline[order].format(
+                    j=j, order=order, F=float_type
+                )
+            )
+
+            # get starting coordinate for spline interpolation along axis j
+            if mode in ["wrap"]:
+                ops.append(f"{float_type} dcoord_{j} = c_{j};")
+                coord_var = f"dcoord_{j}"
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        mode, coord_var, f"xsize_{j}", int_t, True
+                    )
+                )
+            else:
+                coord_var = f"({float_type})c_{j}"
+
+            if order & 1:
+                op_str = """
+                start = ({int_t})floor({coord_var}) - {order_2};"""
+            else:
+                op_str = """
+                start = ({int_t})floor({coord_var} + ({float_type})0.5) - {order_2};"""
+            ops.append(
+                op_str.format(
+                    int_t=int_t,
+                    coord_var=coord_var,
+                    float_type=float_type,
+                    order_2=order // 2,
+                )
+            )
+
+            # set of coordinate values within spline footprint along axis j
+            ops.append(f"""{int_t} ci_{j}[{order + 1}];""")
+            for k in range(order + 1):
+                ixvar = f"ci_{j}[{k}]"
                 ops.append(
                     f"""
+                {ixvar} = start + {k};"""
+                )
+                ops.append(
+                    _util._generate_boundary_condition_ops(
+                        spline_mode, ixvar, f"xsize_{j}", int_t
+                    )
+                )
+
+        if loop_batch_axis:
+            # Optimized path: spatial interpolation loops outside, batch loop innermost
+            # Initialize output array for all batch elements
+            ops.append(
+                f"""
+            {internal_dtype} out_batch[{batch_size}];
+            for ({uint_t} b = 0; b < batch_size; b++) {{ out_batch[b] = 0.0; }}"""
+            )
+
+            # Generate nested loops for spatial interpolation
+            for j in spatial_axes:
+                ops.append(
+                    f"""
+            W w_{j};
+            {int_t} ic_{j};
+            for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
+                {{
+                    w_{j} = weights_{j}[k_{j}];
+                    ic_{j} = ci_{j}[k_{j}] * sx_{j};
+            """
+                )
+
+            # Compute spatial weight and base index
+            _spatial_weight = " * ".join([f"w_{j}" for j in spatial_axes])
+            _spatial_coord_idx = " + ".join([f"ic_{j}" for j in spatial_axes])
+
+            # Innermost batch loop
+            # For order > 1, we need bounds check for both constant and grid-constant modes
+            if mode == "grid-constant" or mode == "constant":
+                _spatial_cond = " || ".join(
+                    [f"(ic_{j} < 0)" for j in spatial_axes]
+                )
+                ops.append(
+                    f"""
+                    W spatial_weight = {_spatial_weight};
+                    {int_t} ic_base = {_spatial_coord_idx};
+                    if ({_spatial_cond}) {{
+                        #pragma unroll 4
+                        for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                            out_batch[batch_idx] += {cval} * ({internal_dtype})spatial_weight;
+                        }}
+                    }} else {{
+                        #pragma unroll 4
+                        for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                            {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
+                            out_batch[batch_idx] += val * ({internal_dtype})spatial_weight;
+                        }}
+                    }}"""
+                )
+            else:
+                ops.append(
+                    f"""
+                    W spatial_weight = {_spatial_weight};
+                    {int_t} ic_base = {_spatial_coord_idx};
+                    #pragma unroll 4
+                    for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                        {internal_dtype} val = ({internal_dtype})x_ptr[ic_base + batch_idx];
+                        out_batch[batch_idx] += val * ({internal_dtype})spatial_weight;
+                    }}"""
+                )
+
+            # Close spatial interpolation loops
+            ops.append("}" * len(spatial_axes))
+
+            # Write results for all batch elements
+            if integer_output:
+                ops.append(
+                    f"""
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = (Y)rint(({float_type})out_batch[batch_idx]);
+            }}"""
+                )
+            else:
+                ops.append(
+                    f"""
+            #pragma unroll 4
+            for ({uint_t} batch_idx = 0; batch_idx < batch_size; batch_idx++) {{
+                y[out_base_idx + batch_idx] = (Y)out_batch[batch_idx];
+            }}"""
+                )
+        else:
+            # Original non-looped code path
+            for j in range(ndim):
+                if j in batch_axes:
+                    ops.append(
+                        f"""
             W w_{j} = (W)1.0;
             {int_t} ic_{j} = (({int_t})in_coord[{j}]) * sx_{j};
             {{  // dummy scope for batch axis {j}"""
-                )
-            else:
-                # determine weights along the current axis
-                ops.append(
-                    f"""
-                W weights_{j}[{order + 1}];"""
-                )
-                ops.append(
-                    spline_weights_inline[order].format(j=j, order=order)
-                )
-
-                # get starting coordinate for spline interpolation along axis j
-                if mode in ["wrap"]:
-                    ops.append(f"{float_type} dcoord = c_{j};")
-                    coord_var = "dcoord"
-                    ops.append(
-                        _util._generate_boundary_condition_ops(
-                            mode, coord_var, f"xsize_{j}", int_t, True
-                        )
                     )
-                else:
-                    coord_var = f"({float_type})c_{j}"
-
-                if order & 1:
-                    op_str = """
-                    start = ({int_t})floor({coord_var}) - {order_2};"""
-                else:
-                    op_str = """
-                    start = ({int_t})floor(
-                        {coord_var} + ({float_type})0.5) - {order_2};"""
-                ops.append(
-                    op_str.format(
-                        int_t=int_t, coord_var=coord_var,
-                        float_type=float_type, order_2=order // 2
-                    )
-                )
-
-                # set of coordinate values within spline footprint along axis j
-                ops.append(f"""{int_t} ci_{j}[{order + 1}];""")
-                for k in range(order + 1):
-                    ixvar = f"ci_{j}[{k}]"
+                elif j in spatial_axes:
+                    # spatial axes already have weights/indices computed, just add the loop
                     ops.append(
                         f"""
-                    {ixvar} = start + {k};"""
-                    )
-                    ops.append(
-                        _util._generate_boundary_condition_ops(
-                            spline_mode, ixvar, f"xsize_{j}", int_t
-                        )
+            W w_{j};
+            {int_t} ic_{j};
+            for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
+                {{
+                    w_{j} = weights_{j}[k_{j}];
+                    ic_{j} = ci_{j}[k_{j}] * sx_{j};
+            """
                     )
 
-                # loop over the order + 1 values in the spline filter
-                ops.append(
-                    f"""
-                W w_{j};
-                {int_t} ic_{j};
-                for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
-                    {{
-                        w_{j} = weights_{j}[k_{j}];
-                        ic_{j} = ci_{j}[k_{j}] * sx_{j};
-                """
-                )
-
-    if order > 0:
+    # Final accumulation and output (for non-looped cases and order > 0)
+    if order > 0 and not (loop_batch_axis and order >= 1):
         _weight = " * ".join([f"w_{j}" for j in range(ndim)])
         _coord_idx = " + ".join([f"ic_{j}" for j in range(ndim)])
         if mode == "grid-constant" or (order > 1 and mode == "constant"):
@@ -773,14 +1160,14 @@ def _generate_interp_custom(
             if ({_cond}) {{
                 out += {cval} * ({internal_dtype})({_weight});
             }} else {{
-                {internal_dtype} val = ({internal_dtype})x[{_coord_idx}];
+                {internal_dtype} val = ({internal_dtype})x_ptr[{_coord_idx}];
                 out += val * ({internal_dtype})({_weight});
             }}"""
             )
         else:
             ops.append(
                 f"""
-            {internal_dtype} val = ({internal_dtype})x[{_coord_idx}];
+            {internal_dtype} val = ({internal_dtype})x_ptr[{_coord_idx}];
             out += val * ({internal_dtype})({_weight});"""
             )
 
@@ -789,10 +1176,12 @@ def _generate_interp_custom(
     if mode == "constant":
         ops.append("}")
 
-    if integer_output:
-        ops.append(f"y = (Y)rint(({float_type})out);")
-    else:
-        ops.append("y = (Y)out;")
+    # Output writing (for non-looped cases - looped cases write inside their batch loops)
+    if not loop_batch_axis:
+        if integer_output:
+            ops.append(f"y = (Y)rint(({float_type})out);")
+        else:
+            ops.append("y = (Y)out;")
     operation = "\n".join(ops)
 
     mode_str = mode.replace("-", "_")  # avoid hyphen in kernel name
@@ -807,7 +1196,27 @@ def _generate_interp_custom(
         name += "_i64"
     if batch_axes:
         name += "_batch_" + "_".join([str(j) for j in sorted(batch_axes)])
+    if loop_batch_axis:
+        name += "_looped"
     return operation, name
+
+
+def use_loop_batch(batch_axes, ndim, yshape):
+    """Whether batch optimization over the final axis should be applied.
+
+    If the last axis (contiguous axis) is a batch axis, we can compute the
+    weights once and then loop over this axis in an inner loop.
+
+    Only enabled when there is at least one spatial axis (ndim > 1).
+
+    Empirically, restrict this optimization to batch size <= 12. Performance
+    degradation was observed at higher batch sizes.
+    """
+    return (
+        batch_axes == (ndim - 1,)
+        and ndim > 1
+        and yshape[-1] <= loop_batch_max_channels
+    )
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -824,7 +1233,17 @@ def _get_map_kernel(
     batch_axes=None,
 ):
     in_params = "raw X x, raw W coords"
-    out_params = "Y y"
+
+    # Optimize for contiguous batch axis at the end
+    # Only enable when there's at least one spatial axis (ndim > 1)
+    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    if loop_batch_axis:
+        out_params = "raw Y y"
+        size = math.prod(yshape[:-1])
+    else:
+        out_params = "Y y"
+        size = None
+
     # if there are batch axes, we need in_coord to be computed
     # (batch axes use in_coord[j] instead of reading from coords)
     omit_in_coord = not batch_axes
@@ -840,12 +1259,14 @@ def _get_map_kernel(
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
-        omit_in_coord=True,  # input image coordinates are not needed
+        omit_in_coord=omit_in_coord,
         batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
     )
-    return cupy.ElementwiseKernel(
+    kernel = cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
     )
+    return KernelInfo(kernel, size)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -862,7 +1283,17 @@ def _get_shift_kernel(
     batch_axes=None,
 ):
     in_params = "raw X x, raw W shift"
-    out_params = "Y y"
+
+    # Optimize for contiguous batch axis at the end
+    # Only enable when there's at least one spatial axis (ndim > 1)
+    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    if loop_batch_axis:
+        out_params = "raw Y y"
+        size = math.prod(yshape[:-1])
+    else:
+        out_params = "Y y"
+        size = None
+
     operation, name = _generate_interp_custom(
         coord_func=_get_coord_shift,
         ndim=ndim,
@@ -876,10 +1307,12 @@ def _get_shift_kernel(
         nprepad=nprepad,
         float_dtype=float_dtype,
         batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
     )
-    return cupy.ElementwiseKernel(
+    kernel = cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
     )
+    return KernelInfo(kernel, size)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -897,7 +1330,17 @@ def _get_zoom_shift_kernel(
     batch_axes=None,
 ):
     in_params = "raw X x, raw W shift, raw W zoom"
-    out_params = "Y y"
+
+    # Optimize for contiguous batch axis at the end
+    # Only enable when there's at least one spatial axis (ndim > 1)
+    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    if loop_batch_axis:
+        out_params = "raw Y y"
+        size = math.prod(yshape[:-1])
+    else:
+        out_params = "Y y"
+        size = None
+
     if grid_mode:
         zoom_shift_func = _get_coord_zoom_and_shift_grid
     else:
@@ -915,10 +1358,12 @@ def _get_zoom_shift_kernel(
         nprepad=nprepad,
         float_dtype=float_dtype,
         batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
     )
-    return cupy.ElementwiseKernel(
+    kernel = cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
     )
+    return KernelInfo(kernel, size)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -936,7 +1381,17 @@ def _get_zoom_kernel(
     batch_axes=None,
 ):
     in_params = "raw X x, raw W zoom"
-    out_params = "Y y"
+
+    # Optimize for contiguous batch axis at the end
+    # Only enable when there's at least one spatial axis (ndim > 1)
+    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    if loop_batch_axis:
+        out_params = "raw Y y"
+        size = math.prod(yshape[:-1])
+    else:
+        out_params = "Y y"
+        size = None
+
     operation, name = _generate_interp_custom(
         coord_func=_get_coord_zoom_grid if grid_mode else _get_coord_zoom,
         ndim=ndim,
@@ -950,10 +1405,12 @@ def _get_zoom_kernel(
         nprepad=nprepad,
         float_dtype=float_dtype,
         batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
     )
-    return cupy.ElementwiseKernel(
+    kernel = cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
     )
+    return KernelInfo(kernel, size)
 
 
 @cupy._util.memoize(for_each_device=True)
@@ -970,7 +1427,17 @@ def _get_affine_kernel(
     batch_axes=None,
 ):
     in_params = "raw X x, raw W mat"
-    out_params = "Y y"
+
+    # Optimize for contiguous batch axis at the end
+    # Only enable when there's at least one spatial axis (ndim > 1)
+    loop_batch_axis = use_loop_batch(batch_axes, ndim, yshape)
+    if loop_batch_axis:
+        out_params = "raw Y y"
+        size = math.prod(yshape[:-1])
+    else:
+        out_params = "Y y"
+        size = None
+
     operation, name = _generate_interp_custom(
         coord_func=_get_coord_affine,
         ndim=ndim,
@@ -984,7 +1451,9 @@ def _get_affine_kernel(
         nprepad=nprepad,
         float_dtype=float_dtype,
         batch_axes=batch_axes,
+        loop_batch_axis=loop_batch_axis,
     )
-    return cupy.ElementwiseKernel(
+    kernel = cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
     )
+    return KernelInfo(kernel, size)

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -22,229 +22,383 @@ math_constants_preamble = r"""
 spline_weights_inline = _spline_kernel_weights.spline_weights_inline
 
 
-def _get_coord_map(ndim, nprepad=0, float_type=None):
+def _get_coord_map(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Extract target coordinate from coords array (for map_coordinates).
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which the coordinates
+            represent an identity mapping (i.e., output index equals input
+            coordinate). For these axes, interpolation is skipped and the
+            coordinate values in the ``coordinates`` array are ignored.
+            This improves performance when only a subset of dimensions
+            require interpolation.
 
-        coords (ndarray): array of shape (ncoords, ndim) containing the target
-            coordinates.
-        c_j: variables to hold the target coordinates
-        float_type: string or None
-            Unused by this function, but required because all `coord_func`
-            passed to `_generate_interp_custom` have to support the same
-            function signature.
+    Note:
 
-    computes::
+        Assumes the following variables have been initialized on the device::
 
-        c_j = coords[i + j * ncoords];
+            coords (ndarray): array of shape (ncoords, ndim) containing the
+                target coordinates.
+            c_j: variables to hold the target coordinates
 
-    ncoords is determined by the size of the output array, y.
-    y will be indexed by the CIndexer, _ind.
-    Thus ncoords = _ind.size();
+        computes::
+
+            c_j = coords[i + j * ncoords];
+
+        ncoords is determined by the size of the output array, y.
+        y will be indexed by the CIndexer, _ind.
+        Thus ncoords = _ind.size();
+
+        For batch axes (identity mapping), the output index is used directly:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
-    ops.append("ptrdiff_t ncoords = _ind.size();")
+    # only need ncoords if there are non-batch axes
+    if len(batch_axes) < ndim:
+        ops.append("ptrdiff_t ncoords = _ind.size();")
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(
-            f"""
+        if j in batch_axes:
+            # batch axis: use identity (output index = input coordinate)
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = coords[i + {j} * ncoords]{pre};"""
-        )
+            )
     return ops
 
 
-def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None):
+def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the center of the edge pixels.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which zoom == 1 and there is no
+            shift (no interpolation required).
 
-        in_coord[ndim]: array containing the source coordinate
-        zoom[ndim]: array containing the zoom for each axis
-        shift[ndim]: array containing the zoom for each axis
-        float_type: string or None
-            Unused by this function, but required because all `coord_func`
-            passed to `_generate_interp_custom` have to support the same
-            function signature.
+    Note:
 
-    computes::
+        Assumes the following variables have been initialized on the device::
 
-        c_j = zoom[j] * (in_coord[j] - shift[j])
+            in_coord[ndim]: array containing the source coordinate
+            zoom[ndim]: array containing the zoom for each axis
+            shift[ndim]: array containing the zoom for each axis
+
+        computes::
+
+            c_j = zoom[j] * (in_coord[j] - shift[j])
+
+        For batch axes (zoom == 1 and shift == 0), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(
-            f"""
+        if j in batch_axes:
+            # identity transform for batch axes
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[{j}]){pre};"""
-        )
+            )
     return ops
 
 
-def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None):
+def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the outer edges of the grid pixels.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which zoom == 1 and there is no
+            shift (no interpolation required).
 
-        in_coord[ndim]: array containing the source coordinate
-        zoom[ndim]: array containing the zoom for each axis
-        shift[ndim]: array containing the zoom for each axis
-        float_type: string.
-            The C++ floating point type used for floating point literals.
+    Note:
 
-    computes::
+        Assumes the following variables have been initialized on the device::
 
-        c_j = zoom[j] * (in_coord[j] - shift[j] + 0.5) - 0.5
+            in_coord[ndim]: array containing the source coordinate
+            zoom[ndim]: array containing the zoom for each axis
+            shift[ndim]: array containing the shift for each axis
+
+        computes::
+
+            c_j = zoom[j] * (in_coord[j] - shift[j] + 0.5) - 0.5
+
+        For batch axes (zoom == 1 and shift == 0), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(
-            f"""
+        if j in batch_axes:
+            # identity transform for batch axes
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + ({float_type})0.5)
               - (W)0.5{pre};"""
-        )
+            )
     return ops
 
 
-def _get_coord_zoom(ndim, nprepad=0, float_type=None):
+def _get_coord_zoom(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Compute target coordinate based on a zoom.
 
     This version zooms from the center of the edge pixels.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which zoom == 1 (no interpolation
+            required).
 
-        in_coord[ndim]: array containing the source coordinate
-        zoom[ndim]: array containing the zoom for each axis
-        float_type: string or None
-            Unused by this function, but required because all `coord_func`
-            passed to `_generate_interp_custom` have to support the same
-            function signature.
+    Note:
 
-    computes::
+        Assumes the following variables have been initialized on the device::
 
-        c_j = zoom[j] * in_coord[j]
+            in_coord[ndim]: array containing the source coordinate
+            zoom[ndim]: array containing the zoom for each axis
+            float_type: string or None
+                Unused by this function, but required because all `coord_func`
+                passed to `_generate_interp_custom` have to support the same
+                function signature.
+
+        computes::
+
+            c_j = zoom[j] * in_coord[j]
+
+        For batch axes (zoom == 1), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(
-            f"""
+        if j in batch_axes:
+            # identity transform for batch axes
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = zoom[{j}] * (W)in_coord[{j}]{pre};"""
-        )
+            )
     return ops
 
 
-def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double"):
+def _get_coord_zoom_grid(ndim, nprepad=0, float_type="double", batch_axes=None):
     """Compute target coordinate based on a zoom (grid_mode=True version).
 
     This version zooms from the outer edges of the grid pixels.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which zoom == 1 (no interpolation
+            required).
 
-        in_coord[ndim]: array containing the source coordinate
-        zoom[ndim]: array containing the zoom for each axis
-        float_type: string
-            The C++ floating point type used for floating point literals.
+    Note:
+        Assumes the following variables have been initialized on the device::
 
-    computes::
+            in_coord[ndim]: array containing the source coordinate
+            zoom[ndim]: array containing the zoom for each axis
+            float_type: string
+                The C++ floating point type used for floating point literals.
 
-        c_j = zoom[j] * (in_coord[j] + 0.5) - 0.5
+        computes::
+
+            c_j = zoom[j] * (in_coord[j] + 0.5) - 0.5
+
+        For batch axes (zoom == 1), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(f"""
+        if j in batch_axes:
+            # identity transform for batch axes
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + ({float_type})0.5)
-                           - ({float_type})0.5{pre};""")
+                           - ({float_type})0.5{pre};"""
+            )
     return ops
 
 
-def _get_coord_shift(ndim, nprepad=0, float_type=None):
+def _get_coord_shift(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Compute target coordinate based on a shift.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which there is no shift.
 
-        in_coord[ndim]: array containing the source coordinate
-        shift[ndim]: array containing the zoom for each axis
-        float_type: string or None
-            Unused by this function, but required because all `coord_func`
-            passed to `_generate_interp_custom` have to support the same
-            function signature.
+    Note:
+        Assumes the following variables have been initialized on the device::
 
-    computes::
+            in_coord[ndim]: array containing the source coordinate
+            shift[ndim]: array containing the shift for each axis
 
-        c_j = in_coord[j] - shift[j]
+        computes::
+
+            c_j = in_coord[j] - shift[j]
+
+        For batch axes (shift == 0), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     for j in range(ndim):
-        ops.append(
-            f"""
+        if j in batch_axes:
+            # identity transform for batch axes
+            ops.append(
+                f"""
+    W c_{j} = (W)in_coord[{j}]{pre};"""
+            )
+        else:
+            ops.append(
+                f"""
     W c_{j} = (W)in_coord[{j}] - shift[{j}]{pre};"""
-        )
+            )
     return ops
 
 
-def _get_coord_affine(ndim, nprepad=0, float_type=None):
+def _get_coord_affine(ndim, nprepad=0, float_type=None, batch_axes=None):
     """Compute target coordinate based on a homogeneous transformation matrix.
 
     The homogeneous matrix has shape (ndim, ndim + 1). It corresponds to
     affine matrix where the last row of the affine is assumed to be:
     ``[0] * ndim + [1]``.
 
-    Notes
-    -----
-    Assumes the following variables have been initialized on the device::
+    Args:
+        ndim (int): number of image dimensions
+        nprepad (int): Amount of boundary padding used during the (optional)
+            spline prefiltering step.
+        float_type (string or None): Unused by this function, but required
+            because all `coord_func` passed to `_generate_interp_custom` have
+            to support the same function signature.
+        batch_axes (tuple of int): Axes along which the coordinates
+            represent an identity mapping (i.e., output index equals input
+            coordinate). For these axes, interpolation is skipped. This
+            improves performance when only a subset of dimensions require
+            interpolation.
 
-        mat(array): array containing the (ndim, ndim + 1) transform matrix.
-        in_coords(array): coordinates of the input
+    Note:
+        Assumes the following variables have been initialized on the device::
 
-    For example, in 2D:
+            mat(array): array containing the (ndim, ndim + 1) transform matrix.
+            in_coords(array): coordinates of the input
 
-        c_0 = mat[0] * in_coords[0] + mat[1] * in_coords[1] + aff[2];
-        c_1 = mat[3] * in_coords[0] + mat[4] * in_coords[1] + aff[5];
+        For example, in 2D:
+
+            c_0 = mat[0] * in_coords[0] + mat[1] * in_coords[1] + aff[2];
+            c_1 = mat[3] * in_coords[0] + mat[4] * in_coords[1] + aff[5];
+
+        For batch axes (identity row with zero offset), the identity is used:
+
+            c_j = in_coord[j]
 
     """
+    if batch_axes is None:
+        batch_axes = ()
     ops = []
     pre = f" + (W){nprepad}" if nprepad > 0 else ""
     ncol = ndim + 1
     for j in range(ndim):
-        ops.append(
-            f"""
-            W c_{j} = (W)0.0;"""
-        )
-        for k in range(ndim):
+        if j in batch_axes:
+            # identity transform for batch axes
             ops.append(
                 f"""
-            c_{j} += mat[{ncol * j + k}] * (W)in_coord[{k}];"""
+            W c_{j} = (W)in_coord[{j}]{pre};"""
             )
-        ops.append(
-            f"""
+        else:
+            ops.append(
+                f"""
+            W c_{j} = (W)0.0;"""
+            )
+            for k in range(ndim):
+                ops.append(
+                    f"""
+            c_{j} += mat[{ncol * j + k}] * (W)in_coord[{k}];"""
+                )
+            ops.append(
+                f"""
             c_{j} += mat[{ncol * j + ndim}]{pre};"""
-        )
+            )
     return ops
 
 
@@ -287,6 +441,7 @@ def _generate_interp_custom(
     nprepad=0,
     float_dtype=cupy.float64,
     omit_in_coord=False,
+    batch_axes=None,
 ):
     """
     Args:
@@ -308,11 +463,17 @@ def _generate_interp_custom(
         omit_in_coord (bool): omit computation of unraveled input coordinates
             when not needed. This is an optimization for use by
             ``map_coordinates`` where the coordinates are already known.
+        batch_axes (tuple or None): tuple of axis indices that are "batch"
+            dimensions where no interpolation is needed (zoom == 1 and
+            shift == 0). For these axes, the identity transform is used and
+            interpolation is skipped.
 
     Returns:
         operation (str): code body for the ElementwiseKernel
         name (str): name for the ElementwiseKernel
     """
+    if batch_axes is None:
+        batch_axes = ()
 
     ops = []
     float_type = cupy._core._scalar.get_typename(float_dtype)
@@ -338,7 +499,8 @@ def _generate_interp_custom(
         ops.append(_unravel_loop_index(yshape, uint_t))
 
     # compute the transformed (target) coordinates, c_j
-    ops = ops + coord_func(ndim, nprepad, float_type)
+    # coord_func uses identity transform for any batch (untransformed) axes
+    ops = ops + coord_func(ndim, nprepad, float_type=float_type, batch_axes=batch_axes)
 
     if cval is numpy.nan:
         cval = "(Y)CUDART_NAN"
@@ -370,43 +532,52 @@ def _generate_interp_custom(
                 f"{float_type} dcoord;"
             )  # mode 'wrap' requires this to work
         for j in range(ndim):
-            # determine nearest neighbor
-            if mode == "wrap":
+            if j in batch_axes:
+                # batch axis: use identity, no interpolation needed
                 ops.append(
                     f"""
-                dcoord = c_{j};"""
+            {int_t} cf_{j} = ({int_t})in_coord[{j}];
+            {int_t} ic_{j} = cf_{j} * sx_{j};"""
                 )
             else:
-                ops.append(
-                    f"""{int_t} cf_{j} = (
-                            {int_t})floor(({float_type})c_{j}
-                                          + ({float_type})0.5);"""
-                )
-
-            # handle boundary
-            if mode != "constant":
-                if mode == "wrap":
-                    ixvar = "dcoord"
-                    float_ix = True
-                else:
-                    ixvar = f"cf_{j}"
-                    float_ix = False
-                ops.append(
-                    _util._generate_boundary_condition_ops(
-                        mode, ixvar, f"xsize_{j}", int_t, float_ix
-                    )
-                )
+                # determine nearest neighbor
                 if mode == "wrap":
                     ops.append(
                         f"""
-                {int_t} cf_{j} = ({int_t})floor(dcoord + ({float_type})0.5);"""
+                    dcoord = c_{j};"""
+                    )
+                else:
+                    ops.append(
+                    f"""{int_t} cf_{j} = (
+                            {int_t})floor(({float_type})c_{j}
+                                          + ({float_type})0.5);"""
                     )
 
-            # sum over ic_j will give the raveled coordinate in the input
-            ops.append(
-                f"""
-            {int_t} ic_{j} = cf_{j} * sx_{j};"""
-            )
+                # handle boundary
+                if mode != "constant":
+                    if mode == "wrap":
+                        ixvar = "dcoord"
+                        float_ix = True
+                    else:
+                        ixvar = f"cf_{j}"
+                        float_ix = False
+                    ops.append(
+                        _util._generate_boundary_condition_ops(
+                            mode, ixvar, f"xsize_{j}", int_t, float_ix
+                        )
+                    )
+                    if mode == "wrap":
+                        ops.append(
+                            f"""
+                    {int_t} cf_{j} = ({int_t})floor(dcoord
+                                      + ({float_type})0.5);"""
+                        )
+
+                # sum over ic_j will give the raveled coordinate in the input
+                ops.append(
+                    f"""
+                {int_t} ic_{j} = cf_{j} * sx_{j};"""
+                )
         _coord_idx = " + ".join([f"ic_{j}" for j in range(ndim)])
         if mode == "grid-constant":
             _cond = " || ".join([f"(ic_{j} < 0)" for j in range(ndim)])
@@ -426,73 +597,83 @@ def _generate_interp_custom(
 
     elif order == 1:
         for j in range(ndim):
-            # get coordinates for linear interpolation along axis j
-            ops.append(
-                f"""
-            {int_t} cf_{j} = ({int_t})floor(({float_type})c_{j});
-            {int_t} cc_{j} = cf_{j} + 1;
-            {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
-            """
-            )
-
-            if mode == "wrap":
+            if j in batch_axes:
+                # batch axis: use identity, no interpolation needed
+                # just set w_{j} = 1.0 and ic_{j} = in_coord[{j}] * sx_{j}
                 ops.append(
                     f"""
-                {float_type} dcoordf = c_{j};
-                {float_type} dcoordc = c_{j} + 1;"""
+            W w_{j} = (W)1.0;
+            {int_t} ic_{j} = (({int_t})in_coord[{j}]) * sx_{j};
+            {{  // dummy scope for batch axis {j}"""
                 )
             else:
-                # handle boundaries for extension modes.
+                # get coordinates for linear interpolation along axis j
                 ops.append(
                     f"""
-                {int_t} cf_bounded_{j} = cf_{j};
-                {int_t} cc_bounded_{j} = cc_{j};"""
+                {int_t} cf_{j} = ({int_t})floor((double)c_{j});
+                {int_t} cc_{j} = cf_{j} + 1;
+                {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
+                """
                 )
 
-            if mode != "constant":
-                if mode == "wrap":
-                    ixvar = "dcoordf"
-                    float_ix = True
-                else:
-                    ixvar = f"cf_bounded_{j}"
-                    float_ix = False
-                ops.append(
-                    _util._generate_boundary_condition_ops(
-                        mode, ixvar, f"xsize_{j}", int_t, float_ix
-                    )
-                )
-
-                ixvar = "dcoordc" if mode == "wrap" else f"cc_bounded_{j}"
-                ops.append(
-                    _util._generate_boundary_condition_ops(
-                        mode, ixvar, f"xsize_{j}", int_t, float_ix
-                    )
-                )
                 if mode == "wrap":
                     ops.append(
                         f"""
-                    {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);
-                    {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf
-                                              + ({float_type})1.0);
-                    """
+                    {float_type} dcoordf = c_{j};
+                    {float_type} dcoordc = c_{j} + ({float_type})1.0;"""
+                    )
+                else:
+                    # handle boundaries for extension modes.
+                    ops.append(
+                        f"""
+                    {int_t} cf_bounded_{j} = cf_{j};
+                    {int_t} cc_bounded_{j} = cc_{j};"""
                     )
 
-            ops.append(
-                f"""
-            for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
-                {{
-                    W w_{j};
-                    {int_t} ic_{j};
-                    if (s_{j} == 0)
+                if mode != "constant":
+                    if mode == "wrap":
+                        ixvar = "dcoordf"
+                        float_ix = True
+                    else:
+                        ixvar = f"cf_bounded_{j}"
+                        float_ix = False
+                    ops.append(
+                        _util._generate_boundary_condition_ops(
+                            mode, ixvar, f"xsize_{j}", int_t, float_ix
+                        )
+                    )
+
+                    ixvar = "dcoordc" if mode == "wrap" else f"cc_bounded_{j}"
+                    ops.append(
+                        _util._generate_boundary_condition_ops(
+                            mode, ixvar, f"xsize_{j}", int_t, float_ix
+                        )
+                    )
+                    if mode == "wrap":
+                        ops.append(
+                            f"""
+                        {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);;
+                        {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf
+                                                  + ({float_type})1.0);;
+                        """
+                        )
+
+                ops.append(
+                    f"""
+                for (int s_{j} = 0; s_{j} < n_{j}; s_{j}++)
                     {{
-                        w_{j} = (W)cc_{j} - c_{j};
-                        ic_{j} = cf_bounded_{j} * sx_{j};
-                    }} else
-                    {{
-                        w_{j} = c_{j} - (W)cf_{j};
-                        ic_{j} = cc_bounded_{j} * sx_{j};
-                    }}"""
-            )
+                        W w_{j};
+                        {int_t} ic_{j};
+                        if (s_{j} == 0)
+                        {{
+                            w_{j} = (W)cc_{j} - c_{j};
+                            ic_{j} = cf_bounded_{j} * sx_{j};
+                        }} else
+                        {{
+                            w_{j} = c_{j} - (W)cf_{j};
+                            ic_{j} = cc_bounded_{j} * sx_{j};
+                        }}"""
+                )
     elif order > 1:
         if mode == "grid-constant":
             spline_mode = "constant"
@@ -502,78 +683,85 @@ def _generate_interp_custom(
             spline_mode = _spline_prefilter_core._get_spline_mode(mode)
 
         # wx, wy are temporary variables used during spline weight computation
-        ops.append(
-            f"""
+        # (only needed for non-batch axes)
+        non_batch_axes = [j for j in range(ndim) if j not in batch_axes]
+        if non_batch_axes:
+            ops.append(
+                f"""
             W wx, wy;
             {int_t} start;"""
-        )
+            )
         for j in range(ndim):
-            # determine weights along the current axis
-            ops.append(
-                f"""
-            W weights_{j}[{order + 1}];"""
-            )
-            ops.append(
-                spline_weights_inline[order].format(
-                    j=j,
-                    order=order,
-                    F=float_type,
-                )
-            )
-
-            # get starting coordinate for spline interpolation along axis j
-            if mode in ["wrap"]:
-                ops.append(f"{float_type} dcoord = c_{j};")
-                coord_var = "dcoord"
-                ops.append(
-                    _util._generate_boundary_condition_ops(
-                        mode, coord_var, f"xsize_{j}", int_t, True
-                    )
-                )
-            else:
-                coord_var = f"({float_type})c_{j}"
-
-            if order & 1:
-                op_str = """
-                start = ({int_t})floor({coord_var}) - {order_2};"""
-            else:
-                op_str = """
-                start = ({int_t})floor(
-                    {coord_var} + ({float_type})0.5) - {order_2};"""
-            ops.append(
-                op_str.format(
-                    int_t=int_t,
-                    float_type=float_type,
-                    coord_var=coord_var,
-                    order_2=order // 2,
-                )
-            )
-
-            # set of coordinate values within spline footprint along axis j
-            ops.append(f"""{int_t} ci_{j}[{order + 1}];""")
-            for k in range(order + 1):
-                ixvar = f"ci_{j}[{k}]"
+            if j in batch_axes:
+                # batch axis: use identity, no interpolation needed
+                # just set w_{j} = 1.0 and ic_{j} = in_coord[{j}] * sx_{j}
                 ops.append(
                     f"""
-                {ixvar} = start + {k};"""
+            W w_{j} = (W)1.0;
+            {int_t} ic_{j} = (({int_t})in_coord[{j}]) * sx_{j};
+            {{  // dummy scope for batch axis {j}"""
+                )
+            else:
+                # determine weights along the current axis
+                ops.append(
+                    f"""
+                W weights_{j}[{order + 1}];"""
                 )
                 ops.append(
-                    _util._generate_boundary_condition_ops(
-                        spline_mode, ixvar, f"xsize_{j}", int_t
+                    spline_weights_inline[order].format(j=j, order=order)
+                )
+
+                # get starting coordinate for spline interpolation along axis j
+                if mode in ["wrap"]:
+                    ops.append(f"{float_type} dcoord = c_{j};")
+                    coord_var = "dcoord"
+                    ops.append(
+                        _util._generate_boundary_condition_ops(
+                            mode, coord_var, f"xsize_{j}", int_t, True
+                        )
+                    )
+                else:
+                    coord_var = f"({float_type})c_{j}"
+
+                if order & 1:
+                    op_str = """
+                    start = ({int_t})floor({coord_var}) - {order_2};"""
+                else:
+                    op_str = """
+                    start = ({int_t})floor(
+                        {coord_var} + ({float_type})0.5) - {order_2};"""
+                ops.append(
+                    op_str.format(
+                        int_t=int_t, coord_var=coord_var,
+                        float_type=float_type, order_2=order // 2
                     )
                 )
 
-            # loop over the order + 1 values in the spline filter
-            ops.append(
-                f"""
-            W w_{j};
-            {int_t} ic_{j};
-            for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
-                {{
-                    w_{j} = weights_{j}[k_{j}];
-                    ic_{j} = ci_{j}[k_{j}] * sx_{j};
-            """
-            )
+                # set of coordinate values within spline footprint along axis j
+                ops.append(f"""{int_t} ci_{j}[{order + 1}];""")
+                for k in range(order + 1):
+                    ixvar = f"ci_{j}[{k}]"
+                    ops.append(
+                        f"""
+                    {ixvar} = start + {k};"""
+                    )
+                    ops.append(
+                        _util._generate_boundary_condition_ops(
+                            spline_mode, ixvar, f"xsize_{j}", int_t
+                        )
+                    )
+
+                # loop over the order + 1 values in the spline filter
+                ops.append(
+                    f"""
+                W w_{j};
+                {int_t} ic_{j};
+                for (int k_{j} = 0; k_{j} <= {order}; k_{j}++)
+                    {{
+                        w_{j} = weights_{j}[k_{j}];
+                        ic_{j} = ci_{j}[k_{j}] * sx_{j};
+                """
+                )
 
     if order > 0:
         _weight = " * ".join([f"w_{j}" for j in range(ndim)])
@@ -617,6 +805,8 @@ def _generate_interp_custom(
     )
     if uint_t == "size_t":
         name += "_i64"
+    if batch_axes:
+        name += "_batch_" + "_".join([str(j) for j in sorted(batch_axes)])
     return operation, name
 
 
@@ -631,9 +821,13 @@ def _get_map_kernel(
     integer_output=False,
     nprepad=0,
     float_dtype=cupy.double,
+    batch_axes=None,
 ):
     in_params = "raw X x, raw W coords"
     out_params = "Y y"
+    # if there are batch axes, we need in_coord to be computed
+    # (batch axes use in_coord[j] instead of reading from coords)
+    omit_in_coord = not batch_axes
     operation, name = _generate_interp_custom(
         coord_func=_get_coord_map,
         ndim=ndim,
@@ -647,6 +841,7 @@ def _get_map_kernel(
         nprepad=nprepad,
         float_dtype=float_dtype,
         omit_in_coord=True,  # input image coordinates are not needed
+        batch_axes=batch_axes,
     )
     return cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
@@ -664,6 +859,7 @@ def _get_shift_kernel(
     integer_output=False,
     nprepad=0,
     float_dtype=cupy.double,
+    batch_axes=None,
 ):
     in_params = "raw X x, raw W shift"
     out_params = "Y y"
@@ -679,6 +875,7 @@ def _get_shift_kernel(
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
+        batch_axes=batch_axes,
     )
     return cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
@@ -697,6 +894,7 @@ def _get_zoom_shift_kernel(
     grid_mode=False,
     nprepad=0,
     float_dtype=cupy.double,
+    batch_axes=None,
 ):
     in_params = "raw X x, raw W shift, raw W zoom"
     out_params = "Y y"
@@ -716,6 +914,7 @@ def _get_zoom_shift_kernel(
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
+        batch_axes=batch_axes,
     )
     return cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
@@ -734,6 +933,7 @@ def _get_zoom_kernel(
     grid_mode=False,
     nprepad=0,
     float_dtype=cupy.double,
+    batch_axes=None,
 ):
     in_params = "raw X x, raw W zoom"
     out_params = "Y y"
@@ -749,6 +949,7 @@ def _get_zoom_kernel(
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
+        batch_axes=batch_axes,
     )
     return cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble
@@ -766,6 +967,7 @@ def _get_affine_kernel(
     integer_output=False,
     nprepad=0,
     float_dtype=cupy.double,
+    batch_axes=None,
 ):
     in_params = "raw X x, raw W mat"
     out_params = "Y y"
@@ -781,6 +983,7 @@ def _get_affine_kernel(
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
+        batch_axes=batch_axes,
     )
     return cupy.ElementwiseKernel(
         in_params, out_params, operation, name, preamble=math_constants_preamble

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interp_kernels.py
@@ -52,9 +52,10 @@ def _get_coord_map(
         batch_axes (tuple of int): Axes along which the coordinates
             represent an identity mapping (i.e., output index equals input
             coordinate). For these axes, interpolation is skipped and the
-            coordinate values in the ``coordinates`` array are ignored.
-            This improves performance when only a subset of dimensions
-            require interpolation.
+            coordinate values in the ``coordinates`` array are ignored. The
+            same spatial coordinate map is applied to every element along
+            these axes, so coordinate planes for non-batch axes must be
+            invariant along each batch axis.
         loop_batch_axis (bool): If True, the last axis is a contiguous batch
             axis and the kernel will loop over it internally. This requires
             using raw output and reduces kernel launch overhead.
@@ -451,9 +452,9 @@ def _get_coord_affine(
             to support the same function signature.
         batch_axes (tuple of int): Axes along which the coordinates
             represent an identity mapping (i.e., output index equals input
-            coordinate). For these axes, interpolation is skipped. This
-            improves performance when only a subset of dimensions require
-            interpolation.
+            coordinate) and no non-batch coordinate depends on that axis. For
+            these axes, interpolation is skipped. This improves performance
+            when only a subset of dimensions require interpolation.
         loop_batch_axis (bool): If True, the last axis is a contiguous batch
             axis and the kernel will loop over it internally. This requires
             using raw output and reduces kernel launch overhead.

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -46,6 +46,10 @@ def _check_parameter(func_name, order, mode):
         raise ValueError(f"boundary mode ({mode}) is not supported")
 
 
+def _output_axis_matches_input(input_shape, output_shape, axis):
+    return output_shape[axis] == input_shape[axis]
+
+
 def _get_spline_output(input, output):
     """Create workspace array, temp, and the final dtype for the output.
 
@@ -557,10 +561,17 @@ def affine_transform(
     matrix = matrix.astype(float_dtype, copy=False)
     if matrix.ndim == 1:
         # identify batch axes where zoom == 1 and shift == 0
-        # (no interpolation needed)
+        # (no interpolation needed). The direct batch-indexing kernel path
+        # bypasses boundary handling and assumes a preserved batch extent.
         matrix_host = cupy.asnumpy(matrix)
         batch_axes = tuple(
-            j for j in range(ndim) if matrix_host[j] == 1.0 and offset[j] == 0.0
+            j
+            for j in range(ndim)
+            if (
+                matrix_host[j] == 1.0
+                and offset[j] == 0.0
+                and _output_axis_matches_input(input.shape, output_shape, j)
+            )
         )
 
         filtered, nprepad = _filter_input(
@@ -590,6 +601,8 @@ def affine_transform(
     else:
         # identify batch axes where the row is an identity row with zero offset
         # i.e., matrix[j, j] == 1, matrix[j, k] == 0 for k != j, and offset[j] == 0
+        # The direct batch-indexing kernel path bypasses boundary handling and
+        # assumes a preserved batch extent.
         matrix_host = cupy.asnumpy(matrix)
         batch_axes = tuple(
             j
@@ -598,6 +611,7 @@ def affine_transform(
                 matrix_host[j, j] == 1.0
                 and all(matrix_host[j, k] == 0.0 for k in range(ndim) if k != j)
                 and offset[j] == 0.0
+                and _output_axis_matches_input(input.shape, output_shape, j)
             )
         )
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -649,7 +649,6 @@ def rotate(
     mode="constant",
     cval=0.0,
     prefilter=True,
-    float64_coords=False,
 ):
     """Rotate an array.
 
@@ -682,9 +681,6 @@ def rotate(
             slightly blurred if ``order > 1``, unless the input is prefiltered,
             i.e. it is the result of calling ``spline_filter`` on the original
             input.
-        float64_coords (bool): If True, always use double precision
-            internally like SciPy. When false, single precision floats and
-            8 or 16-bit integer types will use single precision internally.
 
     Returns:
         cupy.ndarray or None:
@@ -760,7 +756,7 @@ def rotate(
         mode,
         cval,
         prefilter,
-        float64_coords=float64_coords,
+        float64_coords=False,
     )
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -394,6 +394,7 @@ def map_coordinates(
         nprepad=nprepad,
         float_dtype=float_dtype,
         batch_axes=batch_axes,
+        output_c_contiguous=ret.flags.c_contiguous,
     )
     if kern_info.size is not None:
         kern_info.kernel(filtered, coordinates, ret, size=kern_info.size)
@@ -591,6 +592,7 @@ def affine_transform(
             nprepad=nprepad,
             float_dtype=float_dtype,
             batch_axes=batch_axes,
+            output_c_contiguous=output.flags.c_contiguous,
         )
         if kern_info.size is not None:
             kern_info.kernel(
@@ -630,6 +632,7 @@ def affine_transform(
             nprepad=nprepad,
             float_dtype=float_dtype,
             batch_axes=batch_axes,
+            output_c_contiguous=output.flags.c_contiguous,
         )
         m = cupy.zeros((ndim, ndim + 1), dtype=float_dtype)
         m[:, :-1] = matrix
@@ -865,6 +868,7 @@ def shift(
             nprepad=nprepad,
             float_dtype=float_dtype,
             batch_axes=batch_axes,
+            output_c_contiguous=output.flags.c_contiguous,
         )
         shift = cupy.asarray(shift, dtype=float_dtype, order="C")
         if shift.ndim != 1:
@@ -1027,6 +1031,7 @@ def zoom(
             nprepad=nprepad,
             float_dtype=float_dtype,
             batch_axes=batch_axes,
+            output_c_contiguous=output.flags.c_contiguous,
         )
         zoom = cupy.asarray(zoom, dtype=float_dtype)
         if kern_info.size is not None:

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -379,7 +379,7 @@ def map_coordinates(
     float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
     large_int = max(math.prod(input.shape), coordinates.shape[0]) > 1 << 31
 
-    kern = _interp_kernels._get_map_kernel(
+    kern_info = _interp_kernels._get_map_kernel(
         input.ndim,
         large_int,
         yshape=coordinates.shape[1:],
@@ -391,7 +391,10 @@ def map_coordinates(
         float_dtype=float_dtype,
         batch_axes=batch_axes,
     )
-    kern(filtered, coordinates, ret)
+    if kern_info.size is not None:
+        kern_info.kernel(filtered, coordinates, ret, size=kern_info.size)
+    else:
+        kern_info.kernel(filtered, coordinates, ret)
     return ret
 
 
@@ -465,8 +468,9 @@ def affine_transform(
             - ``order=0`` (nearest neighbor) and ``order=1`` (linear
                 interpolation)
             - NVIDIA CUDA GPUs
-        float64_coords (bool): Force use of double-precision computations
-            regardless of input dtype.
+        float64_coords (bool): If True, always use double precision
+            internally like SciPy. When false, single precision floats and
+            8 or 16-bit integer types will use single precision internally.
 
     Returns:
         cupy.ndarray or None:
@@ -565,7 +569,7 @@ def affine_transform(
 
         offset = cupy.asarray(offset, dtype=float_dtype)
         offset = -offset / matrix
-        kern = _interp_kernels._get_zoom_shift_kernel(
+        kern_info = _interp_kernels._get_zoom_shift_kernel(
             ndim,
             large_int,
             output_shape,
@@ -577,7 +581,12 @@ def affine_transform(
             float_dtype=float_dtype,
             batch_axes=batch_axes,
         )
-        kern(filtered, offset, matrix, output)
+        if kern_info.size is not None:
+            kern_info.kernel(
+                filtered, offset, matrix, output, size=kern_info.size
+            )
+        else:
+            kern_info.kernel(filtered, offset, matrix, output)
     else:
         # identify batch axes where the row is an identity row with zero offset
         # i.e., matrix[j, j] == 1, matrix[j, k] == 0 for k != j, and offset[j] == 0
@@ -596,7 +605,7 @@ def affine_transform(
             input, prefilter, mode, cval, order, batch_axes=batch_axes
         )
 
-        kern = _interp_kernels._get_affine_kernel(
+        kern_info = _interp_kernels._get_affine_kernel(
             ndim,
             large_int,
             output_shape,
@@ -611,7 +620,10 @@ def affine_transform(
         m = cupy.zeros((ndim, ndim + 1), dtype=float_dtype)
         m[:, :-1] = matrix
         m[:, -1] = cupy.asarray(offset, dtype=float_dtype)
-        kern(filtered, m, output)
+        if kern_info.size is not None:
+            kern_info.kernel(filtered, m, output, size=kern_info.size)
+        else:
+            kern_info.kernel(filtered, m, output)
     return output
 
 
@@ -637,6 +649,7 @@ def rotate(
     mode="constant",
     cval=0.0,
     prefilter=True,
+    float64_coords=False,
 ):
     """Rotate an array.
 
@@ -669,6 +682,9 @@ def rotate(
             slightly blurred if ``order > 1``, unless the input is prefiltered,
             i.e. it is the result of calling ``spline_filter`` on the original
             input.
+        float64_coords (bool): If True, always use double precision
+            internally like SciPy. When false, single precision floats and
+            8 or 16-bit integer types will use single precision internally.
 
     Returns:
         cupy.ndarray or None:
@@ -700,7 +716,7 @@ def rotate(
     float_dtype = cupy.promote_types(input_arr.real.dtype, cupy.float32)
 
     # determine offsets and output shape as in scipy.ndimage.rotate
-    rot_matrix = numpy.array([[cos, sin], [-sin, cos]])
+    rot_matrix = numpy.array([[cos, sin], [-sin, cos]], dtype=float_dtype)
 
     img_shape = numpy.asarray(input_arr.shape)
     in_plane_shape = img_shape[axes]
@@ -722,7 +738,7 @@ def rotate(
     output_shape[axes] = out_plane_shape
     output_shape = tuple(output_shape)
 
-    matrix = numpy.identity(ndim)
+    matrix = numpy.identity(ndim, dtype=float_dtype)
     matrix[axes[0], axes[0]] = cos
     matrix[axes[0], axes[1]] = sin
     matrix[axes[1], axes[0]] = -sin
@@ -744,7 +760,7 @@ def rotate(
         mode,
         cval,
         prefilter,
-        float64_coords=False,
+        float64_coords=float64_coords,
     )
 
 
@@ -828,7 +844,7 @@ def shift(
             input, prefilter, mode, cval, order, batch_axes=batch_axes
         )
 
-        kern = _interp_kernels._get_shift_kernel(
+        kern_info = _interp_kernels._get_shift_kernel(
             input.ndim,
             large_int,
             input.shape,
@@ -845,7 +861,10 @@ def shift(
             raise ValueError("shift must be 1d")
         if shift.size != filtered.ndim:
             raise ValueError("len(shift) must equal input.ndim")
-        kern(filtered, shift, output)
+        if kern_info.size is not None:
+            kern_info.kernel(filtered, shift, output, size=kern_info.size)
+        else:
+            kern_info.kernel(filtered, shift, output)
     return output
 
 
@@ -987,7 +1006,7 @@ def zoom(
             input, prefilter, mode, cval, order, batch_axes=batch_axes
         )
 
-        kern = _interp_kernels._get_zoom_kernel(
+        kern_info = _interp_kernels._get_zoom_kernel(
             input.ndim,
             large_int,
             output_shape,
@@ -1000,5 +1019,8 @@ def zoom(
             batch_axes=batch_axes,
         )
         zoom = cupy.asarray(zoom, dtype=float_dtype)
-        kern(filtered, zoom, output)
+        if kern_info.size is not None:
+            kern_info.kernel(filtered, zoom, output, size=kern_info.size)
+        else:
+            kern_info.kernel(filtered, zoom, output)
     return output

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -344,9 +344,11 @@ def map_coordinates(
         batch_axes (tuple of int, optional): Axes along which the coordinates
             represent an identity mapping (i.e., output index equals input
             coordinate). For these axes, interpolation is skipped and the
-            coordinate values in the ``coordinates`` array are ignored.
-            This can improve performance when only a subset of dimensions
-            require interpolation.
+            coordinate values in the ``coordinates`` array are ignored. The
+            same spatial coordinate map is applied to every element along
+            these axes, so coordinate planes for non-batch axes must be
+            invariant along each batch axis. This can improve performance when
+            only a subset of dimensions require interpolation.
 
     Returns:
         cupy.ndarray:
@@ -602,7 +604,8 @@ def affine_transform(
             kern_info.kernel(filtered, offset, matrix, output)
     else:
         # identify batch axes where the row is an identity row with zero offset
-        # i.e., matrix[j, j] == 1, matrix[j, k] == 0 for k != j, and offset[j] == 0
+        # and no other row depends on this axis. Otherwise, the transform
+        # varies by batch element and the axis cannot be handled as batch.
         # The direct batch-indexing kernel path bypasses boundary handling and
         # assumes a preserved batch extent.
         matrix_host = cupy.asnumpy(matrix)
@@ -612,6 +615,7 @@ def affine_transform(
             if (
                 matrix_host[j, j] == 1.0
                 and all(matrix_host[j, k] == 0.0 for k in range(ndim) if k != j)
+                and all(matrix_host[k, j] == 0.0 for k in range(ndim) if k != j)
                 and offset[j] == 0.0
                 and _output_axis_matches_input(input.shape, output_shape, j)
             )

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -509,6 +509,7 @@ def affine_transform(
     integer_output = output.dtype.kind in "iu"
     _util._check_cval(mode, cval, integer_output)
     large_int = max(math.prod(input.shape), math.prod(output_shape)) > 1 << 31
+    matrix = matrix.astype(float_dtype, copy=False)
     if matrix.ndim == 1:
         offset = cupy.asarray(offset, dtype=float_dtype)
         offset = -offset / matrix

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -236,7 +236,7 @@ def _check_coordinates(coordinates, order, allow_float32=True):
     return coordinates
 
 
-def _prepad_for_spline_filter(input, mode, cval):
+def _prepad_for_spline_filter(input, mode, cval, batch_axes=None):
     if mode in ["nearest", "grid-constant"]:
         # these modes need padding to get accurate boundary values
         npad = 12  # empirical factor chosen by SciPy
@@ -244,14 +244,22 @@ def _prepad_for_spline_filter(input, mode, cval):
             kwargs = dict(mode="constant", constant_values=cval)
         else:
             kwargs = dict(mode="edge")
-        padded = cupy.pad(input, npad, **kwargs)
+        if batch_axes:
+            # Only pad non-batch axes
+            pad_width = [
+                (0, 0) if axis in batch_axes else (npad, npad)
+                for axis in range(input.ndim)
+            ]
+        else:
+            pad_width = npad
+        padded = cupy.pad(input, pad_width, **kwargs)
     else:
         npad = 0
         padded = input
     return padded, npad
 
 
-def _filter_input(image, prefilter, mode, cval, order):
+def _filter_input(image, prefilter, mode, cval, order, batch_axes=None):
     """Perform spline prefiltering when needed.
 
     Spline orders > 1 need a prefiltering stage to preserve resolution.
@@ -260,12 +268,29 @@ def _filter_input(image, prefilter, mode, cval, order):
     prepadding of the input with cupy.pad is used to maintain accuracy.
     ``npad`` is an integer corresponding to the amount of padding at each edge
     of the array.
+
+    Parameters
+    ----------
+    batch_axes : tuple of int, optional
+        Axes that should not be prefiltered (identity/batch dimensions).
     """
     if not prefilter or order < 2:
         return (cupy.ascontiguousarray(image), 0)
-    padded, npad = _prepad_for_spline_filter(image, mode, cval)
+    padded, npad = _prepad_for_spline_filter(image, mode, cval, batch_axes)
     float_dtype = cupy.promote_types(image.dtype, cupy.float32)
-    filtered = spline_filter(padded, order, output=float_dtype, mode=mode)
+
+    if batch_axes:
+        # Only filter along non-batch axes, following spline_filter's pattern
+        x = padded
+        temp = padded.astype(float_dtype, copy=True)
+        for axis in range(image.ndim):
+            if axis not in batch_axes:
+                spline_filter1d(x, order, axis, output=temp, mode=mode)
+                x = temp
+        filtered = temp
+    else:
+        filtered = spline_filter(padded, order, output=float_dtype, mode=mode)
+
     return cupy.ascontiguousarray(filtered), npad
 
 
@@ -277,6 +302,8 @@ def map_coordinates(
     mode="constant",
     cval=0.0,
     prefilter=True,
+    *,
+    batch_axes=None,
 ):
     """Map the input array to new coordinates by interpolation.
 
@@ -310,6 +337,12 @@ def map_coordinates(
             slightly blurred if ``order > 1``, unless the input is prefiltered,
             i.e. it is the result of calling ``spline_filter`` on the original
             input.
+        batch_axes (tuple of int, optional): Axes along which the coordinates
+            represent an identity mapping (i.e., output index equals input
+            coordinate). For these axes, interpolation is skipped and the
+            coordinate values in the ``coordinates`` array are ignored.
+            This can improve performance when only a subset of dimensions
+            require interpolation.
 
     Returns:
         cupy.ndarray:
@@ -335,19 +368,28 @@ def map_coordinates(
     if input.dtype.kind in "iu":
         input = input.astype(cupy.float32)
     coordinates = _check_coordinates(coordinates, order)
-    filtered, nprepad = _filter_input(input, prefilter, mode, cval, order)
+
+    # convert batch_axes to tuple for hashing in memoized kernel getter
+    if batch_axes is not None:
+        batch_axes = tuple(batch_axes)
+
+    filtered, nprepad = _filter_input(
+        input, prefilter, mode, cval, order, batch_axes=batch_axes
+    )
     float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
     large_int = max(math.prod(input.shape), coordinates.shape[0]) > 1 << 31
+
     kern = _interp_kernels._get_map_kernel(
         input.ndim,
         large_int,
-        yshape=coordinates.shape,
+        yshape=coordinates.shape[1:],
         mode=mode,
         cval=cval,
         order=order,
         integer_output=integer_output,
         nprepad=nprepad,
         float_dtype=float_dtype,
+        batch_axes=batch_axes,
     )
     kern(filtered, coordinates, ret)
     return ret
@@ -504,13 +546,23 @@ def affine_transform(
     output = _util._get_output(output, input, shape=output_shape)
     if input.dtype.kind in "iu":
         input = input.astype(cupy.float32)
-    filtered, nprepad = _filter_input(input, prefilter, mode, cval, order)
 
     integer_output = output.dtype.kind in "iu"
     _util._check_cval(mode, cval, integer_output)
     large_int = max(math.prod(input.shape), math.prod(output_shape)) > 1 << 31
     matrix = matrix.astype(float_dtype, copy=False)
     if matrix.ndim == 1:
+        # identify batch axes where zoom == 1 and shift == 0
+        # (no interpolation needed)
+        matrix_host = cupy.asnumpy(matrix)
+        batch_axes = tuple(
+            j for j in range(ndim) if matrix_host[j] == 1.0 and offset[j] == 0.0
+        )
+
+        filtered, nprepad = _filter_input(
+            input, prefilter, mode, cval, order, batch_axes=batch_axes
+        )
+
         offset = cupy.asarray(offset, dtype=float_dtype)
         offset = -offset / matrix
         kern = _interp_kernels._get_zoom_shift_kernel(
@@ -523,9 +575,27 @@ def affine_transform(
             integer_output=integer_output,
             nprepad=nprepad,
             float_dtype=float_dtype,
+            batch_axes=batch_axes,
         )
         kern(filtered, offset, matrix, output)
     else:
+        # identify batch axes where the row is an identity row with zero offset
+        # i.e., matrix[j, j] == 1, matrix[j, k] == 0 for k != j, and offset[j] == 0
+        matrix_host = cupy.asnumpy(matrix)
+        batch_axes = tuple(
+            j
+            for j in range(ndim)
+            if (
+                matrix_host[j, j] == 1.0
+                and all(matrix_host[j, k] == 0.0 for k in range(ndim) if k != j)
+                and offset[j] == 0.0
+            )
+        )
+
+        filtered, nprepad = _filter_input(
+            input, prefilter, mode, cval, order, batch_axes=batch_axes
+        )
+
         kern = _interp_kernels._get_affine_kernel(
             ndim,
             large_int,
@@ -536,6 +606,7 @@ def affine_transform(
             integer_output=integer_output,
             nprepad=nprepad,
             float_dtype=float_dtype,
+            batch_axes=batch_axes,
         )
         m = cupy.zeros((ndim, ndim + 1), dtype=float_dtype)
         m[:, :-1] = matrix
@@ -745,11 +816,18 @@ def shift(
         output = _util._get_output(output, input)
         if input.dtype.kind in "iu":
             input = input.astype(cupy.float32)
-        filtered, nprepad = _filter_input(input, prefilter, mode, cval, order)
         integer_output = output.dtype.kind in "iu"
         _util._check_cval(mode, cval, integer_output)
         large_int = math.prod(input.shape) > 1 << 31
         float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
+
+        # identify batch axes where shift == 0 (no interpolation needed)
+        batch_axes = tuple(j for j, s in enumerate(shift) if s == 0)
+
+        filtered, nprepad = _filter_input(
+            input, prefilter, mode, cval, order, batch_axes=batch_axes
+        )
+
         kern = _interp_kernels._get_shift_kernel(
             input.ndim,
             large_int,
@@ -760,6 +838,7 @@ def shift(
             integer_output=integer_output,
             nprepad=nprepad,
             float_dtype=float_dtype,
+            batch_axes=batch_axes,
         )
         shift = cupy.asarray(shift, dtype=float_dtype, order="C")
         if shift.ndim != 1:
@@ -889,13 +968,25 @@ def zoom(
         output = _util._get_output(output, input, shape=output_shape)
         if input.dtype.kind in "iu":
             input = input.astype(cupy.float32)
-        filtered, nprepad = _filter_input(input, prefilter, mode, cval, order)
         integer_output = output.dtype.kind in "iu"
         _util._check_cval(mode, cval, integer_output)
         large_int = (
             max(math.prod(input.shape), math.prod(output_shape)) > 1 << 31
         )
         float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
+
+        # identify batch axes where zoom == 1 (no interpolation needed)
+        # this occurs when input_shape[j] == output_shape[j]
+        batch_axes = tuple(
+            j
+            for j, (in_s, out_s) in enumerate(zip(input.shape, output_shape))
+            if in_s == out_s
+        )
+
+        filtered, nprepad = _filter_input(
+            input, prefilter, mode, cval, order, batch_axes=batch_axes
+        )
+
         kern = _interp_kernels._get_zoom_kernel(
             input.ndim,
             large_int,
@@ -906,6 +997,7 @@ def zoom(
             grid_mode=grid_mode,
             nprepad=nprepad,
             float_dtype=float_dtype,
+            batch_axes=batch_axes,
         )
         zoom = cupy.asarray(zoom, dtype=float_dtype)
         kern(filtered, zoom, output)

--- a/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
+++ b/python/cucim/src/cucim/skimage/_vendored/_ndimage_interpolation.py
@@ -50,6 +50,20 @@ def _output_axis_matches_input(input_shape, output_shape, axis):
     return output_shape[axis] == input_shape[axis]
 
 
+def _normalize_batch_axes(batch_axes, ndim, input_shape, output_shape):
+    if batch_axes is None:
+        return None
+    batch_axes = tuple(_normalize_axis_index(axis, ndim) for axis in batch_axes)
+    if len(set(batch_axes)) != len(batch_axes):
+        raise ValueError("batch_axes must be unique")
+    for axis in batch_axes:
+        if not _output_axis_matches_input(input_shape, output_shape, axis):
+            raise ValueError(
+                "output shape must match input shape along batch_axes"
+            )
+    return batch_axes
+
+
 def _get_spline_output(input, output):
     """Create workspace array, temp, and the final dtype for the output.
 
@@ -375,9 +389,9 @@ def map_coordinates(
         input = input.astype(cupy.float32)
     coordinates = _check_coordinates(coordinates, order)
 
-    # convert batch_axes to tuple for hashing in memoized kernel getter
-    if batch_axes is not None:
-        batch_axes = tuple(batch_axes)
+    batch_axes = _normalize_batch_axes(
+        batch_axes, input.ndim, input.shape, ret.shape
+    )
 
     filtered, nprepad = _filter_input(
         input, prefilter, mode, cval, order, batch_axes=batch_axes

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -27,9 +27,10 @@ import pytest
 import cupy
 from cupy.cuda import runtime
 from cupy import testing
-import cupyx.scipy.ndimage
-from cupyx.scipy.ndimage import _util
-from cupyx.scipy.ndimage._interp_kernels import loop_batch_max_channels
+import cucim.skimage._vendored.ndimage as vendored_ndimage
+from cucim.skimage._vendored._ndimage_interp_kernels import (
+    loop_batch_max_channels,
+)
 
 try:
     import scipy
@@ -81,7 +82,7 @@ class TestRotateBatch:
 
     def _rotate(self, a, axes):
         """Compare against manually looping over batch axes."""
-        rotate = cupyx.scipy.ndimage.rotate
+        rotate = vendored_ndimage.rotate
         axes = tuple(ax % a.ndim for ax in axes)
         if a.ndim == 3 and len(axes) == 2 and 2 not in axes:
             # loop over last axis
@@ -232,7 +233,7 @@ class TestShiftBatch:
 
     def _shift(self, a, shift_val):
         """Compare against manually looping over axes where shift is 0."""
-        shift = cupyx.scipy.ndimage.shift
+        shift = vendored_ndimage.shift
         if len(shift_val) == 3 and shift_val[-1] == 0:
             # loop over last axis
             expected = cupy.stack(
@@ -375,7 +376,7 @@ class TestZoomBatch:
 
     def _zoom(self, a, zm):
         """Compare against manually looping over axes where zoom is 1."""
-        zoom = cupyx.scipy.ndimage.zoom
+        zoom = vendored_ndimage.zoom
         if a.ndim == 3 and zm[-1] == 1:
             # loop over last axis
             expected = cupy.stack(

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Infrastructure, Inc.
+# SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Networks, Inc.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extensions to CuPy's own test cases for new features in the vendored code.
+
+Follows the style of the following file in the CuPy repository:
+  tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+
+These additional tests verify new batch kernel launch functionality introduced
+in cuCIM's vendored ndimage interpolation code. These test cases verify that
+using batched kernels gives equivalent results to running multiple separate
+(non-batched) kernels in a loop.
+
+Note that results are NOT equivalent to SciPy in such cases as SciPy would also
+apply spline prefiltering along the batch axes. To get the same results with
+SciPy when prefilter=True, one would have to manually loop over the batched
+axes as done in the reference implementation here.
+"""
+
+from __future__ import annotations
+
+import numpy
+import pytest
+
+import cupy
+from cupy.cuda import runtime
+from cupy import testing
+import cupyx.scipy.ndimage
+from cupyx.scipy.ndimage import _util
+from cupyx.scipy.ndimage._interp_kernels import loop_batch_max_channels
+
+try:
+    import scipy
+    import scipy.ndimage
+
+    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
+except ImportError:
+    pass
+
+try:
+    import cv2
+except ImportError:
+    pass
+
+
+# testing these modes can only be tested against SciPy >= 1.6.0+
+scipy16_modes = ["wrap", "grid-wrap", "reflect", "grid-mirror", "grid-constant"]
+# these modes are okay to test on older SciPy
+legacy_modes = ["constant", "nearest", "mirror"]
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                "shape_and_axes": [
+                    # contiguous (last) axis as batch to test loop_batch_axis case
+                    ((48, 64, 4), (1, 0)),
+                    ((48, 64, loop_batch_max_channels + 1), (1, 0)),
+                    # first axis as batch
+                    ((8, 48, 64), (2, 1)),
+                    # both first and last axes as batch
+                    ((17, 48, 64, 3), (2, 1)),
+                ],
+                "angle": [-15],
+                "reshape": [False],
+                "output": [None],
+                "order": [0, 1, 3],
+                "mode": legacy_modes + scipy16_modes,
+                "cval": [1.0],
+                "prefilter": [False, True],
+            }
+        )
+    )
+)
+@testing.with_requires("scipy")
+class TestRotateBatch:
+    _multiprocess_can_split = True
+
+    def _rotate(self, a, axes):
+        """Compare against manually looping over batch axes."""
+        rotate = cupyx.scipy.ndimage.rotate
+        axes = tuple(ax % a.ndim for ax in axes)
+        if a.ndim == 3 and len(axes) == 2 and 2 not in axes:
+            # loop over last axis
+            expected = cupy.stack(
+                [
+                    rotate(
+                        a[..., i],
+                        self.angle,
+                        axes,
+                        self.reshape,
+                        None,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        elif a.ndim == 3 and len(axes) == 2 and 0 not in axes:
+            # loop over first axis
+            _axes = tuple(ax - 1 for ax in axes)
+            expected = cupy.stack(
+                [
+                    rotate(
+                        a[i, ...],
+                        self.angle,
+                        _axes,
+                        self.reshape,
+                        None,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[0])
+                ],
+                axis=0,
+            )
+        elif a.ndim == 4 and 0 not in axes and 3 not in axes:
+            # loop over first and last axes
+            _axes = tuple(ax - 1 for ax in axes)
+            expected = cupy.stack(
+                [
+                    cupy.stack(
+                        [
+                            rotate(
+                                a[i, ..., j],
+                                self.angle,
+                                _axes,
+                                self.reshape,
+                                None,
+                                self.order,
+                                self.mode,
+                                self.cval,
+                                self.prefilter,
+                            )
+                            for i in range(a.shape[0])
+                        ],
+                        axis=0,
+                    )
+                    for j in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        else:
+            raise ValueError("unsupported test case")
+        result = rotate(
+            a,
+            self.angle,
+            axes,
+            self.reshape,
+            None,
+            self.order,
+            self.mode,
+            self.cval,
+            self.prefilter,
+        )
+
+        # for integer output, allow ±1 due to rint() boundary
+        atol = 1 if numpy.dtype(a.dtype).kind in "iu" else 1e-5
+
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=atol)
+        return result
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_rotate_float(self, dtype):
+        shape, axes = self.shape_and_axes
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._rotate(a, axes)
+
+    @testing.for_complex_dtypes()
+    def test_rotate_complex_float(self, dtype):
+        shape, axes = self.shape_and_axes
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._rotate(a, axes)
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_rotate_fortran_order(self, dtype):
+        shape, axes = self.shape_and_axes
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        a = cupy.asfortranarray(a)
+        return self._rotate(a, axes)
+
+    @testing.for_int_dtypes(no_bool=True)
+    def test_rotate_int(self, dtype):
+        shape, axes = self.shape_and_axes
+
+        if numpy.lib.NumpyVersion(scipy.__version__) < "1.0.0":
+            if dtype in (numpy.dtype("l"), numpy.dtype("q")):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype("L"), numpy.dtype("Q")):
+                dtype = numpy.uint64
+
+        a = testing.shaped_random(shape, cupy, dtype)
+        return self._rotate(a, axes)
+
+
+@testing.parameterize(
+    *(
+        testing.product(
+            {
+                "shape_and_shift": [
+                    # Any axis with shift==0 is effectively a batch dimension.
+                    #
+                    # contiguous (last) axis as batch to test loop_batch_axis case
+                    ((48, 64, 4), (2, -3.2, 0)),
+                    ((48, 64, loop_batch_max_channels + 1), (2, -3.2, 0)),
+                    # first axis as batch
+                    ((8, 48, 64), (0, 2, -3.2)),
+                    # both first and last axes as batch
+                    ((17, 48, 64, 3), (0, 2, -3.2, 0)),
+                ],
+                "output": [None],
+                "order": [0, 1, 3],
+                "mode": legacy_modes + scipy16_modes,
+                "cval": [1.0],
+                "prefilter": [False, True],
+            }
+        )
+    )
+)
+class TestShiftBatch:
+    _multiprocess_can_split = True
+
+    def _shift(self, a, shift_val):
+        """Compare against manually looping over axes where shift is 0."""
+        shift = cupyx.scipy.ndimage.shift
+        if len(shift_val) == 3 and shift_val[-1] == 0:
+            # loop over last axis
+            expected = cupy.stack(
+                [
+                    shift(
+                        a[..., i],
+                        shift_val[:-1],
+                        self.output,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        elif len(shift_val) == 3 and shift_val[0] == 0:
+            # loop over first axis
+            expected = cupy.stack(
+                [
+                    shift(
+                        a[i, ...],
+                        shift_val[1:],
+                        self.output,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[0])
+                ],
+                axis=0,
+            )
+        elif len(shift_val) == 4 and shift_val[0] == 0 and shift_val[-1] == 0:
+            # loop over first and last axes
+            expected = cupy.stack(
+                [
+                    cupy.stack(
+                        [
+                            shift(
+                                a[i, ..., j],
+                                shift_val[1:-1],
+                                self.output,
+                                self.order,
+                                self.mode,
+                                self.cval,
+                                self.prefilter,
+                            )
+                            for i in range(a.shape[0])
+                        ],
+                        axis=0,
+                    )
+                    for j in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        result = shift(
+            a,
+            shift_val,
+            self.output,
+            self.order,
+            self.mode,
+            self.cval,
+            self.prefilter,
+        )
+
+        # for integer output, allow ±1 due to rint() boundary
+        atol = 1 if numpy.dtype(a.dtype).kind in "iu" else 1e-5
+
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=atol)
+        return result
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_shift_float(self, dtype):
+        shape, shift = self.shape_and_shift
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._shift(a, shift)
+
+    @testing.for_complex_dtypes()
+    def test_shift_complex_float(self, dtype):
+        shape, shift = self.shape_and_shift
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._shift(a, shift)
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_shift_fortran_order(self, dtype):
+        shape, shift = self.shape_and_shift
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        a = cupy.asfortranarray(a)
+        return self._shift(a, shift)
+
+    @testing.for_int_dtypes(no_bool=True)
+    def test_shift_int(self, dtype):
+        shape, shift = self.shape_and_shift
+
+        if self.mode == "constant" and not cupy.isfinite(self.cval):
+            if self.output is None or self.output == "empty":
+                # Non-finite cval with integer output array is not supported
+                # CuPy exception is tested in TestInterpolationInvalidCval
+                return cupy.asarray([])
+
+        if numpy.lib.NumpyVersion(scipy.__version__) < "1.0.0":
+            if dtype in (numpy.dtype("l"), numpy.dtype("q")):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype("L"), numpy.dtype("Q")):
+                dtype = numpy.uint64
+
+        a = testing.shaped_random(shape, cupy, dtype)
+        return self._shift(a, shift)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "shape_and_zoom": [
+                # Any axis with zoom == 1 is effectively a batch dimension.
+                #
+                # contiguous (last) axis as batch to test loop_batch_axis case
+                ((32, 64, 4), (2.2, 0.3, 1)),
+                ((32, 64, loop_batch_max_channels + 1), (2.2, 0.3, 1)),
+                # first axis as batch
+                ((8, 32, 64), (1, 2.2, 0.3)),
+                # both first and last axes as batch
+                ((17, 32, 64, 3), (1, 2.2, 0.3, 1)),
+            ],
+            "output": [None],
+            "order": [0, 1, 3],
+            "mode": legacy_modes + scipy16_modes,
+            "cval": [1.0],
+            "prefilter": [False, True],
+        }
+    )
+)
+@testing.with_requires("scipy")
+class TestZoomBatch:
+    _multiprocess_can_split = True
+
+    def _zoom(self, a, zm):
+        """Compare against manually looping over axes where zoom is 1."""
+        zoom = cupyx.scipy.ndimage.zoom
+        if a.ndim == 3 and zm[-1] == 1:
+            # loop over last axis
+            expected = cupy.stack(
+                [
+                    zoom(
+                        a[..., i],
+                        zm[:-1],
+                        self.output,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        elif a.ndim == 3 and zm[0] == 1:
+            # loop over first axis
+            expected = cupy.stack(
+                [
+                    zoom(
+                        a[i, ...],
+                        zm[1:],
+                        self.output,
+                        self.order,
+                        self.mode,
+                        self.cval,
+                        self.prefilter,
+                    )
+                    for i in range(a.shape[0])
+                ],
+                axis=0,
+            )
+        elif a.ndim == 4 and zm[0] == 1 and zm[-1] == 1:
+            # loop over first and last axes
+            expected = cupy.stack(
+                [
+                    cupy.stack(
+                        [
+                            zoom(
+                                a[i, ..., j],
+                                zm[1:-1],
+                                self.output,
+                                self.order,
+                                self.mode,
+                                self.cval,
+                                self.prefilter,
+                            )
+                            for i in range(a.shape[0])
+                        ],
+                        axis=0,
+                    )
+                    for j in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+        else:
+            raise ValueError("unsupported test case")
+        result = zoom(
+            a, zm, self.output, self.order, self.mode, self.cval, self.prefilter
+        )
+
+        # for integer output, allow ±1 due to rint() boundary
+        atol = 1 if numpy.dtype(a.dtype).kind in "iu" else 1e-5
+
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=atol)
+        return result
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_zoom_float(self, dtype):
+        shape, zoom = self.shape_and_zoom
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._zoom(a, zoom)
+
+    @testing.for_complex_dtypes()
+    def test_zoom_complex_float(self, dtype):
+        shape, zoom = self.shape_and_zoom
+        if self.output == numpy.float64:
+            self.output = numpy.complex128
+        a = testing.shaped_random(shape, cupy, dtype, scale=1)
+        return self._zoom(a, zoom)
+
+    @testing.for_float_dtypes(no_float16=True)
+    def test_zoom_fortran_order(self, dtype):
+        shape, zoom = self.shape_and_zoom
+        a = testing.shaped_random(shape, cupy, dtype)
+        a = cupy.asfortranarray(a)
+        return self._zoom(a, zoom)
+
+    @testing.for_int_dtypes(no_bool=True)
+    def test_zoom_int(self, dtype):
+        shape, zoom = self.shape_and_zoom
+        if numpy.lib.NumpyVersion(scipy.__version__) < "1.0.0":
+            if dtype in (numpy.dtype("l"), numpy.dtype("q")):
+                dtype = numpy.int64
+            elif dtype in (numpy.dtype("L"), numpy.dtype("Q")):
+                dtype = numpy.uint64
+        a = testing.shaped_random(shape, cupy, dtype)
+        return self._zoom(a, zoom)

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -785,3 +785,68 @@ class TestLoopBatchNonContiguousOutput:
         assert result is output
         cupy.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
         cupy.testing.assert_array_equal(base[:, 1::2, :], sentinel)
+
+
+class TestLoopBatchIntegerOutputRounding:
+    def test_constant_cval_uses_rint_for_integer_output(self):
+        a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+        result = vendored_ndimage.shift(
+            a,
+            shift=(20, 0.1, 0),
+            output=cupy.uint8,
+            order=1,
+            mode="constant",
+            cval=1.6,
+            prefilter=False,
+        )
+
+        expected = cupy.full(a.shape, 2, dtype=cupy.uint8)
+        cupy.testing.assert_array_equal(result, expected)
+
+    def test_grid_constant_cval_uses_rint_for_integer_output(self):
+        a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+        result = vendored_ndimage.shift(
+            a,
+            shift=(20, 0.1, 0),
+            output=cupy.uint8,
+            order=0,
+            mode="grid-constant",
+            cval=1.6,
+            prefilter=False,
+        )
+
+        expected = cupy.full(a.shape, 2, dtype=cupy.uint8)
+        cupy.testing.assert_array_equal(result, expected)
+
+    def test_order0_samples_use_rint_for_integer_output(self):
+        a = cupy.asarray(
+            [
+                [[1.6, 2.6, 3.6], [4.6, 5.6, 6.6]],
+                [[7.6, 8.6, 9.6], [10.6, 11.6, 12.6]],
+            ],
+            dtype=cupy.float32,
+        )
+        result = vendored_ndimage.shift(
+            a,
+            shift=(0.2, -0.2, 0),
+            output=cupy.uint8,
+            order=0,
+            mode="nearest",
+            prefilter=False,
+        )
+        expected = cupy.stack(
+            [
+                vendored_ndimage.shift(
+                    a[..., i],
+                    shift=(0.2, -0.2),
+                    output=cupy.uint8,
+                    order=0,
+                    mode="nearest",
+                    prefilter=False,
+                )
+                for i in range(a.shape[-1])
+            ],
+            axis=-1,
+        )
+
+        cupy.testing.assert_array_equal(result, expected)

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -51,6 +51,19 @@ except ImportError:
 scipy16_modes = ["wrap", "grid-wrap", "reflect", "grid-mirror", "grid-constant"]
 # these modes are okay to test on older SciPy
 legacy_modes = ["constant", "nearest", "mirror"]
+all_modes = legacy_modes + scipy16_modes
+batch_modes = ["constant", "nearest", "wrap", "grid-constant"]
+order_prefilter_pairs = [(0, False), (1, False), (3, False), (3, True)]
+
+
+class OrderPrefilterMixin:
+    @property
+    def order(self):
+        return self.order_prefilter[0]
+
+    @property
+    def prefilter(self):
+        return self.order_prefilter[1]
 
 
 def test_zoom_shift_grid_codegen_indexes_shift_by_axis():
@@ -77,16 +90,15 @@ def test_zoom_shift_grid_codegen_indexes_shift_by_axis():
                 "angle": [-15],
                 "reshape": [False],
                 "output": [None],
-                "order": [0, 1, 3],
-                "mode": legacy_modes + scipy16_modes,
+                "order_prefilter": order_prefilter_pairs,
+                "mode": batch_modes,
                 "cval": [1.0],
-                "prefilter": [False, True],
             }
         )
     )
 )
 @testing.with_requires("scipy")
-class TestRotateBatch:
+class TestRotateBatch(OrderPrefilterMixin):
     _multiprocess_can_split = True
 
     def _rotate(self, a, axes):
@@ -229,15 +241,14 @@ class TestRotateBatch:
                     ((17, 48, 64, 3), (0, 2, -3.2, 0)),
                 ],
                 "output": [None],
-                "order": [0, 1, 3],
-                "mode": legacy_modes + scipy16_modes,
+                "order_prefilter": order_prefilter_pairs,
+                "mode": batch_modes,
                 "cval": [1.0],
-                "prefilter": [False, True],
             }
         )
     )
 )
-class TestShiftBatch:
+class TestShiftBatch(OrderPrefilterMixin):
     _multiprocess_can_split = True
 
     def _shift(self, a, shift_val):
@@ -372,15 +383,14 @@ class TestShiftBatch:
                 ((17, 32, 64, 3), (1, 2.2, 0.3, 1)),
             ],
             "output": [None],
-            "order": [0, 1, 3],
-            "mode": legacy_modes + scipy16_modes,
+            "order_prefilter": order_prefilter_pairs,
+            "mode": batch_modes,
             "cval": [1.0],
-            "prefilter": [False, True],
         }
     )
 )
 @testing.with_requires("scipy")
-class TestZoomBatch:
+class TestZoomBatch(OrderPrefilterMixin):
     _multiprocess_can_split = True
 
     def _zoom(self, a, zm):
@@ -486,6 +496,81 @@ class TestZoomBatch:
                 dtype = numpy.uint64
         a = testing.shaped_random(shape, cupy, dtype)
         return self._zoom(a, zoom)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "operation": ["rotate", "shift", "zoom"],
+            "mode": all_modes,
+        }
+    )
+)
+class TestBatchAllModesSmoke:
+    def test_all_modes_last_axis_batch(self):
+        a = testing.shaped_random((7, 8, 3), cupy, cupy.float32, scale=1)
+        cval = 1.0
+
+        if self.operation == "rotate":
+            rotate = vendored_ndimage.rotate
+            expected = cupy.stack(
+                [
+                    rotate(
+                        a[..., i],
+                        -15,
+                        (1, 0),
+                        False,
+                        None,
+                        1,
+                        self.mode,
+                        cval,
+                        False,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+            result = rotate(
+                a, -15, (1, 0), False, None, 1, self.mode, cval, False
+            )
+        elif self.operation == "shift":
+            shift = vendored_ndimage.shift
+            expected = cupy.stack(
+                [
+                    shift(
+                        a[..., i],
+                        (0.4, -0.3),
+                        None,
+                        1,
+                        self.mode,
+                        cval,
+                        False,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+            result = shift(a, (0.4, -0.3, 0), None, 1, self.mode, cval, False)
+        else:
+            zoom = vendored_ndimage.zoom
+            expected = cupy.stack(
+                [
+                    zoom(
+                        a[..., i],
+                        (1.2, 0.8),
+                        None,
+                        1,
+                        self.mode,
+                        cval,
+                        False,
+                    )
+                    for i in range(a.shape[-1])
+                ],
+                axis=-1,
+            )
+            result = zoom(a, (1.2, 0.8, 1), None, 1, self.mode, cval, False)
+
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
 
 
 @testing.parameterize(

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -30,6 +30,7 @@ from cupy import testing
 import cucim.skimage._vendored.ndimage as vendored_ndimage
 from cucim.skimage._vendored._ndimage_interp_kernels import (
     _get_coord_zoom_and_shift_grid,
+    _get_shift_kernel,
     loop_batch_max_channels,
 )
 
@@ -72,6 +73,20 @@ def test_zoom_shift_grid_codegen_indexes_shift_by_axis():
     assert "shift[j]" not in code
     for axis in range(3):
         assert f"shift[{axis}]" in code
+
+
+def test_loop_batch_selected_when_last_axis_is_one_of_multiple_batch_axes():
+    kern_info = _get_shift_kernel(
+        4,
+        False,
+        (5, 6, 7, 3),
+        "nearest",
+        order=1,
+        batch_axes=(0, 3),
+        output_c_contiguous=True,
+    )
+
+    assert kern_info.size == 5 * 6 * 7
 
 
 @testing.parameterize(

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -29,6 +29,7 @@ from cupy.cuda import runtime
 from cupy import testing
 import cucim.skimage._vendored.ndimage as vendored_ndimage
 from cucim.skimage._vendored._ndimage_interp_kernels import (
+    _get_coord_zoom_and_shift_grid,
     loop_batch_max_channels,
 )
 
@@ -50,6 +51,14 @@ except ImportError:
 scipy16_modes = ["wrap", "grid-wrap", "reflect", "grid-mirror", "grid-constant"]
 # these modes are okay to test on older SciPy
 legacy_modes = ["constant", "nearest", "mirror"]
+
+
+def test_zoom_shift_grid_codegen_indexes_shift_by_axis():
+    code = "\n".join(_get_coord_zoom_and_shift_grid(3, float_type="float"))
+
+    assert "shift[j]" not in code
+    for axis in range(3):
+        assert f"shift[{axis}]" in code
 
 
 @testing.parameterize(

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -477,3 +477,53 @@ class TestZoomBatch:
                 dtype = numpy.uint64
         a = testing.shaped_random(shape, cupy, dtype)
         return self._zoom(a, zoom)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "matrix_kind": ["diagonal", "full"],
+            "mode": ["constant", "nearest"],
+        }
+    )
+)
+@testing.with_requires("scipy")
+class TestAffineTransformBatchOutputShape:
+    def test_identity_batch_axis_output_larger_than_input(self):
+        input_shape = (3, 4, 2)
+        # Safe to request a different identity-axis extent: the optimized
+        # batch kernel is only selected when the input/output extents match.
+        output_shape = (3, 4, 5)
+        cval = -7.0
+        a_np = numpy.arange(numpy.prod(input_shape), dtype=numpy.float32)
+        a_np = a_np.reshape(input_shape)
+        a = cupy.asarray(a_np)
+
+        if self.matrix_kind == "diagonal":
+            matrix_np = numpy.ones(a_np.ndim, dtype=numpy.float32)
+        else:
+            matrix_np = numpy.eye(a_np.ndim, dtype=numpy.float32)
+        matrix = cupy.asarray(matrix_np)
+
+        result = vendored_ndimage.affine_transform(
+            a,
+            matrix,
+            offset=0.0,
+            output_shape=output_shape,
+            order=1,
+            mode=self.mode,
+            cval=cval,
+            prefilter=False,
+        )
+        expected = scipy.ndimage.affine_transform(
+            a_np,
+            matrix_np,
+            offset=0.0,
+            output_shape=output_shape,
+            order=1,
+            mode=self.mode,
+            cval=cval,
+            prefilter=False,
+        )
+
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -527,3 +527,88 @@ class TestAffineTransformBatchOutputShape:
         )
 
         cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+@testing.parameterize(
+    *testing.product(
+        {
+            "operation": [
+                "map_coordinates",
+                "shift",
+                "zoom",
+                "affine_diagonal",
+                "affine_full",
+            ],
+        }
+    )
+)
+class TestLoopBatchNonContiguousOutput:
+    def _run_operation(self, a, output=None):
+        if self.operation == "map_coordinates":
+            coordinates = cupy.indices(a.shape, dtype=cupy.float32)
+            coordinates[0] += 0.3
+            coordinates[1] -= 0.2
+            return vendored_ndimage.map_coordinates(
+                a,
+                coordinates,
+                output=output,
+                order=1,
+                mode="nearest",
+                prefilter=False,
+                batch_axes=(2,),
+            )
+        if self.operation == "shift":
+            return vendored_ndimage.shift(
+                a,
+                shift=(0.3, -0.2, 0),
+                output=output,
+                order=1,
+                mode="nearest",
+                prefilter=False,
+            )
+        if self.operation == "zoom":
+            return vendored_ndimage.zoom(
+                a,
+                zoom=(1.2, 0.8, 1),
+                output=output,
+                order=1,
+                mode="nearest",
+                prefilter=False,
+            )
+
+        offset = (0.3, -0.2, 0)
+        if self.operation == "affine_diagonal":
+            matrix = cupy.ones(a.ndim, dtype=cupy.float32)
+        else:
+            matrix = cupy.eye(a.ndim, dtype=cupy.float32)
+        return vendored_ndimage.affine_transform(
+            a,
+            matrix,
+            offset=offset,
+            output=output,
+            order=1,
+            mode="nearest",
+            prefilter=False,
+        )
+
+    def test_loop_batch_falls_back_for_non_contiguous_output(self):
+        a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+        expected = self._run_operation(a)
+
+        sentinel = cupy.asarray(-12345, dtype=expected.dtype)
+        base_shape = (
+            expected.shape[0],
+            expected.shape[1] * 2,
+            expected.shape[2],
+        )
+        base = cupy.full(base_shape, sentinel, dtype=expected.dtype)
+        output = base[:, ::2, :]
+        assert not output.flags.c_contiguous
+
+        # The loop-batch kernel writes raw contiguous output, so strided output
+        # views must fall back to the normal strided ElementwiseKernel output.
+        result = self._run_operation(a, output=output)
+
+        assert result is output
+        cupy.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+        cupy.testing.assert_array_equal(base[:, 1::2, :], sentinel)

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -538,6 +538,85 @@ class TestAffineTransformBatchOutputShape:
         cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
 
 
+@testing.with_requires("scipy")
+def test_affine_transform_cross_term_from_last_axis_is_not_batch_axis():
+    input_shape = (5, 6, 4)
+    a_np = numpy.arange(numpy.prod(input_shape), dtype=numpy.float32)
+    a_np = a_np.reshape(input_shape)
+    a = cupy.asarray(a_np)
+
+    matrix_np = numpy.asarray(
+        [
+            [1.0, 0.0, 0.25],
+            [0.0, 0.9, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=numpy.float32,
+    )
+    matrix = cupy.asarray(matrix_np)
+    offset = (0.1, -0.2, 0.0)
+
+    result = vendored_ndimage.affine_transform(
+        a,
+        matrix,
+        offset=offset,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+    )
+    expected = scipy.ndimage.affine_transform(
+        a_np,
+        matrix_np,
+        offset=offset,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+    )
+
+    cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_map_coordinates_batch_axes_use_same_spatial_map_for_all_channels():
+    a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+    coordinates = cupy.indices(a.shape, dtype=cupy.float32)
+    coordinates[0] += 0.2
+    coordinates[1] -= 0.3
+
+    # These channel-varying spatial coordinate planes intentionally violate
+    # the batch_axes contract. With batch_axes=(2,), the same spatial
+    # transform is applied to all channels, so only channel 0's spatial
+    # coordinate planes are used by the looped batch path.
+    coordinates[0, :, :, 1] += 0.5
+    coordinates[0, :, :, 2] += 1.0
+    coordinates[1, :, :, 1] -= 0.25
+    coordinates[1, :, :, 2] -= 0.5
+
+    invariant_coordinates = coordinates.copy()
+    for axis in (0, 1):
+        invariant_coordinates[axis] = invariant_coordinates[axis, :, :, 0][
+            :, :, cupy.newaxis
+        ]
+
+    result = vendored_ndimage.map_coordinates(
+        a,
+        coordinates,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+        batch_axes=(2,),
+    )
+    expected = vendored_ndimage.map_coordinates(
+        a,
+        invariant_coordinates,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+        batch_axes=(2,),
+    )
+
+    cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
 @testing.parameterize(
     *testing.product(
         {

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -589,6 +589,144 @@ class TestBatchAllModesSmoke:
         cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize(
+    "operation", ["map_coordinates", "shift", "zoom", "affine"]
+)
+@pytest.mark.parametrize("mode", all_modes)
+def test_prefilter_boundary_modes_with_batch_axes(operation, mode):
+    shape = (2, 5, 6, 3)
+    a = cupy.arange(numpy.prod(shape), dtype=cupy.float32).reshape(shape)
+    a = a / 10 + 0.125
+    cval = -7.25
+
+    if operation == "map_coordinates":
+        coordinates = cupy.indices(shape, dtype=cupy.float32)
+        coordinates[1] -= 1.2
+        coordinates[2] += 0.85
+        result = vendored_ndimage.map_coordinates(
+            a,
+            coordinates,
+            order=3,
+            mode=mode,
+            cval=cval,
+            prefilter=True,
+            batch_axes=(0, 3),
+        )
+        expected = cupy.stack(
+            [
+                cupy.stack(
+                    [
+                        vendored_ndimage.map_coordinates(
+                            a[n, :, :, c],
+                            coordinates[1:3, n, :, :, c],
+                            order=3,
+                            mode=mode,
+                            cval=cval,
+                            prefilter=True,
+                        )
+                        for c in range(shape[-1])
+                    ],
+                    axis=-1,
+                )
+                for n in range(shape[0])
+            ],
+            axis=0,
+        )
+    elif operation == "shift":
+        result = vendored_ndimage.shift(
+            a,
+            shift=(0, 1.2, -0.85, 0),
+            order=3,
+            mode=mode,
+            cval=cval,
+            prefilter=True,
+        )
+        expected = cupy.stack(
+            [
+                cupy.stack(
+                    [
+                        vendored_ndimage.shift(
+                            a[n, :, :, c],
+                            shift=(1.2, -0.85),
+                            order=3,
+                            mode=mode,
+                            cval=cval,
+                            prefilter=True,
+                        )
+                        for c in range(shape[-1])
+                    ],
+                    axis=-1,
+                )
+                for n in range(shape[0])
+            ],
+            axis=0,
+        )
+    elif operation == "zoom":
+        result = vendored_ndimage.zoom(
+            a,
+            zoom=(1, 1.4, 0.7, 1),
+            order=3,
+            mode=mode,
+            cval=cval,
+            prefilter=True,
+        )
+        expected = cupy.stack(
+            [
+                cupy.stack(
+                    [
+                        vendored_ndimage.zoom(
+                            a[n, :, :, c],
+                            zoom=(1.4, 0.7),
+                            order=3,
+                            mode=mode,
+                            cval=cval,
+                            prefilter=True,
+                        )
+                        for c in range(shape[-1])
+                    ],
+                    axis=-1,
+                )
+                for n in range(shape[0])
+            ],
+            axis=0,
+        )
+    else:
+        matrix = cupy.eye(a.ndim, dtype=cupy.float32)
+        offset = (0, 1.2, -0.85, 0)
+        result = vendored_ndimage.affine_transform(
+            a,
+            matrix,
+            offset=offset,
+            order=3,
+            mode=mode,
+            cval=cval,
+            prefilter=True,
+        )
+        expected = cupy.stack(
+            [
+                cupy.stack(
+                    [
+                        vendored_ndimage.affine_transform(
+                            a[n, :, :, c],
+                            cupy.eye(2, dtype=cupy.float32),
+                            offset=offset[1:3],
+                            order=3,
+                            mode=mode,
+                            cval=cval,
+                            prefilter=True,
+                        )
+                        for c in range(shape[-1])
+                    ],
+                    axis=-1,
+                )
+                for n in range(shape[0])
+            ],
+            axis=0,
+        )
+
+    cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
 @testing.parameterize(
     *testing.product(
         {

--- a/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
+++ b/python/cucim/src/cucim/skimage/_vendored/tests/test_interpolation_batch.py
@@ -28,6 +28,7 @@ import cupy
 from cupy.cuda import runtime
 from cupy import testing
 import cucim.skimage._vendored.ndimage as vendored_ndimage
+from cucim.skimage._vendored._internal import AxisError
 from cucim.skimage._vendored._ndimage_interp_kernels import (
     _get_coord_zoom_and_shift_grid,
     _get_shift_kernel,
@@ -715,6 +716,70 @@ def test_map_coordinates_batch_axes_use_same_spatial_map_for_all_channels():
     )
 
     cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_map_coordinates_batch_axes_negative_axis_is_normalized():
+    a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+    coordinates = cupy.indices(a.shape, dtype=cupy.float32)
+    coordinates[0] += 0.2
+    coordinates[1] -= 0.3
+
+    result = vendored_ndimage.map_coordinates(
+        a,
+        coordinates,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+        batch_axes=(-1,),
+    )
+    expected = vendored_ndimage.map_coordinates(
+        a,
+        coordinates,
+        order=1,
+        mode="nearest",
+        prefilter=False,
+        batch_axes=(2,),
+    )
+
+    cupy.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "batch_axes, match",
+    [
+        ((3,), "out of bounds"),
+        ((-4,), "out of bounds"),
+        ((2, -1), "unique"),
+    ],
+)
+def test_map_coordinates_batch_axes_invalid_axes(batch_axes, match):
+    a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+    coordinates = cupy.indices(a.shape, dtype=cupy.float32)
+
+    with pytest.raises((ValueError, AxisError), match=match):
+        vendored_ndimage.map_coordinates(
+            a,
+            coordinates,
+            order=1,
+            mode="nearest",
+            prefilter=False,
+            batch_axes=batch_axes,
+        )
+
+
+def test_map_coordinates_batch_axes_require_matching_output_extent():
+    a = testing.shaped_random((5, 6, 3), cupy, cupy.float32, scale=1)
+    coordinates = cupy.indices((5, 6, 4), dtype=cupy.float32)
+
+    with pytest.raises(ValueError, match="output shape must match input shape"):
+        vendored_ndimage.map_coordinates(
+            a,
+            coordinates,
+            order=1,
+            mode="nearest",
+            prefilter=False,
+            batch_axes=(2,),
+        )
 
 
 @testing.parameterize(

--- a/python/cucim/src/cucim/skimage/transform/_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/_warps.py
@@ -606,8 +606,10 @@ def rotate(
         # keep original shape on the excess dimensions
         output_shape = output_shape + image.shape[2:]
 
+    float_dtype = cp.promote_types(image.real.dtype, cp.float32)
+
     # transfer the coordinate transform to the GPU
-    affine_params = cp.asarray(affine_params)
+    affine_params = cp.asarray(affine_params, dtype=float_dtype)
 
     return _ndimage_affine(
         image,

--- a/python/cucim/src/cucim/skimage/transform/_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/_warps.py
@@ -17,7 +17,6 @@ from .._shared.utils import (
     safe_as_int,
     warn,
 )
-from .._vendored import pad
 from ..measure import block_reduce
 from ._geometric import (
     AffineTransform,
@@ -958,6 +957,7 @@ def warp(
     cval=0.0,
     clip=None,
     preserve_range=False,
+    batch_axes=None,
 ):
     """Warp an image according to a given coordinate transformation.
 
@@ -1028,7 +1028,12 @@ def warp(
         image is converted according to the conventions of `img_as_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
-
+    batch_axes (tuple of int, optional): Axes along which the coordinates
+        represent an identity mapping (i.e., output index equals input
+        coordinate). For these axes, interpolation is skipped and the
+        coordinate values in the ``coordinates`` array are ignored.
+        This can improve performance when only a subset of dimensions
+        require interpolation.
     Returns
     -------
     warped : double ndarray
@@ -1159,6 +1164,7 @@ def warp(
     prefilter = order > 1
 
     ndi_mode = _to_ndimage_mode(mode)
+
     warped = ndi.map_coordinates(
         image,
         coords,
@@ -1166,6 +1172,7 @@ def warp(
         mode=ndi_mode,
         order=order,
         cval=cval,
+        batch_axes=batch_axes,
     )
 
     _clip_warp_output(image, warped, mode, cval, order, clip)
@@ -1342,11 +1349,103 @@ def warp_polar(
     k_angle = height / (2 * np.pi)
     warp_args = {"k_angle": k_angle, "k_radius": k_radius, "center": center}
 
+    if multichannel:
+        channel_axis = channel_axis % image.ndim
+        batch_axes = (channel_axis,)
+    else:
+        batch_axes = ()
+
     warped = warp(
-        image, map_func, map_args=warp_args, output_shape=output_shape, **kwargs
+        image,
+        map_func,
+        map_args=warp_args,
+        output_shape=output_shape,
+        batch_axes=batch_axes,
+        **kwargs,
     )
 
     return warped
+
+
+@cp.memoize(for_each_device=True)
+def _get_local_mean_weights_kernel(grid_mode):
+    """Get a kernel for computing local mean weights."""
+    if grid_mode:
+        # grid_mode=True: breaks are evenly spaced
+        # old_breaks[k] = k, new_breaks[k] = k * old_size / new_size
+        # Row sum is always old_size / new_size, so we can normalize directly
+        return cp.ElementwiseKernel(
+            "int32 old_size, float64 scale",
+            "W weights",
+            """
+            // For 2D C-contiguous array of shape (new_size, old_size):
+            // row = i / old_size, col = i % old_size
+            int row = i / old_size;
+            int col = i % old_size;
+
+            // new_breaks[row] = row * scale, new_breaks[row+1] = (row+1) * scale
+            // old_breaks[col] = col, old_breaks[col+1] = col + 1
+            double new_lo = row * scale;
+            double new_hi = (row + 1) * scale;
+            double old_lo = col;
+            double old_hi = col + 1;
+
+            double upper = (new_hi < old_hi) ? new_hi : old_hi;
+            double lower = (new_lo > old_lo) ? new_lo : old_lo;
+            double w = upper - lower;
+
+            // Normalize by row sum (which equals scale for grid_mode)
+            weights = (W)((w > 0) ? w / scale : 0);
+            """,
+            "local_mean_weights_grid",
+        )
+    else:
+        # grid_mode=False: more complex break computation
+        # Need two-pass: compute unnormalized, then normalize
+        return cp.ElementwiseKernel(
+            "int32 new_size, int32 old_size, float64 old, float64 val, float64 step",
+            "W weights",
+            """
+            // For 2D C-contiguous array of shape (new_size, old_size):
+            // row = i / old_size, col = i % old_size
+            int row = i / old_size;
+            int col = i % old_size;
+
+            // Compute old_breaks[col] and old_breaks[col+1]
+            // old_breaks = [0, 0.5, 1.5, ..., old-0.5, old]
+            double old_lo, old_hi;
+            if (col == 0) {
+                old_lo = 0.0;
+            } else {
+                old_lo = 0.5 + (col - 1);
+            }
+            if (col == old_size - 1) {
+                old_hi = old;
+            } else {
+                old_hi = 0.5 + col;
+            }
+
+            // Compute new_breaks[row] and new_breaks[row+1]
+            // new_breaks = [0, val, val+step, ..., old-val, old]
+            double new_lo, new_hi;
+            if (row == 0) {
+                new_lo = 0.0;
+            } else {
+                new_lo = val + (row - 1) * step;
+            }
+            if (row == new_size - 1) {
+                new_hi = old;
+            } else {
+                new_hi = val + row * step;
+            }
+
+            double upper = (new_hi < old_hi) ? new_hi : old_hi;
+            double lower = (new_lo > old_lo) ? new_lo : old_lo;
+            double w = upper - lower;
+            weights = (W)((w > 0) ? w : 0);
+            """,
+            "local_mean_weights_pixel",
+        )
 
 
 def _local_mean_weights(old_size, new_size, grid_mode, dtype):
@@ -1370,33 +1469,23 @@ def _local_mean_weights(old_size, new_size, grid_mode, dtype):
         Rows sum to 1.
 
     """
+    weights = cp.empty((new_size, old_size), dtype=dtype)
+    kern = _get_local_mean_weights_kernel(grid_mode)
+
     if grid_mode:
-        old_breaks = cp.linspace(0, old_size, num=old_size + 1, dtype=dtype)
-        new_breaks = cp.linspace(0, old_size, num=new_size + 1, dtype=dtype)
+        scale = old_size / new_size
+        kern(old_size, scale, weights)
     else:
         old, new = old_size - 1, new_size - 1
-        old_breaks = pad(
-            cp.linspace(0.5, old - 0.5, old, dtype=dtype),
-            1,
-            "constant",
-            constant_values=(0, old),
-        )
         if new == 0:
             val = np.inf
+            step = 0.0
         else:
             val = 0.5 * old / new
-        new_breaks = pad(
-            cp.linspace(val, old - val, new, dtype=dtype),
-            1,
-            "constant",
-            constant_values=(0, old),
-        )
-
-    upper = cp.minimum(new_breaks[1:, np.newaxis], old_breaks[np.newaxis, 1:])
-    lower = cp.maximum(new_breaks[:-1, np.newaxis], old_breaks[np.newaxis, :-1])
-
-    weights = cp.maximum(upper - lower, 0)
-    weights /= weights.sum(axis=1, keepdims=True)
+            step = (old - 2 * val) / (new - 1) if new > 1 else 0.0
+        kern(new_size, old_size, float(old), val, step, weights)
+        # Normalize rows (grid_mode=False doesn't have constant row sum)
+        weights /= weights.sum(axis=1, keepdims=True)
 
     return weights
 

--- a/python/cucim/src/cucim/skimage/transform/_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/_warps.py
@@ -1033,9 +1033,11 @@ def warp(
     batch_axes (tuple of int, optional): Axes along which the coordinates
         represent an identity mapping (i.e., output index equals input
         coordinate). For these axes, interpolation is skipped and the
-        coordinate values in the ``coordinates`` array are ignored.
-        This can improve performance when only a subset of dimensions
-        require interpolation.
+        coordinate values in the ``coordinates`` array are ignored. The same
+        spatial coordinate map is applied to every element along these axes,
+        so coordinate planes for non-batch axes must be invariant along each
+        batch axis. This can improve performance when only a subset of
+        dimensions require interpolation.
     Returns
     -------
     warped : double ndarray

--- a/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
@@ -1038,7 +1038,7 @@ def test_resize_local_mean3d_keep(channel_axis):
     resized = resize_local_mean(x, out_shape)
     # move channels back to last axis to match the reference image
     resized = cp.moveaxis(resized, channel_axis, -1)
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
 
 
 def test_resize_local_mean3d_resize():
@@ -1048,7 +1048,7 @@ def test_resize_local_mean3d_resize():
     resized = resize_local_mean(x, (10, 10, 1))
     ref = cp.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
 
     # can't resize along specified channel axis
     with pytest.raises(ValueError):
@@ -1062,7 +1062,7 @@ def test_resize_local_mean3d_2din_3dout():
     resized = resize_local_mean(x, (10, 10, 1))
     ref = cp.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
 
 
 def test_resize_local_mean2d_4d():
@@ -1073,7 +1073,7 @@ def test_resize_local_mean2d_4d():
     resized = resize_local_mean(x, out_shape)
     ref = cp.zeros(out_shape)
     ref[2:4, 2:4, ...] = 1
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
 
 
 @pytest.mark.parametrize("dim", range(1, 6))
@@ -1084,7 +1084,7 @@ def test_resize_local_mean_nd(dim):
     resized = resize_local_mean(x, out_shape)
     expected_shape = tuple(1.5 * np.asarray(shape))
     assert_array_equal(resized.shape, expected_shape)
-    assert_array_equal(resized, 1)
+    assert_allclose(resized, 1, atol=1e-7)
 
 
 def test_resize_local_mean3d():
@@ -1094,7 +1094,7 @@ def test_resize_local_mean3d():
     resized = resize_local_mean(x, (10, 10, 1))
     ref = cp.zeros((10, 10, 1))
     ref[2:4, 2:4, :] = 0.5
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
     resized = resize_local_mean(x, (10, 10, 1), grid_mode=False)
     ref[1, 1, :] = 0.0703125
     ref[2, 2, :] = 0.5
@@ -1102,7 +1102,7 @@ def test_resize_local_mean3d():
     ref[1, 2, :] = ref[2, 1, :] = 0.1875
     ref[1, 3, :] = ref[3, 1, :] = 0.1640625
     ref[2, 3, :] = ref[3, 2, :] = 0.4375
-    assert_array_almost_equal(resized, ref)
+    assert_allclose(resized, ref, atol=1e-7)
 
 
 def test_resize_local_mean_dtype():

--- a/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
+++ b/python/cucim/src/cucim/skimage/transform/tests/test_warps.py
@@ -120,6 +120,14 @@ def test_warp_nd():
         assert_array_almost_equal(outx, refx)
 
 
+def test_warp_batch_axes_require_matching_output_extent():
+    image = cp.random.rand(5, 6, 3)
+    coords = cp.indices((5, 6, 4), dtype=cp.float32)
+
+    with pytest.raises(ValueError, match="output shape must match input shape"):
+        warp(image, coords, order=1, batch_axes=(2,))
+
+
 def test_warp_clip():
     x = cp.zeros((5, 5), dtype=cp.float64)
     x[2, 2] = 1


### PR DESCRIPTION
# Batch-axis optimization for ndimage interpolation kernels

**Note:** Changes from #1055 are also present here, so that one should be reviewed and merged first.

## Overview

These two commits optimize `cucim.skimage._vendored.ndimage` interpolation functions (`affine_transform`, `rotate`, `shift`, `zoom`, `map_coordinates`) for arrays with non-interpolated "batch" dimensions. The most common cases being RGB/RGBA  image channels (H, W, C) or a stack of equally sized images (N, H, W) or (N, H, W, C).

Previously for these functions, an `(H, W, 3)` uint8 image rotation was treated as a full 3D interpolation: each output pixel * channel launched a separate thread that independently computed 3D affine coordinates and interpolated across a 4×4×4 = 64-neighbor stencil in 3D (for order=3), even though the channel axis requires no interpolation at all. For order>=2 when spline prefiltering is used, that separable prefiltering should also only be applied along the axes that are actually being filtered.

For SciPy and current `cupyx.scipy.ndimage`, to avoid the extra interpolation work along batch axes for a (N, H, W, C) image stack, one would need to loop the computation like this:

```python
for batch_idx in range(N):
    for channel_idx in range(C):
        output[batch_idx, :, :, channel_idx] = rotate(image[batch_idx, :, :, channel_idx], angle=5, axes=(1, 0), mode='reflect', order=3)
```
vs. with the change in this PR a single CUDA kernel can be launched using just
```python
output = rotate(image, angle=5, axes=(2, 1), mode='reflect', order=3)
```
Due to the flexibility of the interpolation kernels (various interpolation orders and boundary extension modes), the kernel code itself is not straightforward to review. The conceptual changes made are fairly simple, though and are explained below via concrete examples.

There are two separate optimizations in this PR:
1. `batch_axes` detection to avoid unnecessary interpolation work along non-interpolated axes
   - this reduces the number of axes involved in the kernel loop to only the non-batch axes instead of all axes
   - the same is true for the separable spline prefiltering
1. `loop_batch_axis` to have a single thread loop over elements of the batch when the last axis is in `batch_axes`
   - in other words instead of 1 pixel per GPU thread, there are N batch elements/channels computed per GPU thread

Of these two, the first provides the majority of the benefit, but the second was still found to be beneficial in cases with relatively few channels on the last axis (e.g. the common case of RGB and RGBA images).

## Optimization 1: Batch axes detection

Detects axes where the transform is the identity (e.g., `zoom=1`, `shift=0`, or the corresponding affine matrix row is `[0...0, 1, 0...0, 0]`). These "batch axes" skip interpolation and use a direct index copy instead.

For the `(H, W, 3)` rotation example, axis 2 (channels) is detected as a batch axis. The affine coordinate computation for `order=3` shrinks from 3D to 2D and
the interpolation stencil shrinks from `4 * 4 * 4 = 64` to `4 * 4 = 16` neighbors.

**Key changes in `_ndimage_interpolation.py`:**
- Transform analysis functions (`_determine_batch_axes_*`) inspect the matrix/zoom/shift to identify batch dimensions.
- Batch axes are propagated to the kernel getters.

**Key changes in `_ndimage_interp_kernels.py`:**
- All `_get_coord_*` functions accept `batch_axes` and emit identity transforms (`c_j = in_coord[j]`) for those axes.
- `_generate_interp_custom` skips interpolation weight computation, boundary condition checks, and nested stencil loops for batch axes.

### Generated kernel before (3D interpolation, all 3 axes):

```cpp
// 3D affine coordinate computation (3 axes × 4 matrix elements each)
W c_0 = 0.0;
c_0 += mat[0] * in_coord[0]; c_0 += mat[1] * in_coord[1]; c_0 += mat[2] * in_coord[2]; c_0 += mat[3];
W c_1 = ...;  // same for axis 1
W c_2 = ...;  // same for axis 2 (channel) — unnecessary!

// Bounds check on all 3 axes including channels
if ((c_0 < 0) || ... || (c_2 < 0) || (c_2 > xsize_2 - 1)) { ... }

// Triply-nested stencil loop: 4 × 4 × 4 = 64 iterations
for (k_0 = 0; k_0 <= 3; k_0++) {          // axis 0
    // weights_0, boundary conditions for axis 0 (×4)
    for (k_1 = 0; k_1 <= 3; k_1++) {      // axis 1
        // weights_1, boundary conditions for axis 1 (×4)
        for (k_2 = 0; k_2 <= 3; k_2++) {  // axis 2 (channels) — unnecessary!
            // weights_2, boundary conditions for axis 2 (×4)
            out += x[ic_0 + ic_1 + ic_2] * (w_0 * w_1 * w_2);
        }
    }
}
```

### Generated kernel after (2D interpolation, channel axis = identity):

```cpp
// 2D affine coordinate computation (channel axis skipped)
W c_0 = 0.0;
c_0 += mat[0] * in_coord[0]; c_0 += mat[1] * in_coord[1]; c_0 += mat[3];
W c_1 = ...;

// Bounds check on 2 spatial axes only
if ((c_0 < 0) || ... || (c_1 > xsize_1 - 1)) { ... }

// Doubly-nested stencil: 4 × 4 = 16 iterations
// Channel axis uses w_2 = 1.0, ic_2 = in_coord[2] * sx_2 (identity)
for (k_0 = 0; k_0 <= 3; k_0++) {      // axis 0
    for (k_1 = 0; k_1 <= 3; k_1++) {  // axis 1
        {  // batch axis 2: weight=1, no interpolation
            out += x[ic_0 + ic_1 + ic_2] * (w_0 * w_1 * w_2);
        }
    }
}
```

## Optimization 2: Contiguous batch axis optimization

When the batch axis is the last (innermost) axis, restructures the kernel so that one thread processes all batch elements at a given spatial position. Spatial interpolation weights and indices are computed once, then reused across a tight inner loop over the batch dimension.

For the `(H, W, 3)` case, the grid shrinks from `H_out × W_out × 3` threads to `H_out × W_out` threads. Each thread reads all 3 channels at each of the 16 spatial neighbors.

**Key changes in `_ndimage_interp_kernels.py`:**
- `loop_batch_axis` flag triggers when the batch axis is the last dimension.
- Output switches from indexed `Y y` to `raw Y y` with manual index computation.
- Index unraveling covers only spatial dimensions; `batch_size` is a compile-time constant.
- Stencil loops iterate over spatial axes only; the innermost loop iterates over batch elements, accumulating into a per-batch output array.

**Key changes in `_ndimage_interpolation.py`:**
- Kernel getters return a `KernelInfo(kernel, size)` where `size` is the reduced spatial-only element count for the looped case.

### Example of generated kernel code with batch loop:

```cpp
// One thread per spatial position (not per pixel×channel)
const unsigned int batch_size = 3;
const unsigned int out_base_idx = i * batch_size;

// Index unraveling: 2D spatial only (no channel dimension)
in_coord[1] = ...; in_coord[0] = ...;

// 2D affine coordinate computation (same as commit 1)
W c_0 = ...; W c_1 = ...;

// Spatial bounds check -> fill all channels with cval if out of bounds
if (out_of_bounds) {
    for (batch_idx = 0; batch_idx < batch_size; batch_idx++)
        y[out_base_idx + batch_idx] = cval;
} else {
    // Compute spline weights/indices for spatial axes ONCE
    W weights_0[4]; ...  // axis 0 weights and boundary indices
    W weights_1[4]; ...  // axis 1 weights and boundary indices

    float out_batch[3] = {0, 0, 0};

    // Spatial stencil loops (outer)
    for (k_0 = 0; k_0 <= 3; k_0++) {
        for (k_1 = 0; k_1 <= 3; k_1++) {
            W spatial_weight = w_0 * w_1;  // computed once
            int ic_base = ic_0 + ic_1;     // computed once

            // Batch loop (innermost) -- reads 3 channels at same neighbor
            for (batch_idx = 0; batch_idx < batch_size; batch_idx++) {
                float val = x[ic_base + batch_idx];
                out_batch[batch_idx] += val * spatial_weight;
            }
        }
    }

    for (batch_idx = 0; batch_idx < batch_size; batch_idx++)
        y[out_base_idx + batch_idx] = (Y)rint(out_batch[batch_idx]);
}
```

## Performance impact

The following test cases compare the performance of the batch implementation in this PR to using CuPy `main` directly. The comparison here is to CuPy after the float32 dtype fixes were already incorporated there, so this difference is due purely to the batch axis changes in this MR.

The results in the table below are for `cupyx.scipy.ndimage.rotate` vs. `cucim.skimage._vendored.ndimage.rotate`

Note that cuCIM's `cucim.skimage.transform.rotate` does not currently support multiple batch-axes, but does support rotation of RGB/RGBA images with channels on the last axis. So the (3840, 2160, 4) and (512, 512, 100) cases are most relevant to cuCIM usage.

|  shape  |   axes  | dtype | order | prefilter | CuPy (ms) | This PR (ms) | accel. |
|---------|---------|-------|-------|-----------|--------------------|------------------------|--------------|
| (3840, 2160, 4) | (1, 0) | uint8 |  0  | False | 0.528 | 0.551 | 0.957 |
| (3840, 2160, 4) | (1, 0) | uint8 |  1  | False | 0.586 | 0.547 | 1.071 |
| (3840, 2160, 4) | (1, 0) | uint8 |  2  | False | 1.022 | 0.561 | 1.821 |
| (3840, 2160, 4) | (1, 0) | uint8 |  3  | False | 1.530 | 0.619 | 2.470 |
| (3840, 2160, 4) | (1, 0) | uint8 |  4  | False | 2.241 | 0.672 | 3.336 |
| (3840, 2160, 4) | (1, 0) | uint8 |  5  | False | 6.226 | 0.749 | 8.307 |
| (3840, 2160, 4) | (1, 0) | uint8 |  2  | True | 3.742 | 2.794 | 1.339 |
| (3840, 2160, 4) | (1, 0) | uint8 |  3  | True | 4.222 | 2.844 | 1.485 |
| (3840, 2160, 4) | (1, 0) | uint8 |  4  | True | 6.904 | 4.564 | 1.513 |
| (3840, 2160, 4) | (1, 0) | uint8 |  5  | True | 10.802 | 4.648 | 2.324 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  0  | False | 0.730 | 0.732 | 0.998 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  1  | False | 0.891 | 0.847 | 1.051 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  2  | False | 3.339 | 1.443 | 2.313 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  3  | False | 5.911 | 1.918 | 3.081 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  4  | False | 9.663 | 2.436 | 3.967 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  5  | False | 27.540 | 3.135 | 8.785 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  2  | True | 6.159 | 2.855 | 2.158 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  3  | True | 8.730 | 3.316 | 2.632 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  4  | True | 14.571 | 4.623 | 3.152 |
| (16, 1920, 1080, 4) | (2, 1) | uint8 |  5  | True | 33.358 | 5.491 | 6.075 |
| (512, 512, 100) | (1, 0) | uint8 |  0  | False | 0.531 | 0.549 | 0.967 |
| (512, 512, 100) | (1, 0) | uint8 |  1  | False | 0.587 | 0.557 | 1.055 |
| (512, 512, 100) | (1, 0) | uint8 |  2  | False | 1.070 | 0.574 | 1.864 |
| (512, 512, 100) | (1, 0) | uint8 |  3  | False | 1.611 | 0.621 | 2.594 |
| (512, 512, 100) | (1, 0) | uint8 |  4  | False | 2.373 | 0.678 | 3.500 |
| (512, 512, 100) | (1, 0) | uint8 |  5  | False | 6.415 | 0.763 | 8.404 |
| (512, 512, 100) | (1, 0) | uint8 |  2  | True | 3.820 | 2.826 | 1.352 |
| (512, 512, 100) | (1, 0) | uint8 |  3  | True | 4.301 | 2.878 | 1.494 |
| (512, 512, 100) | (1, 0) | uint8 |  4  | True | 7.043 | 4.616 | 1.526 |
| (512, 512, 100) | (1, 0) | uint8 |  5  | True | 11.006 | 4.750 | 2.317 |
| (512, 100, 512) | (2, 0) | uint8 |  0  | False | 0.889 | 0.874 | 1.017 |
| (512, 100, 512) | (2, 0) | uint8 |  1  | False | 1.211 | 1.095 | 1.105 |
| (512, 100, 512) | (2, 0) | uint8 |  2  | False | 5.336 | 2.090 | 2.554 |
| (512, 100, 512) | (2, 0) | uint8 |  3  | False | 9.375 | 2.964 | 3.162 |
| (512, 100, 512) | (2, 0) | uint8 |  4  | False | 15.537 | 3.891 | 3.993 |
| (512, 100, 512) | (2, 0) | uint8 |  5  | False | 45.219 | 4.750 | 9.520 |
| (512, 100, 512) | (2, 0) | uint8 |  2  | True | 8.171 | 4.043 | 2.021 |
| (512, 100, 512) | (2, 0) | uint8 |  3  | True | 12.276 | 4.932 | 2.489 |
| (512, 100, 512) | (2, 0) | uint8 |  4  | True | 20.294 | 7.173 | 2.829 |
| (512, 100, 512) | (2, 0) | uint8 |  5  | True | 49.587 | 8.141 | 6.091 |
| (100, 512, 512) | (2, 1) | uint8 |  0  | False | 0.749 | 0.744 | 1.008 |
| (100, 512, 512) | (2, 1) | uint8 |  1  | False | 0.916 | 0.868 | 1.056 |
| (100, 512, 512) | (2, 1) | uint8 |  2  | False | 3.545 | 1.502 | 2.361 |
| (100, 512, 512) | (2, 1) | uint8 |  3  | False | 6.196 | 1.969 | 3.147 |
| (100, 512, 512) | (2, 1) | uint8 |  4  | False | 10.281 | 2.513 | 4.091 |
| (100, 512, 512) | (2, 1) | uint8 |  5  | False | 29.419 | 3.285 | 8.957 |
| (100, 512, 512) | (2, 1) | uint8 |  2  | True | 6.335 | 2.964 | 2.137 |
| (100, 512, 512) | (2, 1) | uint8 |  3  | True | 8.998 | 3.411 | 2.638 |
| (100, 512, 512) | (2, 1) | uint8 |  4  | True | 14.985 | 4.834 | 3.100 |
| (100, 512, 512) | (2, 1) | uint8 |  5  | True | 33.993 | 5.477 | 6.206 |

