### PR TITLE
Fix per-process image cache key equality

### DIFF
--- a/cpp/src/cache/image_cache_per_process.cpp
+++ b/cpp/src/cache/image_cache_per_process.cpp
@@ -25,7 +25,7 @@ size_t hash<std::shared_ptr<cucim::cache::ImageCacheKey>>::operator()(
 bool equal_to<std::shared_ptr<cucim::cache::ImageCacheKey>>::operator()(
     const std::shared_ptr<cucim::cache::ImageCacheKey>& lhs, const std::shared_ptr<cucim::cache::ImageCacheKey>& rhs) const
 {
-    return lhs->location_hash == rhs->location_hash;
+    return lhs->file_hash == rhs->file_hash && lhs->location_hash == rhs->location_hash;
 }
 
 } // namespace std

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(cucim_tests
         main.cpp
         test_read_region.cpp
         test_cufile.cpp
+        test_image_cache.cpp
         test_metadata.cpp
         )
 

--- a/cpp/tests/test_image_cache.cpp
+++ b/cpp/tests/test_image_cache.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cucim/cache/image_cache_manager.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+
+namespace
+{
+
+std::shared_ptr<cucim::cache::ImageCacheValue> create_cache_value(cucim::cache::ImageCache& cache, uint8_t byte)
+{
+    auto* data = static_cast<uint8_t*>(cache.allocate(1));
+    REQUIRE(data != nullptr);
+    data[0] = byte;
+    return cache.create_value(data, 1, cucim::io::DeviceType::kCPU);
+}
+
+} // namespace
+
+TEST_CASE("Per-process image cache should distinguish file hash for matching tile locations", "[test_image_cache.cpp]")
+{
+    cucim::cache::ImageCacheConfig config{};
+    config.type = cucim::cache::CacheType::kPerProcess;
+    config.capacity = 4;
+    config.memory_capacity = 1;
+    config.list_padding = 1;
+
+    auto cache = cucim::cache::ImageCacheManager::create_cache(config, cucim::io::DeviceType::kCPU);
+
+    auto first_key = cache->create_key(0x101, 42);
+    auto second_key = cache->create_key(0x202, 42);
+    auto first_value = create_cache_value(*cache, 0x11);
+    auto second_value = create_cache_value(*cache, 0x22);
+
+    REQUIRE(cache->insert(first_key, first_value));
+    REQUIRE(cache->insert(second_key, second_value));
+
+    auto found_first = cache->find(first_key);
+    auto found_second = cache->find(second_key);
+
+    REQUIRE(found_first);
+    REQUIRE(found_second);
+    REQUIRE(found_first != found_second);
+    REQUIRE(static_cast<uint8_t*>(found_first->data)[0] == 0x11);
+    REQUIRE(static_cast<uint8_t*>(found_second->data)[0] == 0x22);
+}


### PR DESCRIPTION
## Summary

Fix per-process image cache key equality so entries with the same tile location but different file hashes do not alias.

## What changed

- compare both `file_hash` and `location_hash` in the per-process cache key equality functor
- add a CPU-only regression test that inserts two cache entries with the same tile location and different file hashes
- wire the new regression test into `cucim_tests`

## Why

The per-process cache hash already mixed `file_hash` and `location_hash`, but equality only compared `location_hash`.

That allowed different files or IFDs with matching tile coordinates to be treated as the same cache key, which could return the wrong cached tile or reject a valid insert as a duplicate.

## Validation

- reviewed the per-process cache hash/equality implementation and confirmed the mismatch with the shared-memory cache comparator
- added a regression test through the public cache manager API to exercise the collision case directly
- attempted local CMake configure, but this machine cannot build the project because `FindCUDAToolkit` fails to locate `nvcc`
