### PR TITLE
Route device allocations through a CCCL memory resource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ find_package(Threads REQUIRED)
 ################################################################################
 superbuild_depend(fmt)
 #superbuild_depend(boost)
+superbuild_depend(cccl)
 superbuild_depend(abseil)
 superbuild_depend(googletest)
 superbuild_depend(googlebenchmark)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(${CUCIM_PACKAGE_NAME}
         src/loader/thread_batch_data_loader.cpp
         src/logger/logger.cpp
         src/logger/timer.cpp
+        src/memory/device_resources.cpp
         src/memory/memory_manager.cpp
         src/plugin/image_format.cpp
         src/plugin/plugin_config.cpp
@@ -155,6 +156,24 @@ target_link_libraries(${CUCIM_PACKAGE_NAME}
             deps::json
             deps::nvtx3
             deps::taskflow
+        )
+
+# CCCL's headers have to be searched before the CUDA toolkit's.
+#
+# The toolkit ships its own copy of libcudacxx, and for every CUDA version
+# cuCIM supports that copy predates cuda::mr. If the toolkit include directory
+# (pulled in by CUDA::cudart_static) is searched first, CCCL's
+# <cuda/memory_resource> still resolves but the cuda/std/* headers it depends
+# on come from the toolkit, the version guards do not line up, and cuda::mr
+# silently disappears. BEFORE is what keeps the two copies from being mixed.
+#
+# PUBLIC because <cucim/memory/device_resources.h> exposes cuda::mr types.
+# BUILD_INTERFACE only: installed consumers of that header still need CCCL
+# exported or a cuda-cccl dependency added, which is not done yet.
+target_include_directories(${CUCIM_PACKAGE_NAME}
+        BEFORE
+        PUBLIC
+            $<BUILD_INTERFACE:${deps-cccl_SOURCE_DIR}/libcudacxx/include>
         )
 
 if (CUCIM_STATIC_GDS)

--- a/cpp/cmake/deps/cccl.cmake
+++ b/cpp/cmake/deps/cccl.cmake
@@ -1,0 +1,43 @@
+#
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+#
+
+if (NOT TARGET deps::cccl)
+    FetchContent_Declare(
+            deps-cccl
+            GIT_REPOSITORY https://github.com/NVIDIA/cccl.git
+            GIT_TAG v3.4.2
+            GIT_SHALLOW TRUE
+            # `libcudacxx/include` holds no CMakeLists.txt, so this downloads the
+            # sources without configuring CCCL's own project, which would build
+            # Thrust, CUB and their test suites. Only the header-only
+            # `cuda::mr` types are needed here.
+            SOURCE_SUBDIR libcudacxx/include
+            EXCLUDE_FROM_ALL
+    )
+    message(STATUS "Fetching CCCL sources")
+
+    FetchContent_MakeAvailable(deps-cccl)
+    message(STATUS "Fetching CCCL sources - done")
+
+    # Note for consumers: linking this target is not by itself enough for any
+    # target that also pulls in the CUDA toolkit include directory. The toolkit
+    # bundles an older libcudacxx, and whichever include directory is searched
+    # first wins for cuda/std/*, which decides whether cuda::mr exists at all.
+    # Targets in that situation add this directory with
+    # target_include_directories(... BEFORE ...); see cpp/CMakeLists.txt.
+    add_library(deps::cccl INTERFACE IMPORTED GLOBAL)
+    # SYSTEM so that CCCL's own headers do not trip cuCIM's -Werror settings.
+    set_target_properties(deps::cccl PROPERTIES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+            "${deps-cccl_SOURCE_DIR}/libcudacxx/include"
+        INTERFACE_INCLUDE_DIRECTORIES
+            "${deps-cccl_SOURCE_DIR}/libcudacxx/include"
+    )
+
+    set(deps-cccl_SOURCE_DIR ${deps-cccl_SOURCE_DIR} CACHE INTERNAL "" FORCE)
+    mark_as_advanced(deps-cccl_SOURCE_DIR)
+endif ()

--- a/cpp/include/cucim/memory/device_resources.h
+++ b/cpp/include/cucim/memory/device_resources.h
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CUCIM_MEMORY_DEVICE_RESOURCES_H
+#define CUCIM_MEMORY_DEVICE_RESOURCES_H
+
+#include "cucim/core/framework.h"
+#include "cucim/io/device.h"
+
+#include <cuda/memory_resource>
+#include <cuda/stream_ref>
+
+#include <cstddef>
+
+/**
+ * Device memory allocation through a caller-supplied CCCL memory resource.
+ *
+ * Note on packaging: this header exposes `cuda::mr` types, so anything
+ * including it needs CCCL headers on its include path. The build links CCCL
+ * through `$<BUILD_INTERFACE:deps::cccl>`; exporting it for installed consumers
+ * (either by installing the headers or by depending on `cuda-cccl`) is still
+ * outstanding.
+ */
+namespace cucim::memory
+{
+
+/**
+ * @brief The set of CCCL properties cuCIM requires of a device memory resource.
+ *
+ * Device-accessible only. cuCIM hands the resulting pointers to CUDA kernels,
+ * nvImageCodec and `__cuda_array_interface__` consumers, none of which can use
+ * host-only memory.
+ */
+using device_accessible = ::cuda::mr::device_accessible;
+
+/**
+ * @brief Alignment cuCIM requests for device allocations.
+ *
+ * `cudaMalloc` already guarantees at least this much, so the default resource
+ * ignores the value; it is stated explicitly because a pool resource supplied
+ * by the caller will honour it, and image rows are addressed on 256-byte
+ * boundaries downstream.
+ */
+inline constexpr std::size_t kDefaultAlignment = 256;
+
+/**
+ * @brief Stream-ordered, device-accessible resource reference.
+ *
+ * This is the type that should appear in cuCIM APIs that allocate device
+ * memory. It binds to resources from either CCCL or RMM, so callers already
+ * holding an `rmm::device_async_resource_ref` can pass it straight through.
+ */
+using device_resource_ref = ::cuda::mr::resource_ref<device_accessible>;
+
+/**
+ * @brief Owning, type-erased, device-accessible resource.
+ *
+ * Used where cuCIM has to keep a resource alive rather than borrow one, most
+ * importantly for memory handed back to the user: whatever allocated a buffer
+ * has to still exist when that buffer is freed, which for an image can be long
+ * after the call that produced it returned.
+ */
+using any_device_resource = ::cuda::mr::any_resource<device_accessible>;
+
+/**
+ * @brief A resource that allocates with `cudaMalloc` and frees with `cudaFree`.
+ *
+ * This is what cuCIM did before memory resources existed, expressed as a
+ * resource so that the default path stays byte-for-byte what it was and only
+ * callers who supply their own resource see different behaviour.
+ *
+ * Stateless, so it can be stored by value and compares equal to every other
+ * instance. Being stateless is also why it needs no global: there is nothing
+ * to share.
+ *
+ * The stream-ordered overloads ignore the stream, since `cudaMalloc` and
+ * `cudaFree` synchronize the whole device rather than a single stream. That
+ * makes them correct but not stream-ordered, which is the reason a caller
+ * wanting real asynchrony should pass a pool resource instead.
+ */
+class EXPORT_VISIBLE CudaMemoryResource
+{
+public:
+    void* allocate_sync(std::size_t bytes, std::size_t alignment);
+    void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment);
+
+    void* allocate(::cuda::stream_ref stream, std::size_t bytes, std::size_t alignment);
+    void deallocate(::cuda::stream_ref stream, void* ptr, std::size_t bytes, std::size_t alignment);
+
+    bool operator==(const CudaMemoryResource&) const noexcept
+    {
+        return true;
+    }
+    bool operator!=(const CudaMemoryResource&) const noexcept
+    {
+        return false;
+    }
+
+    friend void get_property(const CudaMemoryResource&, device_accessible) noexcept
+    {
+    }
+};
+
+/**
+ * @brief Where device memory comes from, and the stream that orders it.
+ *
+ * Deliberately not a singleton and never consulted from global scope. RAPIDS
+ * guidance is to avoid a process-wide "current" resource, because it makes the
+ * owner of a buffer impossible to determine locally and is being removed from
+ * RMM; instead an instance of this is passed to whatever needs to allocate, and
+ * carried by objects that own device memory so they can free it through the
+ * same resource later.
+ *
+ * The resource is held by value in an owning `any_device_resource` rather than
+ * as a bare `device_resource_ref`. A reference would be the cheaper choice but
+ * would let a handle outlive what it points at, which is easy to do here since
+ * handles get copied into images that may outlive the call that created them.
+ *
+ * Because it owns, constructing a handle *copies* the resource, and so does
+ * copying a handle. For the usual case that is what you want: callers wrap a
+ * reference to their allocator, such as an `rmm::device_async_resource_ref`,
+ * and copying a reference still points at the one underlying pool. Wrapping a
+ * stateful allocator *by value* instead would duplicate it, and the copy the
+ * handle owns is then the one that serves every request.
+ *
+ * Default construction yields the pre-existing behaviour: `cudaMalloc` and
+ * `cudaFree` on the default stream.
+ */
+class EXPORT_VISIBLE DeviceResources
+{
+public:
+    /// Raw `cudaMalloc`/`cudaFree` on the default stream.
+    DeviceResources();
+
+    /// Allocate from *resource*, ordering allocations on *stream*.
+    explicit DeviceResources(any_device_resource resource,
+                             ::cuda::stream_ref stream = ::cuda::stream_ref{ cudaStream_t{} });
+
+    /**
+     * @brief Allocate *bytes* of device memory.
+     *
+     * @return pointer to device memory, or nullptr when *bytes* is 0.
+     * @throws std::bad_alloc if the resource cannot satisfy the request.
+     */
+    void* allocate(std::size_t bytes);
+
+    /**
+     * @brief Return memory obtained from allocate().
+     *
+     * *bytes* must be the size originally requested; pool resources need it to
+     * return the block to the right free list, unlike `cudaFree`.
+     */
+    void deallocate(void* ptr, std::size_t bytes) noexcept;
+
+    /**
+     * @brief Borrowed reference, for handing to APIs that take a resource.
+     *
+     * Non-const because a `resource_ref` allocates through the resource it
+     * refers to, so CCCL will only build one from a non-const resource.
+     */
+    device_resource_ref resource() noexcept;
+
+    ::cuda::stream_ref stream() const noexcept
+    {
+        return stream_;
+    }
+
+private:
+    any_device_resource resource_;
+    ::cuda::stream_ref stream_;
+};
+
+/**
+ * @brief move_raster_from_host() allocating from *resources*.
+ *
+ * Same contract as the overload in memory_manager.h, except that the device
+ * memory written to *target* comes from *resources*. The caller therefore has
+ * to free it through the same resource, so it must keep *resources* alive at
+ * least as long as the buffer.
+ *
+ * Declared here rather than beside the original in memory_manager.h because
+ * that header is included throughout the plugins, which would then all need
+ * CCCL on their include path.
+ *
+ * EXPORT_VISIBLE rather than CUCIM_API: the latter adds `extern "C"`, which
+ * would both rule out overloading the existing name and be wrong for a
+ * function taking a C++ reference.
+ */
+EXPORT_VISIBLE bool move_raster_from_host(void** target,
+                                          size_t size,
+                                          const cucim::io::Device& dst_device,
+                                          DeviceResources& resources);
+
+/**
+ * @brief move_raster_from_device() freeing through *resources*.
+ *
+ * *resources* must be the resource that allocated `*target`; this releases it
+ * after copying to the host. Passing a different resource is undefined, which
+ * is why the plain overload in memory_manager.h still exists for buffers that
+ * came from raw `cudaMalloc` (notably anything allocated inside a plugin).
+ */
+EXPORT_VISIBLE bool move_raster_from_device(void** target,
+                                            size_t size,
+                                            const cucim::io::Device& dst_device,
+                                            DeviceResources& resources);
+
+} // namespace cucim::memory
+
+#endif // CUCIM_MEMORY_DEVICE_RESOURCES_H

