### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - c-compiler
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - c-compiler
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=12.9

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - c-compiler
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - c-compiler
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version=13.3

--- a/conda/recipes/cucim/conda_build_config.yaml
+++ b/conda/recipes/cucim/conda_build_config.yaml
@@ -14,4 +14,4 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"

--- a/conda/recipes/libcucim/conda_build_config.yaml
+++ b/conda/recipes/libcucim/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 nvimgcodec_version:
   - ">=0.8.0,<0.9.0"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,7 +100,7 @@ dependencies:
       #   python/cucim/src/cucim/clara/ before calling `pip install .`.
       - output_types: [conda, requirements]
         packages:
-          - cmake>=4.0
+          - cmake>=4.0,<4.4
           - ninja
       - output_types: conda
         packages:


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
