### PR TITLE
Use S3 for preprocessor cache

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -16,11 +16,17 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
+sccache --stop-server 2>/dev/null || true
+
+export SCCACHE_S3_KEY_PREFIX="libcucim/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/object-cache"
+export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="libcucim/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/preprocessor-cache"
+export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE="true"
+
+sccache --start-server
+
 # this can be set back to 'prevent' once the xorg-* migrations are completed
 # ref: https://github.com/rapidsai/cucim/issues/800#issuecomment-2529593457
 conda config --set path_conflict warn
-
-sccache --zero-stats
 
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build \
     conda/recipes/libcucim

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -18,13 +18,19 @@ rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 
+sccache --stop-server 2>/dev/null || true
+
+export SCCACHE_S3_KEY_PREFIX="cucim/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/object-cache"
+export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="cucim/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/preprocessor-cache"
+export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE="true"
+
+sccache --start-server
+
 # this can be set back to 'prevent' once the xorg-* migrations are completed
 # ref: https://github.com/rapidsai/cucim/issues/800#issuecomment-2529593457
 conda config --set path_conflict warn
 
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-
-sccache --zero-stats
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -13,6 +13,14 @@ source rapids-configure-sccache
 source rapids-date-string
 source rapids-init-pip
 
+sccache --stop-server 2>/dev/null || true
+
+export SCCACHE_S3_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/object-cache"
+export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/preprocessor-cache"
+export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE="true"
+
+sccache --start-server
+
 rapids-generate-version > ./VERSION
 
 rapids-logger "Generating build requirements"


### PR DESCRIPTION
Enable sccache's preprocessor cache mode and store the preprocessor cache in S3.

```
Cache location                        s3, name: rapids-sccache-east, prefix: /libcucim/aarch64/cuda13/object-cache/
Use direct/preprocessor mode?         yes
Preprocessor cache location           s3, name: rapids-sccache-east, prefix: /libcucim/aarch64/cuda13/preprocessor-cache/
```