### PR TITLE
Update CuPy and NumPy dependency specs

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8
@@ -23,7 +23,7 @@ dependencies:
 - matplotlib-base>=3.7
 - nbsphinx
 - ninja
-- numpy>=1.23.4,<3.0
+- numpy>=2.0,<3.0
 - numpydoc>=1.7
 - nvimgcodec>=0.8.0,<0.9.0
 - openslide-python>=1.3.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8
@@ -24,7 +24,7 @@ dependencies:
 - matplotlib-base>=3.7
 - nbsphinx
 - ninja
-- numpy>=1.23.4,<3.0
+- numpy>=2.0,<3.0
 - numpydoc>=1.7
 - nvimgcodec>=0.8.0,<0.9.0
 - openslide-python>=1.3.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - gcc_linux-aarch64=14.*
 - imagecodecs>=2021.6.8
@@ -23,7 +23,7 @@ dependencies:
 - matplotlib-base>=3.7
 - nbsphinx
 - ninja
-- numpy>=1.23.4,<3.0
+- numpy>=2.0,<3.0
 - numpydoc>=1.7
 - nvimgcodec>=0.8.0,<0.9.0
 - openslide-python>=1.3.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - gcc_linux-64=14.*
 - imagecodecs>=2021.6.8
@@ -24,7 +24,7 @@ dependencies:
 - matplotlib-base>=3.7
 - nbsphinx
 - ninja
-- numpy>=1.23.4,<3.0
+- numpy>=2.0,<3.0
 - numpydoc>=1.7
 - nvimgcodec>=0.8.0,<0.9.0
 - openslide-python>=1.3.0

--- a/conda/recipes/cucim/meta.yaml
+++ b/conda/recipes/cucim/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - click
     - cuda-version ={{ cuda_version }}
     - cuda-cudart-dev
-    - cupy >=13.6.0,!=14.0.0,!=14.1.0
+    - cupy >=14.0.1,!=14.1.0
     - libcucim ={{ version }}
     - python
     - python-gil
@@ -63,9 +63,9 @@ requirements:
     - setuptools >=80.9.0
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-    - numpy >=1.23,<3.0
+    - numpy >=2.0,<3.0
     - click
-    - cupy >=13.6.0,!=14.0.0,!=14.1.0
+    - cupy >=14.0.1,!=14.1.0
     - lazy_loader >=0.1
     - libcucim ={{ version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -332,23 +332,23 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - &cupy_cu12 cupy-cuda12x>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - &cupy_cu13 cupy-cuda13x>=14.0.1,!=14.1.0
       - output_types: pyproject
         matrices:
           - matrix:
               cuda: "12.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - *cupy_cu12
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - *cupy_cu13
           - matrix:
               cuda: "12.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -301,12 +301,12 @@ dependencies:
         packages:
           - click
           - lazy-loader>=0.4
-          - numpy>=1.23.4,<3.0
+          - numpy>=2.0,<3.0
           - scikit-image>=0.23.2,<0.27.0
           - scipy>=1.11.2
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0,!=14.1.0
+          - &cupy_unsuffixed cupy>=14.0.1,!=14.1.0
           - libnvimgcodec>=0.8.0,<0.9.0
           - nvimgcodec>=0.8.0,<0.9.0
     specific:
@@ -315,12 +315,12 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
               - nvidia-nvimgcodec-cu12>=0.8.0,<0.9.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
               - nvidia-nvimgcodec-cu13>=0.8.0,<0.9.0
   test_python:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -16,6 +16,7 @@ files:
       - docs
       - py_version
       - run
+      - depends_on_cupy
       - test_python
   test_python:
     output: none
@@ -60,6 +61,7 @@ files:
       table: project
     includes:
       - run
+      - depends_on_cupy
   py_optional_test:
     output: pyproject
     pyproject_dir: python/cucim
@@ -306,7 +308,6 @@ dependencies:
           - scipy>=1.11.2
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=14.0.1,!=14.1.0
           - libnvimgcodec>=0.8.0,<0.9.0
           - nvimgcodec>=0.8.0,<0.9.0
     specific:
@@ -315,13 +316,47 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
               - nvidia-nvimgcodec-cu12>=0.8.0,<0.9.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
               - nvidia-nvimgcodec-cu13>=0.8.0,<0.9.0
+  depends_on_cupy:
+    common:
+      - output_types: conda
+        packages:
+          - &cupy_unsuffixed cupy>=14.0.1,!=14.1.0
+    specific:
+      - output_types: requirements
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
+          - matrix:
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          - matrix:
+              cuda: "13.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
+          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
+          - matrix:
+            packages:
+              - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
   test_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -30,9 +30,9 @@ license-files = [
 requires-python = ">=3.11"
 dependencies = [
     "click",
-    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
+    "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "lazy-loader>=0.4",
-    "numpy>=1.23.4,<3.0",
+    "numpy>=2.0,<3.0",
     "nvidia-nvimgcodec-cu13>=0.8.0,<0.9.0",
     "scikit-image>=0.23.2,<0.27.0",
     "scipy>=1.11.2",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/279

RAPIDS is taking on requirements `cupy>=14.0.1,!=14.1.0` and `numpy>=2.0`. Wheel dependencies on `cupy-cuda12x` and `cupy-cuda13x` now use the `[ctk]` extra.

See the linked issue for details.