--- a/cpp/src/cache/image_cache_per_process.cpp
+++ b/cpp/src/cache/image_cache_per_process.cpp
@@ -46,8 +46,9 @@ struct PerProcessImageCacheItem
 PerProcessImageCacheValue::PerProcessImageCacheValue(void* data,
                                                      uint64_t size,
                                                      void* user_obj,
-                                                     const cucim::io::DeviceType device_type)
-    : ImageCacheValue(data, size, user_obj, device_type){};
+                                                     const cucim::io::DeviceType device_type,
+                                                     cucim::memory::DeviceResources device_resources)
+    : ImageCacheValue(data, size, user_obj, device_type), device_resources_(std::move(device_resources)){};
 
 PerProcessImageCacheValue::~PerProcessImageCacheValue()
 {
@@ -59,8 +60,10 @@ PerProcessImageCacheValue::~PerProcessImageCacheValue()
             cucim_free(data);
             break;
         case io::DeviceType::kCUDA: {
-            cudaError_t cuda_status;
-            CUDA_TRY(cudaFree(data));
+            // Returned to the resource that allocated it, not to cudaFree: a
+            // pool resource has to get its block back to stay a pool, and
+            // `size` is what tells it which block this was.
+            device_resources_.deallocate(data, size);
             break;
         }
         case io::DeviceType::kCUDAHost:
@@ -103,7 +106,15 @@ std::shared_ptr<ImageCacheValue> PerProcessImageCache::create_value(void* data,
                                                                     uint64_t size,
                                                                     const cucim::io::DeviceType device_type)
 {
-    return std::make_shared<PerProcessImageCacheValue>(data, size, nullptr, device_type);
+    // The value keeps the resource so it can free through it later, which is
+    // the only way the pairing stays correct if set_device_resources() swaps
+    // the resource while this entry is still cached.
+    return std::make_shared<PerProcessImageCacheValue>(data, size, nullptr, device_type, device_resources_);
+}
+
+void PerProcessImageCache::set_device_resources(cucim::memory::DeviceResources device_resources)
+{
+    device_resources_ = std::move(device_resources);
 }
 
 void* PerProcessImageCache::allocate(std::size_t n)
@@ -113,10 +124,17 @@ void* PerProcessImageCache::allocate(std::size_t n)
     case io::DeviceType::kCPU:
         return cucim_malloc(n);
     case io::DeviceType::kCUDA: {
-        cudaError_t cuda_status;
-        void* image_data_ptr = nullptr;
-        CUDA_TRY(cudaMalloc(&image_data_ptr, n));
-        return image_data_ptr;
+        // The resource throws on failure, whereas this returns nullptr to
+        // signal "no room in the cache" to callers that then decode without
+        // caching. Keep that contract rather than propagating.
+        try
+        {
+            return device_resources_.allocate(n);
+        }
+        catch (const std::bad_alloc&)
+        {
+            return nullptr;
+        }
     }
     case io::DeviceType::kCUDAHost:
     case io::DeviceType::kCUDAManaged:

--- a/cpp/src/cache/image_cache_per_process.h
+++ b/cpp/src/cache/image_cache_per_process.h
@@ -7,6 +7,7 @@
 #define CUCIM_CACHE_IMAGE_CACHE_PER_PROCESS_H
 
 #include "cucim/cache/image_cache.h"
+#include "cucim/memory/device_resources.h"
 
 #include <libcuckoo/cuckoohash_map.hh>
 #include <memory>
@@ -38,11 +39,25 @@ struct PerProcessImageCacheItem;
 
 struct PerProcessImageCacheValue : public ImageCacheValue
 {
+    /**
+     * @param device_resources Resource that allocated *data*, when
+     *        *device_type* is kCUDA. Held by value rather than by reference
+     *        because a cached value can outlive the cache that produced it
+     *        (an entry evicted while a reader still holds it is destroyed
+     *        last), and freeing through a dangling resource would be worse
+     *        than the duplicated handle. Copying is cheap: the handle is a
+     *        type-erased resource plus a stream.
+     */
     PerProcessImageCacheValue(void* data,
                               uint64_t size,
                               void* user_obj = nullptr,
-                              const cucim::io::DeviceType device_type = cucim::io::DeviceType::kCPU);
+                              const cucim::io::DeviceType device_type = cucim::io::DeviceType::kCPU,
+                              cucim::memory::DeviceResources device_resources = {});
     ~PerProcessImageCacheValue() override;
+
+private:
+    /// Must be the resource that allocated `data`; see the constructor.
+    cucim::memory::DeviceResources device_resources_;
 };
 
 
