### PR TITLE
chore: bump `codespell` version for Python 3.14+ compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --config, "python/cucim/pyproject.toml"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["--toml", "python/cucim/pyproject.toml"]

--- a/docs/adr/example.md
+++ b/docs/adr/example.md
@@ -131,7 +131,7 @@ Summary per language:
 
   * Erlang: excellent runtime including deployability and concurrency; challenging developer experience; relatively small ecosystem.
 
-  * Elm: looks very promising; IBM is publishing major case studies with good resutls; smaller ecosystem.
+  * Elm: looks very promising; IBM is publishing major case studies with good results; smaller ecosystem.
 
   * Flow: interesting improvement over JavaScript; however; developers are moving away from it.
 

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -195,7 +195,7 @@ order-by-type = true
 #   codespell --toml python/cucim/pyproject.toml . -i 3 -w
 skip = "build*,dist,.cache,html,_build,_deps,3rdparty/*,_static,generated,latex,.git,*.ipynb,test_data/input/LICENSE-3rdparty,jitify_testing"
 # ignore-regex = ""
-ignore-words-list = "ans,coo,boun,bu,bui,gool,hart,lond,manuel,nd,paeth,unser,wronly"
+ignore-words-list = "ans,coo,boun,bu,bui,gool,hart,lond,manuel,nd,paeth,unser,wronly,thirdparty,burnin,tge"
 quiet-level = 3
 
 # to undo: ./test_data/input/LICENSE-3rdparty

--- a/python/cucim/src/cucim/skimage/filters/cuda/histogram_median.cu
+++ b/python/cucim/src/cucim/skimage/filters/cuda/histogram_median.cu
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
  * SPDX-FileCopyrightText: Copyright (C) 2009, Willow Garage Inc., all rights reserved.
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
  */
 
@@ -149,7 +149,7 @@ extern "C" __global__ void cuRankFilterMultiBlock(IMAGE_T* src, IMAGE_T* dest,
 
   // In the original algorithm an initialization phase was required as part of
   // the window was outside the image. In this parallel version, the
-  // initializtion is required for all thread blocks that part of the median
+  // initialization is required for all thread blocks that part of the median
   // filter is outside the window. For all threads in the block the same code
   // will be executed.
   if (initNeeded) {


### PR DESCRIPTION
## Description

xref https://github.com/rapidsai/build-planning/issues/205
xref https://github.com/rapidsai/build-planning/issues/152

Python 3.14 brings with it newer versions of `setuptools` that are
incompatible with older license formats in `pyproject.toml`. We fixed this
for RAPIDS in rapidsai/build-planning#152.  `codespell` needs to be bumped
to version 2.4.1 to be compatible with newer setuptools.
