### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.2
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.2
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - click
     - cuda-version ={{ cuda_version }}
     - cuda-cudart-dev
-    - cupy >=13.6.0,!=14.0.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - libcucim ={{ version }}
     - python
     - python-gil
@@ -66,7 +66,7 @@ requirements:
     - cuda-cudart
     - numpy >=1.23,<3.0
     - click
-    - cupy >=13.6.0,!=14.0.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - lazy_loader >=0.1
     - libcucim ={{ version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -297,7 +297,7 @@ dependencies:
           - scipy>=1.11.2
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0
+          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0,!=14.1.0
           - libnvimgcodec>=0.8.0,<0.9.0
           - nvimgcodec>=0.8.0,<0.9.0
     specific:
@@ -306,12 +306,12 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
               - nvidia-nvimgcodec-cu12>=0.8.0,<0.9.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
               - nvidia-nvimgcodec-cu13>=0.8.0,<0.9.0
   test_python:
     common:

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -30,7 +30,7 @@ license-files = [
 requires-python = ">=3.11"
 dependencies = [
     "click",
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "lazy-loader>=0.4",
     "numpy>=1.23.4,<3.0",
     "nvidia-nvimgcodec-cu13>=0.8.0,<0.9.0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