@@ -91,6 +106,19 @@ public:
 
     std::shared_ptr<ImageCacheValue> find(const std::shared_ptr<ImageCacheKey>& key) override;
 
+    /**
+     * @brief Allocate device tiles from *device_resources* from now on.
+     *
+     * Only affects allocations made after the call. Entries already cached
+     * keep a copy of the resource they were allocated from, so they are still
+     * freed correctly; the two resources simply coexist until those entries
+     * are evicted.
+     *
+     * Not declared on ImageCache because that header is included by the
+     * plugins, which would then all need CCCL on their include path.
+     */
+    void set_device_resources(cucim::memory::DeviceResources device_resources);
+
 private:
     bool is_list_full() const;
     bool is_memory_full(uint64_t additional_size = 0) const;
@@ -98,6 +126,9 @@ private:
     bool erase(const std::shared_ptr<ImageCacheKey>& key);
 
     std::vector<std::mutex> mutex_array_;
+
+    /// Where device tiles come from. Defaults to cudaMalloc/cudaFree.
+    cucim::memory::DeviceResources device_resources_;
 
     std::atomic<uint64_t> size_nbytes_ = 0; /// size of cache memory used
     uint64_t capacity_nbytes_ = 0; /// size of cache memory allocated

--- a/cpp/src/memory/device_resources.cpp
+++ b/cpp/src/memory/device_resources.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cucim/memory/device_resources.h"
+
+#include "cucim/profiler/nvtx3.h"
+
+#include <cuda_runtime.h>
+
+#include <new>
+
+namespace cucim::memory
+{
+
+void* CudaMemoryResource::allocate_sync(std::size_t bytes, std::size_t /*alignment*/)
+{
+    PROF_SCOPED_RANGE(PROF_EVENT_P(cucim_malloc, bytes));
+
+    if (bytes == 0)
+    {
+        return nullptr;
+    }
+
+    // cudaMalloc already satisfies any alignment cuCIM asks for (256 bytes),
+    // so the requested alignment needs no extra handling.
+    void* ptr = nullptr;
+    if (cudaMalloc(&ptr, bytes) != cudaSuccess)
+    {
+        // Clear the sticky error so the next CUDA call is not blamed for this
+        // failure, then report it the way a resource is expected to.
+        static_cast<void>(cudaGetLastError());
+        throw std::bad_alloc();
+    }
+    return ptr;
+}
+
+void CudaMemoryResource::deallocate_sync(void* ptr, std::size_t /*bytes*/, std::size_t /*alignment*/)
+{
+    PROF_SCOPED_RANGE(PROF_EVENT(cucim_free));
+
+    if (ptr != nullptr)
+    {
+        static_cast<void>(cudaFree(ptr));
+    }
+}
+
+void* CudaMemoryResource::allocate(::cuda::stream_ref /*stream*/, std::size_t bytes, std::size_t alignment)
+{
+    // cudaMalloc synchronizes the device, so it is trivially ordered with
+    // respect to any stream and the argument can be ignored.
+    return allocate_sync(bytes, alignment);
+}
+
+void CudaMemoryResource::deallocate(::cuda::stream_ref /*stream*/,
+                                    void* ptr,
+                                    std::size_t bytes,
+                                    std::size_t alignment)
+{
+    deallocate_sync(ptr, bytes, alignment);
+}
+
+DeviceResources::DeviceResources()
+    : resource_(CudaMemoryResource{}), stream_(::cuda::stream_ref{ cudaStream_t{} })
+{
+}
+
+DeviceResources::DeviceResources(any_device_resource resource, ::cuda::stream_ref stream)
+    : resource_(std::move(resource)), stream_(stream)
+{
+}
+
+void* DeviceResources::allocate(std::size_t bytes)
+{
+    if (bytes == 0)
+    {
+        return nullptr;
+    }
+    return resource_.allocate(stream_, bytes, kDefaultAlignment);
+}
+
+void DeviceResources::deallocate(void* ptr, std::size_t bytes) noexcept
+{
+    if (ptr == nullptr)
+    {
+        return;
+    }
+    // Deallocation runs from destructors, where letting an exception escape
+    // would terminate the process; a leak is the better failure here.
+    try
+    {
+        resource_.deallocate(stream_, ptr, bytes, kDefaultAlignment);
+    }
+    catch (...)
+    {
+    }
+}
+
+device_resource_ref DeviceResources::resource() noexcept
+{
+    return device_resource_ref{ resource_ };
+}
+
+} // namespace cucim::memory

