### PR TITLE
Fix O_DIRECT tail offsets for aligned partial I/O

### DIFF
--- a/cpp/src/filesystem/cufile_driver.cpp
+++ b/cpp/src/filesystem/cufile_driver.cpp
@@ -567,10 +567,11 @@ ssize_t CuFileDriver::pread(void* buf, size_t count, off_t file_offset, off_t bu
             {
                 uint8_t internal_buf[PAGE_SIZE * 2]; // no need to initialize for pread()
                 uint8_t* buf_pos = reinterpret_cast<uint8_t*>(ALIGN_UP(static_cast<uint8_t*>(internal_buf), PAGE_SIZE));
+                off_t tail_offset = file_offset + block_read_size;
 
                 // Read the remaining block (size of PAGE_SIZE)
                 ssize_t read_cnt;
-                read_cnt = ::pread(handle_->fd, buf_pos, PAGE_SIZE, block_read_size);
+                read_cnt = ::pread(handle_->fd, buf_pos, PAGE_SIZE, tail_offset);
                 if (read_cnt < 0)
                 {
                     fmt::print(stderr, "Cannot read the remaining file content block! ({})\n", std::strerror(errno));
@@ -878,10 +879,11 @@ ssize_t CuFileDriver::pwrite(const void* buf, size_t count, off_t file_offset, o
                 uint8_t internal_buf[PAGE_SIZE * 2]{};
                 uint8_t* internal_buf_pos =
                     reinterpret_cast<uint8_t*>(ALIGN_UP(static_cast<uint8_t*>(internal_buf), PAGE_SIZE));
+                off_t tail_offset = file_offset + block_write_size;
 
                 // Read the remaining block (size of PAGE_SIZE)
                 ssize_t read_cnt;
-                read_cnt = ::pread(handle_->fd, internal_buf_pos, PAGE_SIZE, block_write_size);
+                read_cnt = ::pread(handle_->fd, internal_buf_pos, PAGE_SIZE, tail_offset);
                 if (read_cnt < 0)
                 {
                     fmt::print(stderr, "Cannot read the remaining file content block! ({})\n", std::strerror(errno));
@@ -904,7 +906,7 @@ ssize_t CuFileDriver::pwrite(const void* buf, size_t count, off_t file_offset, o
                     }
                 }
                 // Write the constructed block
-                write_cnt = ::pwrite(handle_->fd, internal_buf_pos, PAGE_SIZE, block_write_size);
+                write_cnt = ::pwrite(handle_->fd, internal_buf_pos, PAGE_SIZE, tail_offset);
                 if (write_cnt < 0)
                 {
                     fmt::print(stderr, "Cannot write the remaining file content! ({})\n", std::strerror(errno));

--- a/cpp/tests/test_cufile.cpp
+++ b/cpp/tests/test_cufile.cpp
@@ -68,9 +68,9 @@ TEST_CASE("Verify libcufile usage", "[test_cufile.cpp]")
     constexpr int W_FLAG_LEN = sizeof(test_w_flags) / sizeof(test_w_flags[0]);
     constexpr char const* test_r_flags[] = { "rpn", "rp", "rn", "r" };
     // clang-format off
-    constexpr int test_buf_offsets[] =  { 0,   0,   0,    0,  0,     0,    0,    0,    0,            0 };
-    constexpr int test_file_offsets[] = { 0, 500,   0,    0, 400,  400, 4000, 4500, 4500, 4096 * 2 - 1 };
-    constexpr int test_counts[] =       { 0,   0, 500, 4097, 500, 4097,  500,  500, 4097,          500 };
+    constexpr int test_buf_offsets[] =  { 0,   0,   0,    0,  0,     0,    0,    0,    0,            0,        0 };
+    constexpr int test_file_offsets[] = { 0, 500,   0,    0, 400,  400, 4000, 4500, 4500, 4096 * 2 - 1, 4096 };
+    constexpr int test_counts[] =       { 0,   0, 500, 4097, 500, 4097,  500,  500, 4097,          500, 4097 };
     // clang-format on
     constexpr int TEST_PARAM_LEN = sizeof(test_counts) / sizeof(test_counts[0]);
     uint8_t test_data[BLOCK_SECTOR_SIZE * 3];


### PR DESCRIPTION
## Summary

Fix the aligned `O_DIRECT` tail read/write path to use the correct absolute file offset for the final partial page.

## What changed

- use `file_offset + block_read_size` for the aligned tail `pread()`
- use `file_offset + block_write_size` for the aligned tail read-modify-write `pread()` and final `pwrite()`
- add a regression case for a page-aligned nonzero file offset with a non-page-aligned transfer size

## Why

The aligned tail path was using `block_read_size` / `block_write_size` as an absolute file offset. For nonzero page-aligned offsets, that makes the last partial-page operation read or write the wrong page.

That can corrupt file contents on writes and return incorrect bytes on reads.

## Validation

- reviewed the aligned `O_DIRECT` read and write control flow in `cufile_driver.cpp`
- added a regression case to `test_cufile.cpp` that exercises the affected path
- not run locally: this machine does not have the CUDA toolchain or GPU runtime available (`nvcc` and `nvidia-smi` are not installed)
