### PR TITLE
Replace `shape` assignment with `reshape` calls

### DIFF
--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -92,7 +92,7 @@ def _decode(data, tile_shape, truncation_slices):
     """
     if not hasattr(data, "__cuda_array_interface__"):
         data = np.frombuffer(data, np.uint8)
-    data = data.reshape(tile_shape, copy=False)
+    data = data.reshape(tile_shape)
     # truncate any tiles that extend past the image boundary
     if truncation_slices:
         data = data[truncation_slices]

--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -92,7 +92,7 @@ def _decode(data, tile_shape, truncation_slices):
     """
     if not hasattr(data, "__cuda_array_interface__"):
         data = np.frombuffer(data, np.uint8)
-    data = data.reshape(tile_shape)
+    data = data.reshape(tile_shape, copy=False)
     # truncate any tiles that extend past the image boundary
     if truncation_slices:
         data = data[truncation_slices]

--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/python/gds_whole_slide/demo_implementation.py
+++ b/examples/python/gds_whole_slide/demo_implementation.py
@@ -92,7 +92,7 @@ def _decode(data, tile_shape, truncation_slices):
     """
     if not hasattr(data, "__cuda_array_interface__"):
         data = np.frombuffer(data, np.uint8)
-    data.shape = tile_shape
+    data = data.reshape(tile_shape)
     # truncate any tiles that extend past the image boundary
     if truncation_slices:
         data = data[truncation_slices]

--- a/python/cucim/pyproject.toml
+++ b/python/cucim/pyproject.toml
@@ -148,6 +148,10 @@ filterwarnings = [
     "error::DeprecationWarning",
     # https://github.com/cupy/cupy/blob/main/cupy/testing/_helper.py#L56
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    # https://github.com/cupy/cupy/blob/v14.1.1/cupy/_padding/pad.py#L408
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:cupy",
+    # https://github.com/scikit-image/scikit-image/blob/v0.26.0/skimage/measure/_marching_cubes_lewiner.py#L237
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:skimage",
 ]
 
 [tool.ruff]

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Infrastructure, Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Networks, Inc.
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 
 """version of cupy.pad that dispatches to elementwise kernels for some boundary

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -408,7 +408,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.reshape(ndim, 2)
+    x_view = x.reshape((ndim, 2), copy=False)
     return x_view.tolist()
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -408,7 +408,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.reshape((ndim, 2), copy=False)
+    x_view = x.reshape((ndim, 2))
     return x_view.tolist()
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Infrastructure, Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2015 Preferred Networks, Inc.
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 
 """version of cupy.pad that dispatches to elementwise kernels for some boundary
@@ -408,8 +408,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.view()
-    x_view.shape = (ndim, 2)
+    x_view = x.reshape((ndim, 2))
     return x_view.tolist()
 
 

--- a/python/cucim/src/cucim/skimage/_vendored/pad.py
+++ b/python/cucim/src/cucim/skimage/_vendored/pad.py
@@ -408,8 +408,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.view()
-    x_view.shape = (ndim, 2)
+    x_view = x.reshape(ndim, 2)
     return x_view.tolist()
 
 

--- a/python/cucim/src/cucim/skimage/util/_map_array.py
+++ b/python/cucim/src/cucim/skimage/util/_map_array.py
@@ -85,8 +85,7 @@ def map_array(input_arr, input_vals, output_vals, out=None):
             f"output array has shape {out.shape}."
         )
     try:
-        out_view = out.view()
-        out_view.shape = (-1,)  # no-copy reshape/ravel
+        out_view = out.reshape(-1)  # no-copy reshape/ravel
     except AttributeError:  # if out strides are not compatible with 0-copy
         raise ValueError(
             "If out array is provided, it should be either contiguous "

--- a/python/cucim/src/cucim/skimage/util/_map_array.py
+++ b/python/cucim/src/cucim/skimage/util/_map_array.py
@@ -85,7 +85,8 @@ def map_array(input_arr, input_vals, output_vals, out=None):
             f"output array has shape {out.shape}."
         )
     try:
-        out_view = out.reshape((-1,), copy=False)  # no-copy reshape/ravel
+        out_view = out.view()
+        out_view.shape = (-1,)  # no-copy reshape/ravel
     except AttributeError:  # if out strides are not compatible with 0-copy
         raise ValueError(
             "If out array is provided, it should be either contiguous "

--- a/python/cucim/src/cucim/skimage/util/_map_array.py
+++ b/python/cucim/src/cucim/skimage/util/_map_array.py
@@ -85,7 +85,7 @@ def map_array(input_arr, input_vals, output_vals, out=None):
             f"output array has shape {out.shape}."
         )
     try:
-        out_view = out.reshape(-1)  # no-copy reshape/ravel
+        out_view = out.reshape((-1,), copy=False)  # no-copy reshape/ravel
     except AttributeError:  # if out strides are not compatible with 0-copy
         raise ValueError(
             "If out array is provided, it should be either contiguous "


### PR DESCRIPTION
NumPy is deprecating direct `shape` assignment. The underlying code path simply goes through `reshape`. So just switch to `reshape` to eliminate the deprecation warning and future proof the code.

ref: https://github.com/numpy/numpy/blob/2a674fc909ef47631e4f6550e25817731534987f/numpy/_core/src/multiarray/getset.c#L64