--- a/cpp/src/memory/memory_manager.cpp
+++ b/cpp/src/memory/memory_manager.cpp
@@ -7,12 +7,11 @@
 
 #include "cucim/memory/memory_manager.h"
 
-#include <memory_resource>
-
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 
 #include "cucim/io/device_type.h"
+#include "cucim/memory/device_resources.h"
 #include "cucim/profiler/nvtx3.h"
 #include "cucim/util/cuda.h"
 
@@ -64,7 +63,10 @@ void get_pointer_attributes(PointerAttributes& attr, const void* ptr)
     }
 }
 
-CUCIM_API bool move_raster_from_host(void** target, size_t size, const cucim::io::Device& dst_device)
+EXPORT_VISIBLE bool move_raster_from_host(void** target,
+                                          size_t size,
+                                          const cucim::io::Device& dst_device,
+                                          DeviceResources& resources)
 {
     switch (dst_device.type())
     {
@@ -73,15 +75,15 @@ CUCIM_API bool move_raster_from_host(void** target, size_t size, const cucim::io
     case cucim::io::DeviceType::kCUDA: {
         cudaError_t cuda_status;
         void* host_mem = *target;
-        void* cuda_mem;
-        CUDA_TRY(cudaMalloc(&cuda_mem, size));
-        if (cuda_status)
-        {
-            throw std::bad_alloc();
-        }
+        // Throws std::bad_alloc on failure, which is what the hand-rolled
+        // check below used to raise.
+        void* cuda_mem = resources.allocate(size);
         CUDA_TRY(cudaMemcpy(cuda_mem, host_mem, size, cudaMemcpyHostToDevice));
         if (cuda_status)
         {
+            // Give the block back before unwinding, or the failed transfer
+            // leaks it. The original code leaked here.
+            resources.deallocate(cuda_mem, size);
             throw std::bad_alloc();
         }
         cucim_free(host_mem);
@@ -94,7 +96,10 @@ CUCIM_API bool move_raster_from_host(void** target, size_t size, const cucim::io
     return true;
 }
 
-CUCIM_API bool move_raster_from_device(void** target, size_t size, const cucim::io::Device& dst_device)
+EXPORT_VISIBLE bool move_raster_from_device(void** target,
+                                            size_t size,
+                                            const cucim::io::Device& dst_device,
+                                            DeviceResources& resources)
 {
     switch (dst_device.type())
     {
@@ -105,9 +110,10 @@ CUCIM_API bool move_raster_from_device(void** target, size_t size, const cucim::
         CUDA_TRY(cudaMemcpy(host_mem, cuda_mem, size, cudaMemcpyDeviceToHost));
         if (cuda_status)
         {
+            cucim_free(host_mem);
             throw std::bad_alloc();
         }
-        cudaFree(cuda_mem);
+        resources.deallocate(cuda_mem, size);
         *target = host_mem;
         break;
     }
@@ -117,6 +123,26 @@ CUCIM_API bool move_raster_from_device(void** target, size_t size, const cucim::
         throw std::runtime_error("Unsupported device type");
     }
     return true;
+}
+
+// The resource-free overloads are the long-standing entry points and are what
+// the plugins call. They delegate to a default-constructed handle, which is
+// cudaMalloc/cudaFree, so their behaviour is unchanged.
+//
+// This is also the only correct thing they can do: a buffer allocated inside a
+// plugin came from a raw cudaMalloc, and freeing it through a caller's pool
+// resource would corrupt that pool.
+
+CUCIM_API bool move_raster_from_host(void** target, size_t size, const cucim::io::Device& dst_device)
+{
+    DeviceResources resources{};
+    return move_raster_from_host(target, size, dst_device, resources);
+}
+
+CUCIM_API bool move_raster_from_device(void** target, size_t size, const cucim::io::Device& dst_device)
+{
+    DeviceResources resources{};
+    return move_raster_from_device(target, size, dst_device, resources);
 }
 
 } // namespace cucim::memory

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(cucim_tests
         test_read_region.cpp
         test_cufile.cpp
         test_metadata.cpp
+        test_device_resources.cpp
         )
 
 set_target_properties(cucim_tests
@@ -50,6 +51,15 @@ target_link_libraries(cucim_tests
             deps::openslide
             deps::taskflow
             Threads::Threads # -lpthread
+        )
+
+# Same reason as in cpp/CMakeLists.txt: CCCL must be searched before the CUDA
+# toolkit's older bundled libcudacxx, and CUDA::cudart_static above brings the
+# toolkit include directory in.
+target_include_directories(cucim_tests
+        BEFORE
+        PRIVATE
+            ${deps-cccl_SOURCE_DIR}/libcudacxx/include
         )
 
 include(Catch)

--- a/cpp/tests/test_device_resources.cpp
+++ b/cpp/tests/test_device_resources.cpp
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cucim/memory/device_resources.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <new>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using cucim::memory::any_device_resource;
+using cucim::memory::CudaMemoryResource;
+using cucim::memory::DeviceResources;
+using cucim::memory::device_resource_ref;
+
+namespace
+{
+
+/**
+ * A resource that hands out host memory and records what it was asked for.
+ *
+ * Host memory is deliberate: these tests are about whether cuCIM routes its
+ * allocations through the resource it was given and pairs every allocation
+ * with a matching deallocation, and answering that does not require a GPU.
+ * Claiming `device_accessible` is a lie that nothing here dereferences.
+ */
+class TrackingResource
+{
+public:
+    void* allocate_sync(std::size_t bytes, std::size_t alignment)
+    {
+        ++allocate_calls;
+        last_alignment = alignment;
+        void* ptr = ::operator new(bytes);
+        outstanding[ptr] = bytes;
+        return ptr;
+    }
+
+    void deallocate_sync(void* ptr, std::size_t bytes, std::size_t)
+    {
+        ++deallocate_calls;
+        auto it = outstanding.find(ptr);
+        // A resource is only able to reclaim a block if it is told the size it
+        // handed out; a pool would corrupt its free lists otherwise.
+        if (it != outstanding.end())
+        {
+            size_matched_on_free = size_matched_on_free && (it->second == bytes);
+            outstanding.erase(it);
+        }
+        else
+        {
+            saw_foreign_pointer = true;
+        }
+        ::operator delete(ptr);
+    }
+
+    void* allocate(::cuda::stream_ref, std::size_t bytes, std::size_t alignment)
+    {
+        return allocate_sync(bytes, alignment);
+    }
+
+    void deallocate(::cuda::stream_ref, void* ptr, std::size_t bytes, std::size_t alignment)
+    {
+        deallocate_sync(ptr, bytes, alignment);
+    }
+
+    bool operator==(const TrackingResource& other) const noexcept
+    {
+        return this == &other;
+    }
+    bool operator!=(const TrackingResource& other) const noexcept
+    {
+        return this != &other;
+    }
+
+    friend void get_property(const TrackingResource&, cucim::memory::device_accessible) noexcept
+    {
+    }
+
+    int allocate_calls = 0;
+    int deallocate_calls = 0;
+    std::size_t last_alignment = 0;
+    bool size_matched_on_free = true;
+    bool saw_foreign_pointer = false;
+    std::unordered_map<void*, std::size_t> outstanding;
+};
+
+/// A resource that refuses every request, to exercise the failure path.
+class FailingResource
+{
+public:
+    void* allocate_sync(std::size_t, std::size_t)
+    {
+        throw std::bad_alloc();
+    }
+    void deallocate_sync(void*, std::size_t, std::size_t) {}
+    void* allocate(::cuda::stream_ref, std::size_t, std::size_t)
+    {
+        throw std::bad_alloc();
+    }
+    void deallocate(::cuda::stream_ref, void*, std::size_t, std::size_t) {}
+
+    bool operator==(const FailingResource&) const noexcept
+    {
+        return true;
+    }
+    bool operator!=(const FailingResource&) const noexcept
+    {
+        return false;
+    }
+    friend void get_property(const FailingResource&, cucim::memory::device_accessible) noexcept
+    {
+    }
+};
+
+/**
+ * Reach the resource that *resources* actually allocates from.
+ *
+ * `any_device_resource` stores the resource by value and DeviceResources takes
+ * it by value in turn, so the object handed to the constructor is not the one
+ * serving requests. Anything inspecting a stateful resource has to go through
+ * the handle, which is what this does. The returned pointer refers into the
+ * handle, so it stays valid for as long as *resources* does.
+ */
+TrackingResource* tracker_of(DeviceResources& resources)
+{
+    auto ref = resources.resource();
+    return ::cuda::mr::resource_cast<TrackingResource>(&ref);
+}
+
+} // namespace
+
+// The whole point of adopting CCCL rather than inventing another allocator
+// interface is that a resource written elsewhere - by RMM, by CCCL, or by a
+// user - drops in. If cuCIM's own resources stopped satisfying the concepts,
+// none of them would be interchangeable any more.
+TEST_CASE("cuCIM resources satisfy the CCCL concepts", "[test_device_resources.cpp]")
+{
+    STATIC_REQUIRE(::cuda::mr::synchronous_resource<CudaMemoryResource>);
+    STATIC_REQUIRE(::cuda::mr::resource<CudaMemoryResource>);
+    STATIC_REQUIRE(::cuda::mr::synchronous_resource<TrackingResource>);
+    STATIC_REQUIRE(::cuda::mr::resource<TrackingResource>);
+
+    // device_accessible is what cuCIM requires of a resource, since the
+    // pointers reach CUDA kernels and __cuda_array_interface__ consumers.
+    STATIC_REQUIRE(::cuda::has_property<CudaMemoryResource, cucim::memory::device_accessible>);
+    STATIC_REQUIRE(::cuda::has_property<TrackingResource, cucim::memory::device_accessible>);
+}
+
+TEST_CASE("DeviceResources allocates from the resource it was given", "[test_device_resources.cpp]")
+{
+    SECTION("allocation and deallocation reach the supplied resource")
+    {
+        DeviceResources resources{ any_device_resource{ TrackingResource{} } };
+        auto* tracker = tracker_of(resources);
+        REQUIRE(tracker != nullptr);
+
+        constexpr std::size_t nbytes = 4096;
+        void* ptr = resources.allocate(nbytes);
+        REQUIRE(ptr != nullptr);
+        REQUIRE(tracker->allocate_calls == 1);
+        REQUIRE(tracker->last_alignment == cucim::memory::kDefaultAlignment);
+
+        resources.deallocate(ptr, nbytes);
+        REQUIRE(tracker->deallocate_calls == 1);
+        REQUIRE(tracker->outstanding.empty());
+    }
+
+    SECTION("a zero-byte request never reaches the resource")
+    {
+        // Callers ask for empty regions, and cudaMalloc(0) is not something
+        // every resource tolerates, so this is filtered out before dispatch.
+        DeviceResources resources{ any_device_resource{ TrackingResource{} } };
+        auto* tracker = tracker_of(resources);
+
+        REQUIRE(resources.allocate(0) == nullptr);
+        REQUIRE(tracker->allocate_calls == 0);
+    }
+
+    SECTION("deallocating nullptr is a no-op")
+    {
+        DeviceResources resources{ any_device_resource{ TrackingResource{} } };
+        auto* tracker = tracker_of(resources);
+
+        resources.deallocate(nullptr, 0);
+        REQUIRE(tracker->deallocate_calls == 0);
+    }
+}
+
+// Every allocation must come back to the same resource carrying the size it
+// was given out with. A pool resource needs that size to return the block to
+// the right free list, which is the reason deallocate() takes one at all.
+TEST_CASE("DeviceResources pairs allocations with sized deallocations", "[test_device_resources.cpp]")
+{
+    DeviceResources resources{ any_device_resource{ TrackingResource{} } };
+    auto* tracker = tracker_of(resources);
+    REQUIRE(tracker != nullptr);
+
+    std::vector<std::pair<void*, std::size_t>> blocks;
+    for (std::size_t bytes : { std::size_t{ 512 }, std::size_t{ 4096 }, std::size_t{ 1u << 20 } })
+    {
+        void* ptr = resources.allocate(bytes);
+        REQUIRE(ptr != nullptr);
+        blocks.emplace_back(ptr, bytes);
+    }
+    REQUIRE(tracker->allocate_calls == 3);
+
+    for (auto& [ptr, bytes] : blocks)
+    {
+        resources.deallocate(ptr, bytes);
+    }
+
+    REQUIRE(tracker->deallocate_calls == 3);
+    REQUIRE(tracker->outstanding.empty());
+    REQUIRE(tracker->size_matched_on_free);
+    REQUIRE_FALSE(tracker->saw_foreign_pointer);
+}
+
+TEST_CASE("DeviceResources propagates allocation failure as bad_alloc", "[test_device_resources.cpp]")
+{
+    DeviceResources resources{ any_device_resource{ FailingResource{} } };
+
+    // Callers such as the tile cache rely on this being an exception rather
+    // than a null return, so they can decide whether to fall back.
+    REQUIRE_THROWS_AS(resources.allocate(1024), std::bad_alloc);
+}
+
+TEST_CASE("DeviceResources is copyable and keeps its resource alive", "[test_device_resources.cpp]")
+{
+    // Cached tile values hold a copy of the handle precisely so that they can
+    // outlive the cache that allocated them, so a copy has to remain usable
+    // after the original is gone.
+    void* ptr = nullptr;
+    constexpr std::size_t nbytes = 2048;
+
+    DeviceResources copy = [&] {
+        DeviceResources original{ any_device_resource{ TrackingResource{} } };
+        ptr = original.allocate(nbytes);
+        return original;
+    }();
+
+    REQUIRE(ptr != nullptr);
+
+    // Freeing through the copy must reach the same resource the original
+    // allocated from; an owning handle is what makes this well defined. If the
+    // handle held a bare resource_ref instead, this would dangle.
+    copy.deallocate(ptr, nbytes);
+
+    auto* tracker = tracker_of(copy);
+    REQUIRE(tracker != nullptr);
+    REQUIRE(tracker->allocate_calls == 1);
+    REQUIRE(tracker->deallocate_calls == 1);
+    REQUIRE_FALSE(tracker->saw_foreign_pointer);
+    REQUIRE(tracker->outstanding.empty());
+}
+
+TEST_CASE("DeviceResources exposes a borrowable resource_ref", "[test_device_resources.cpp]")
+{
+    // This is the type cuCIM APIs should take, and it is what lets an
+    // rmm::device_async_resource_ref be passed straight through.
+    // Uses a tracking resource so the test needs no GPU.
+    DeviceResources resources{ any_device_resource{ TrackingResource{} } };
+    device_resource_ref ref = resources.resource();
+
+    void* ptr = ref.allocate(resources.stream(), 256, cucim::memory::kDefaultAlignment);
+    REQUIRE(ptr != nullptr);
+    ref.deallocate(resources.stream(), ptr, 256, cucim::memory::kDefaultAlignment);
+}


### PR DESCRIPTION
## Summary

Adopts CCCL memory resources for cuCIM's device allocations, following the RAPIDS guidance from @bdice in `#swrapids-cucim`: APIs should accept a `cuda::mr::resource_ref` so resources from either CCCL or RMM can be passed in, allocations returned to the user should come from the caller's resource, and there should be no process-wide "current" resource.

This is the foundation plus the internal allocation sites. It deliberately stops short of output allocations, for a reason detailed below that I think needs a decision before going further.

## What this adds

`cucim::memory::DeviceResources` — a non-global handle bundling a device-accessible memory resource with the stream that orders its allocations. It is passed explicitly and carried by objects that own device memory, so the resource that allocated a buffer is the one that frees it. There is no singleton and no default global resource, per the guidance that RMM's per-device resource map is being removed.

`cucim::memory::CudaMemoryResource` — the previous `cudaMalloc`/`cudaFree` behaviour expressed as a CCCL resource, so a default-constructed handle behaves exactly as cuCIM did before and only callers who supply a resource see anything different.

The public type in the API is `cuda::mr::resource_ref<cuda::mr::device_accessible>`, as recommended, which is what allows an `rmm::device_async_resource_ref` to be passed straight through.

## What this converts

The sites where core both allocates *and* frees, so the pairing is provably correct:

- **Device tile cache** (`PerProcessImageCache`). Allocates through the resource; each cached value keeps the resource it was allocated from and frees through that, so an entry evicted while a reader still holds it is still returned correctly, and a pool gets its blocks back rather than losing them to `cudaFree`.
- **`move_raster_from_host` / `move_raster_from_device`**, which gain resource-aware overloads. The existing signatures delegate to a default handle, so plugin callers are unaffected.

## What this does not convert, and why

Output allocations are the one thing the guidance calls a must ("if cuCIM returns device memory, it should definitely use the provided memory resource"). They are not converted here because cuCIM cannot currently do it correctly:

- Device memory reaching the user is often allocated **inside a plugin** — `cuslide2`'s `ifd.cpp:556,836` and `nvimgcodec_decoder.cpp:179` all call `cudaMalloc` directly.
- It is freed by **core**, in `CuImage::~CuImage` (`cuimage.cpp:285`), which calls `cudaFree` regardless of where the buffer came from.
- `ImageDataDesc` is `{container, shm_name, loader}` — there is **no field through which a resource could cross the plugin boundary**, and the boundary is a C ABI.

So converting `CuImage`'s free today would pair a plugin's raw `cudaMalloc` with a caller's pool resource, corrupting the pool. Getting output allocations onto a memory resource needs the plugin ABI to carry one first, which is a separate design change. Related: cuCIM has no `DLManagedTensor` deleter at all, so ownership of returned memory is implicit in `CuImage` rather than expressed in the DLPack container.

## Notes for reviewers

**CCCL is a new dependency.** cuCIM has no rapids-cmake or CPM, so it is added through the existing hand-rolled `FetchContent` pattern in `cpp/cmake/deps/`, pinned to `v3.4.2`. Worth noting that RMM was deliberately *removed* from cuCIM in #175/#946, so re-introducing a RAPIDS memory stack is a reversal that should be a conscious choice.

**Include order is load-bearing.** The CUDA toolkit bundles its own libcudacxx, older than `cuda::mr` for every CUDA version cuCIM supports. If the toolkit's include directory is searched first, CCCL's `<cuda/memory_resource>` still resolves but its `cuda/std/*` dependencies come from the toolkit, the version guards do not line up, and `cuda::mr` silently disappears with a confusing "`mr` in namespace `cuda` does not name a type". Both affected targets add CCCL with `target_include_directories(... BEFORE ...)`. I hit this while verifying, so it seemed worth commenting in-tree rather than leaving as a trap.

**The API in the original advice has since split.** CCCL now has both `resource_ref` (stream-ordered) and `synchronous_resource_ref`, and the async methods are spelled `allocate(stream, bytes, alignment)`. This uses the stream-ordered `resource_ref` as named in the guidance, since that is what matches RMM.

**`cuda::buffer` is not adopted here.** It is recommended for holding device memory, but is still published under `/unstable/` in the CCCL docs, and using it would change `ImageDataDesc`/DLPack layout. Left as a follow-up rather than baking an unstable API into the public container — happy to do it if you'd rather.

**Packaging is unfinished.** `device_resources.h` exposes `cuda::mr` types, so it is linked `PUBLIC` but `BUILD_INTERFACE` only. Installed consumers of that header will need CCCL exported or a `cuda-cccl` dependency added; not done here.

## Open question from the guidance

The advice explicitly left this to us: whether the memory resource should control output allocations, temporary allocations, or both, and whether to accept a second resource for temporaries. This PR uses a single resource for the internal allocations it converts. If you want separate output/temporary resources, that shape is easier to change now than later.

## Testing

`cpp/tests/test_device_resources.cpp` (new) covers:

- `CudaMemoryResource` and a user-written resource satisfy `cuda::mr::synchronous_resource`, `cuda::mr::resource` and `device_accessible` — this is the property that makes RMM/CCCL/user resources interchangeable, so it is asserted statically.
- Allocations reach the supplied resource, with the requested alignment, and every allocation is matched by a deallocation carrying the original size.
- Zero-byte allocations and `nullptr` deallocations never reach the resource.
- Allocation failure surfaces as `std::bad_alloc`, which the tile cache relies on to fall back to an uncached decode.
- A copied handle can still free memory the original allocated, which is what cached tile values depend on.

Verification I was able to do in this environment, and its limits: the new test file and both modified translation units compile clean with the build's own flags. All assertions were additionally run standalone and pass (16/16) — the checked-in Catch2 test could not be linked locally because the prebuilt `libCatch2.a` is ABI-incompatible with the local g++. **CMake configure was verified to fetch CCCL without configuring CCCL's own project, but a full cuCIM build and a GPU run were not possible here (no GPU access), so CI is the real check.**

One thing worth flagging: writing the tests caught that `any_resource` stores the resource *by value*, so wrapping a stateful allocator by value duplicates it and the handle's copy is what serves requests. That is fine for the intended usage (wrapping a reference such as `rmm::device_async_resource_ref`) but is a footgun, so it is documented on the class.

## Drive-by fixes

Two leaks on error paths in code this PR already touches: a failed `cudaMemcpy` in each of `move_raster_from_host`/`move_raster_from_device` threw without releasing the buffer it had just allocated. Also drops a dead `<memory_resource>` include in `memory_manager.cpp` that referred to `std::pmr`, which is actively confusing next to real memory-resource work.
