### PR TITLE
fix 'yum update' in nightly wheels tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-      matrix_type: "nightly"
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,6 +153,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
+      matrix_type: "nightly"
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -24,7 +24,7 @@ rapids-pip-retry install \
     "$(echo ${PYTHON_WHEELHOUSE}/cucim*.whl)[test]"
 
 if type -f yum > /dev/null 2>&1; then
-    yum update -y
+    yum update --nobest -y
     yum install -y openslide
 else
     DEBIAN_FRONTEND=noninteractive apt update


### PR DESCRIPTION
Nightly tests on `release/26.06` have been failing recently. Only CUDA 12.x wheels tests on Rocky Linux 8 have been failing, like this:

```text
Rocky Linux 8 - AppStream                       8.3 MB/s |  29 MB     00:03    
Rocky Linux 8 - BaseOS                          2.6 MB/s |  59 MB     00:23    
Rocky Linux 8 - Extras                           32 kB/s |  15 kB     00:00    
cuda                                             12 MB/s | 7.1 MB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64  4.0 MB/s |  14 MB     00:03    
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Error: 
 Problem: package cuda-cudart-devel-12-9-12.9.79-1.x86_64 from @System requires cuda-cccl-12-9, but none of the providers can be installed
  - package cccl-13-3-13.3.3.3.1-1.x86_64 from cuda obsoletes cuda-cccl-12-9 provided by cuda-cccl-12-9-12.9.27-1.x86_64 from @System
  - package cccl-13-3-13.3.3.3.1-1.x86_64 from cuda obsoletes cuda-cccl-12-9 provided by cuda-cccl-12-9-12.9.27-1.x86_64 from cuda
  - cannot install the best update candidate for package cuda-cudart-devel-12-9-12.9.79-1.x86_64
  - cannot install the best update candidate for package cuda-cccl-12-9-12.9.27-1.x86_64
 ```

([build link](https://github.com/rapidsai/cucim/actions/runs/26803434447/job/79092114040#step:13:254))

This has the same root cause as https://github.com/rapidsai/ci-imgs/issues/411, see that issue for more details.

https://github.com/rapidsai/ci-imgs/pull/412 already resolves this on `main` (affects all `dnf upgrade` / `yum upgrade` calls in RAPIDS CI images), but wasn't backported to `release/26.06`.

To avoid building new CI images close to release, this backports the fix from https://github.com/rapidsai/ci-imgs/pull/412  to cuCIM's CI... passing `--nobest` to `yum upgrade`, so it will fall back to a different solve and not be broken by the renaming of the CCCL packages.

## Notes for Reviewers

### How I tested this

On the first commit, ran wheel tests with `matrix_type: nightly`.

Saw all the tests jobs succeed: https://github.com/rapidsai/cucim/actions/runs/26840592270/job/79149819727?pr=1099