### PR TITLE
Ignore CuPy NumPy shape deprecation warning

### DIFF
--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -148,6 +148,10 @@ filterwarnings = [
     "error::DeprecationWarning",
     # https://github.com/cupy/cupy/blob/main/cupy/testing/_helper.py#L56
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    # https://github.com/cupy/cupy/blob/v14.1.1/cupy/_padding/pad.py#L408
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:cupy",
+    # https://github.com/scikit-image/scikit-image/blob/v0.26.0/skimage/measure/_marching_cubes_lewiner.py#L237
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:skimage",
 ]
 
 [tool.ruff]

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Infrastructure, Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Networks, Inc.
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 
 """version of cupy.pad that dispatches to elementwise kernels for some boundary
@@ -408,8 +408,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.view()
-    x_view.shape = (ndim, 2)
+    x_view = x.reshape((ndim, 2))
     return x_view.tolist()
 
 


### PR DESCRIPTION
## Summary

Fixes NumPy 2.5 `DeprecationWarning` failures triggered when pytest promotes deprecations to errors.

This PR:

- updates cucim's vendored pad helper to use `reshape` instead of assigning to `ndarray.shape`
- filters the same NumPy 2.5 warning when it originates from upstream CuPy
- filters the same NumPy 2.5 warning when it originates from upstream scikit-image marching-cubes lookup-table setup

## Root Cause

The failing CI job used Python 3.12, NumPy 2.5.0, and CuPy 14.1.1. NumPy 2.5 warns when code assigns directly to `ndarray.shape`; cucim's pytest config treats `DeprecationWarning` as an error.

The extracted failures came from three locations:

- `cucim/skimage/_vendored/pad.py::_as_pairs`
- `cupy/_padding/pad.py::_as_pairs`
- `skimage/measure/_marching_cubes_lewiner.py`

The cucim-owned vendored helper is fixed directly. The CuPy and scikit-image occurrences are upstream dependency warnings, so they are filtered narrowly by module.

## Validation

Created an isolated conda environment at `.conda-cucim-cupy-np25` with Python 3.12.13, NumPy 2.5.0, CuPy 14.1.1, and the cucim test dependencies.

Extracted the failing node IDs from the CI log for `actions/runs/28078321887/job/83129420085`:

```text
1062 unique failing node IDs
```

Ran the exact extracted subset locally with GPU access outside the sandbox:

```bash
PYTHONPATH=src /home/bdice/code/cucim/.conda-cucim-cupy-np25/bin/python -m pytest -s -q -c pyproject.toml --tb=short -x <extracted-node-ids>
```

Result:

```text
1062 passed, 8 warnings in 133.77s (0:02:13)
```

Also ran:

```bash
git diff --check
```
