### PR TITLE
Add ImageCacheKey::lock_hash() so cache locking derives from the key

### DIFF
--- a/cpp/include/cucim/cache/image_cache.h
+++ b/cpp/include/cucim/cache/image_cache.h
@@ -26,6 +26,25 @@ struct EXPORT_VISIBLE ImageCacheKey
 {
     ImageCacheKey(uint64_t file_hash, uint64_t index);
 
+    /**
+     * @brief Hash identifying this key's lock in the cache's mutex pool.
+     *
+     * Pass this to ImageCache::lock(), unlock() and mutex() instead of
+     * deriving a hash at the call site.  Callers previously computed their own
+     * value next to the key they had just created, which meant the same tile
+     * was described two different ways in adjacent lines, and nothing tied the
+     * two together if one of them changed.
+     *
+     * The value only selects which mutex of the pool guards this entry, so it
+     * is not an identity: it does not have to be unique, but every lock(),
+     * unlock() and mutex() call for a given entry must derive it the same way
+     * or they will take different locks.  Deriving it from the key is what
+     * guarantees that.
+     *
+     * @return uint64_t
+     */
+    uint64_t lock_hash() const;
+
     uint64_t file_hash = 0; /// st_dev + st_ino + st_mtime + ifd_index
     uint64_t location_hash = 0; ///  tile_index or (x , y)
 };

