### PR TITLE
ci: ensure pr-builder always runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,6 +29,9 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
   telemetry-setup:
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
#1131 introduced `changed-files` to skip CI based on which files a PR changes.

It missed also updating the `pr-builder` configuration to ensure that job always runs. That job is required by branch protections here, so when it is skipped merging will be blocked.

This fixes that.

## Notes for Reviewers

Changes like this one were made in most of the PRs for https://github.com/rapidsai/build-planning/issues/94, but `cucim` was excluded from that migration. I'm not sure why.