### PR TITLE
selectively skip CI jobs based on changed files, update pre-commit hooks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,7 @@ jobs:
   pr-builder:
     needs:
       - build-details
+      - changed-files
       - checks
       - check-nightly-ci
       - conda-cpp-build
@@ -43,6 +44,113 @@ jobs:
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
+  changed-files:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      pull-requests: read
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
+    with:
+      files_yaml: |
+        build_docs:
+          - '**'
+          - '!.clang-format'
+          - '!.github/CODEOWNERS'
+          - '!.github/ISSUE_TEMPLATE/**'
+          - '!.github/PULL_REQUEST_TEMPLATE.md'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/workflows/trigger-breaking-change-alert.yaml'
+          - '!.github/zizmor.yml'
+          - '!.git-blame-ignore-revs'
+          - '!.editorconfig'
+          - '!.gitignore'
+          - '!.pre-commit-config.yaml'
+          - '!3rdparty/**'
+          - '!CHANGELOG.md'
+          - '!CONTRIBUTING.md'
+          - '!LICENSE'
+          - '!LICENSE-3rdparty.md'
+          - '!LICENSES/**'
+          - '!README.md'
+          - '!SECURITY.md'
+          - '!benchmarks/**'
+          - '!ci/build_wheel.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/**'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
+          - '!test_data/**'
+        test_python_conda:
+          - '**'
+          - '!.clang-format'
+          - '!.editorconfig'
+          - '!.github/CODEOWNERS'
+          - '!.github/ISSUE_TEMPLATE/**'
+          - '!.github/PULL_REQUEST_TEMPLATE.md'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/workflows/trigger-breaking-change-alert.yaml'
+          - '!.github/zizmor.yml'
+          - '!.git-blame-ignore-revs'
+          - '!.gitignore'
+          - '!.pre-commit-config.yaml'
+          - '!3rdparty/**'
+          - '!CHANGELOG.md'
+          - '!CONTRIBUTING.md'
+          - '!LICENSE'
+          - '!LICENSE-3rdparty.md'
+          - '!LICENSES/**'
+          - '!README.md'
+          - '!SECURITY.md'
+          - '!ci/build_wheel.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/**'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
+          - '!docs/**'
+          - '!notebooks/**'
+        test_python_wheels:
+          - '**'
+          - '!.clang-format'
+          - '!.editorconfig'
+          - '!.github/CODEOWNERS'
+          - '!.github/ISSUE_TEMPLATE/**'
+          - '!.github/PULL_REQUEST_TEMPLATE.md'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/workflows/trigger-breaking-change-alert.yaml'
+          - '!.github/zizmor.yml'
+          - '!.git-blame-ignore-revs'
+          - '!.gitignore'
+          - '!.pre-commit-config.yaml'
+          - '!3rdparty/**'
+          - '!CHANGELOG.md'
+          - '!CONTRIBUTING.md'
+          - '!LICENSE'
+          - '!LICENSE-3rdparty.md'
+          - '!LICENSES/**'
+          - '!README.md'
+          - '!SECURITY.md'
+          - '!ci/build_cpp.sh'
+          - '!ci/build_python.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/**'
+          - '!ci/test_python.sh'
+          - '!conda/**'
+          - '!docs/**'
+          - '!examples/**'
+          - '!notebooks/**'
   checks:
     needs: telemetry-setup
     permissions:
@@ -102,7 +210,8 @@ jobs:
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
   conda-python-tests:
-    needs: conda-python-build
+    needs: [conda-python-build, changed-files]
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     permissions:
       actions: read
       contents: read
@@ -115,7 +224,8 @@ jobs:
       build_type: pull-request
       script: ci/test_python.sh
   docs-build:
-    needs: conda-python-build
+    needs: [conda-python-build, changed-files]
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     permissions:
       actions: read
       contents: read
@@ -147,7 +257,8 @@ jobs:
       package-name: cucim
       package-type: python
   wheel-tests:
-    needs: wheel-build
+    needs: [wheel-build, changed-files]
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     permissions:
       actions: read
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # To install the git pre-commit hook run:
@@ -14,21 +14,21 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         types_or: [python, pyi]
         args: [--fix, --exit-non-zero-on-fix, --config, "python/cucim/pyproject.toml"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["--toml", "python/cucim/pyproject.toml"]
         additional_dependencies:
           - tomli
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.4.3
+    rev: v1.6.1
     hooks:
       - id: verify-copyright
         name: verify-copyright-cucim
@@ -600,16 +600,16 @@ repos:
             [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$|
             [.]code-workspace$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.0
+    rev: v1.22.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.29.0
     hooks:
       - id: zizmor


### PR DESCRIPTION
Closes #1128

Introduces the `changed-files` GitHub workflow used in many other RAPIDS repos. This configuration allows skipping CI in PRs based on which files changed.

For example, PRs that only change the README or `.gitignore` will now be mergeable without any test jobs that run on GPU runners 😁 

This also updates all pre-commit hooks via `pre-commit autoupdate`, to take advantage of the CI run + reviews.