### PR TITLE
Fix stain normalizer float dtype detection

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -57,7 +57,7 @@ def image_to_absorbance(image, source_intensity=255.0, dtype=cp.float32):
             "Source transmitted light intensity must be a positive value."
         )
     source_intensity = float(source_intensity)
-    if input_dtype == "f":
+    if input_dtype.kind == "f":
         min_val = source_intensity / 255.0
         max_val = source_intensity
     else:

--- a/python/cucim/tests/unit/core/test_stain_normalizer.py
+++ b/python/cucim/tests/unit/core/test_stain_normalizer.py
@@ -6,9 +6,29 @@ import cupy as cp
 import pytest
 
 from cucim.core.operations.color import (
+    image_to_absorbance,
     normalize_colors_pca,
     stain_extraction_pca,
 )
+
+
+class TestImageToAbsorbance:
+    @pytest.mark.parametrize("dtype", [cp.float32, cp.float64])
+    def test_should_clip_normalized_float_input_if_dtype_is_float(self, dtype):
+        image = cp.asarray(
+            [0.0, 1.0 / 510.0, 1.0 / 255.0, 0.5, 1.5],
+            dtype=dtype,
+        )
+
+        result = image_to_absorbance(
+            image,
+            source_intensity=1.0,
+            dtype=dtype,
+        )
+        expected = -cp.log(cp.clip(image, 1.0 / 255.0, 1.0))
+
+        assert result.dtype == cp.dtype(dtype)
+        cp.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-6)
 
 
 class TestStainExtractorMacenko:


### PR DESCRIPTION
## Summary

Fix float input detection in `image_to_absorbance` so normalized floating-point images use the float clipping path.

## What changed

- detect float inputs with `image.dtype.kind == "f"` instead of comparing the dtype object to the string `"f"`
- add regression coverage for `float32` and `float64` inputs in `test_stain_normalizer.py`
- validate the normalized-float case with `source_intensity=1.0`, including lower-bound and upper-bound clipping

## Why

`image_to_absorbance` receives `image.dtype` as a dtype object, so the old `input_dtype == "f"` check was always false.

That sent float images through the integer clipping path. For normalized inputs, especially with `source_intensity=1.0`, values below `1.0` were clipped incorrectly before the absorbance transform.

## Validation

- reviewed the float/int clipping logic in `stain_normalizer.py`
- added direct unit coverage for `image_to_absorbance` with `float32` and `float64` inputs
- ran `python3 -m py_compile` on the changed source and test files
- could not run the Python unit tests locally because this machine does not have `cupy` installed