--- a/cpp/plugins/cucim.kit.cuslide2/src/cuslide/tiff/ifd.cpp
+++ b/cpp/plugins/cucim.kit.cuslide2/src/cuslide/tiff/ifd.cpp
@@ -705,10 +705,6 @@ bool IFD::read([[maybe_unused]] const TIFF* tiff,
                 const size_t tile_buf_size = static_cast<size_t>(actual_tw) * actual_th * samples * bytes_per_px;
                 const uint32_t tile_row_stride = actual_tw * samples * bytes_per_px;
 
-                // Hash for per-tile locking
-                const uint64_t index_hash = ifd_hash ^
-                    (static_cast<uint64_t>(tile_index) | (static_cast<uint64_t>(tile_index) << 32));
-
                 // --- Cache lookup (RAII lock guard for exception safety) ---
                 auto key = image_cache.create_key(ifd_hash, tile_index);
 
@@ -722,7 +718,7 @@ bool IFD::read([[maybe_unused]] const TIFF* tiff,
                     ~CacheLockGuard() { if (locked) cache.unlock(hash); }
                     void unlock() { if (locked) { cache.unlock(hash); locked = false; } }
                 };
-                CacheLockGuard tile_lock(image_cache, index_hash);
+                CacheLockGuard tile_lock(image_cache, key->lock_hash());
 
                 auto cached_value = image_cache.find(key);
 

--- a/cpp/src/cache/image_cache.cpp
+++ b/cpp/src/cache/image_cache.cpp
@@ -14,6 +14,16 @@ ImageCacheKey::ImageCacheKey(uint64_t file_hash, uint64_t index) : file_hash(fil
 {
 }
 
+uint64_t ImageCacheKey::lock_hash() const
+{
+    // Spreading location_hash across both halves keeps consecutive tile indices
+    // in distinct pool slots once this is taken modulo the pool size, which is
+    // the access pattern tile assembly actually produces.  This reproduces what
+    // the IFD readers were computing inline, so which mutex a tile maps to is
+    // unchanged for them.
+    return file_hash ^ (location_hash | (location_hash << 32));
+}
+
 ImageCacheValue::ImageCacheValue(void* data, uint64_t size, void* user_obj, const cucim::io::DeviceType device_type)
     : data(data), size(size), user_obj(user_obj), device_type(device_type)
 {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(cucim_tests
         test_read_region.cpp
         test_cufile.cpp
         test_metadata.cpp
+        test_image_cache.cpp
         )
 
 set_target_properties(cucim_tests

--- a/cpp/tests/test_image_cache.cpp
+++ b/cpp/tests/test_image_cache.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cucim/cache/image_cache.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <set>
+
+using cucim::cache::ImageCacheKey;
+
+// The lock hash selects which mutex of the cache's pool guards an entry, so it
+// is deliberately not an identity.  What callers depend on is that it is a pure
+// function of the key: every lock(), unlock() and mutex() call for one entry has
+// to land on the same mutex, and deriving the hash from the key is what makes
+// that true regardless of where in the read path the call happens.
+TEST_CASE("ImageCacheKey::lock_hash is a pure function of the key", "[test_image_cache.cpp]")
+{
+    const uint64_t file_hash = 0x123456789abcdefULL;
+
+    SECTION("repeated calls agree")
+    {
+        ImageCacheKey key{ file_hash, 42 };
+        REQUIRE(key.lock_hash() == key.lock_hash());
+    }
+
+    SECTION("separately constructed but equal keys agree")
+    {
+        // This is the property the read path relies on: a key built during the
+        // lookup and a key built later for the insert must lock the same mutex.
+        ImageCacheKey first{ file_hash, 42 };
+        ImageCacheKey second{ file_hash, 42 };
+        REQUIRE(first.lock_hash() == second.lock_hash());
+    }
+
+    SECTION("matches what the IFD readers computed inline")
+    {
+        // Pins the value rather than just the behaviour, so that the existing
+        // readers keep mapping each tile onto the mutex they mapped it to
+        // before this method existed.
+        const uint64_t index = 42;
+        ImageCacheKey key{ file_hash, index };
+        REQUIRE(key.lock_hash() == (file_hash ^ (index | (index << 32))));
+    }
+}
+
+TEST_CASE("ImageCacheKey::lock_hash separates neighbouring tiles", "[test_image_cache.cpp]")
+{
+    SECTION("consecutive tile indices occupy distinct pool slots")
+    {
+        // Tile assembly walks a contiguous run of tile indices, so if neighbours
+        // collided in the mutex pool they would serialize against each other for
+        // no reason.  Checked modulo the pool size, which is how the pool is
+        // actually indexed.
+        constexpr uint64_t pool_capacity = 64;
+        const uint64_t file_hash = 0xfeedfacecafebeefULL;
+
+        std::set<uint64_t> slots;
+        for (uint64_t index = 0; index < pool_capacity; ++index)
+        {
+            slots.insert(ImageCacheKey{ file_hash, index }.lock_hash() % pool_capacity);
+        }
+        REQUIRE(slots.size() == pool_capacity);
+    }
+
+    SECTION("the same tile index in different IFDs does not share a slot")
+    {
+        // Tiles from different IFDs are independent entries; they should not
+        // contend just because they sit at the same grid position.
+        constexpr uint64_t index = 7;
+        ImageCacheKey first{ 0x1111111111111111ULL, index };
+        ImageCacheKey second{ 0x2222222222222222ULL, index };
+        REQUIRE(first.lock_hash() != second.lock_hash());
+    }
+}


### PR DESCRIPTION
Implements #1066, addressing @mkepa-nv's review note on #1034:

> This interleaved usage of `index_hash` and `key` looks error prone. Maybe in a future MPR it would be better to use `key` for `lock()`?

## The problem

The cuslide2 tile path built a key from `(ifd_hash, tile_index)` and then, on an adjacent line, computed a separate `index_hash` from those same two values by hand:

```cpp
// Hash for per-tile locking
const uint64_t index_hash = ifd_hash ^
    (static_cast<uint64_t>(tile_index) | (static_cast<uint64_t>(tile_index) << 32));

// --- Cache lookup (RAII lock guard for exception safety) ---
auto key = image_cache.create_key(ifd_hash, tile_index);
```

The same tile was described two different ways with nothing tying them together, so changing one would silently not reach the other.

Worth being explicit about why that is worse than ordinary duplication: the hash only selects which mutex of the pool guards an entry, so a divergence would not fail loudly or immediately. `lock()` and `unlock()` would simply operate on different mutexes, and the tile would be decoded and inserted with no lock actually held. That is a latent data race, not a crash.

## The change

`ImageCacheKey::lock_hash()` derives the value from the key, and cuslide2 passes `key->lock_hash()` to its lock guard. The formula is exactly the one the IFD readers computed inline, so every tile still maps onto the mutex it mapped to before — **no behavioural change**.

## Scope

Deliberately limited to cuslide2, the file the review comment was on. Two other places derive a lock hash by hand and are left alone:

- **Legacy cuslide `ifd.cpp`** keeps its `index_hash` because a `PROF_SCOPED_RANGE` profiling marker consumes it earlier in the function, before any key exists.
- **`NvJpegProcessor`** derives its lock hash with `splitmix64(index)` in both `request()` and `wait_for_processing()`.

Both are self-consistent today, so converting them would change which mutex a tile maps to without any functional gain, on a code path I cannot test here. `lock_hash()` is available to them whenever that code is next touched with tests to back the change.

## Tests

`cpp/tests/test_image_cache.cpp` covers the invariants callers actually depend on rather than restating the implementation:

- the hash is a pure function of the key
- separately constructed equal keys agree — this is the real-world case, where the lookup and the later insert each build their own key
- the value still matches the previous inline formula, pinning the no-behaviour-change claim
- consecutive tile indices land in distinct pool slots, which is the access pattern tile assembly produces
- one tile index in different IFDs does not share a slot

## Verification

`-fsyntax-only` against the project's own `compile_commands.json` for `image_cache.cpp`, `ifd.cpp` and the new test, which compiles under the test target's `-Werror -Wall -Wextra`. All clean.

I also executed the test assertions standalone, since compiling a test proves nothing about whether it passes:

```
  repeated calls agree                                       PASS
  equal keys agree                                           PASS
  matches inline IFD formula                                 PASS
  64 consecutive indices -> 64 distinct slots                PASS
  same index, different IFD -> different hash                PASS
  pool=8 -> all distinct                                     PASS
  pool=16 -> all distinct                                    PASS
  pool=32 -> all distinct                                    PASS
  pool=128 -> all distinct                                   PASS
  pool=256 -> all distinct                                   PASS
```

The distinct-slot property holds across pool sizes 8 through 256, so the assertion is not overfit to the single size the test uses.

## Unrelated issue noticed nearby, not fixed here

While tracing the key's hashing I found that `PerProcessImageCache`'s equality comparator ignores `file_hash`:

https://github.com/rapidsai/cucim/blob/main/cpp/src/cache/image_cache_per_process.cpp#L25-L29

```cpp
bool equal_to<std::shared_ptr<cucim::cache::ImageCacheKey>>::operator()(
    const std::shared_ptr<cucim::cache::ImageCacheKey>& lhs, const std::shared_ptr<cucim::cache::ImageCacheKey>& rhs) const
{
    return lhs->location_hash == rhs->location_hash;
}
```

`std::hash` for the same key does combine both fields, so two keys differing only in `file_hash` normally land in different buckets and the comparator is never asked. But bucket assignment is `hash % bucket_count`, so a collision is possible, and when it happens this returns a tile belonging to a different image or IFD. `SharedMemoryImageCache`'s comparator does compare both fields, which suggests this one is an oversight rather than intentional.

Left out of this PR since it is a separate defect with its own behavioural risk. Happy to file it as its own issue if you agree it is one.
