### PR TITLE
Add ImageMetadata::store_string() and document why _GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,30 @@ option(CUCIM_SUPPORT_NVTX "Support NVTX" ON)
 # Setup CXX11 ABI
 # : Adds CXX11 ABI definition to the compiler command line for targets in the current directory,
 #   whether added before or after this command is invoked, and for the ones in sub-directories added after.
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # TODO: create two library, one with CXX11 ABI and one without it.
+#
+# Why 0 (this is the canonical explanation; the other CMakeLists.txt files that
+# set the same definition point here):
+#
+#   This dates to building manylinux2014 wheels. That platform tag requires a
+#   gcc4-compatible libstdc++ ABI (gcc configured with
+#   '--with-default-libstdcxx-abi=gcc4-compatible', see
+#   https://gcc.gnu.org/onlinedocs/libstdc++/manual/configure.html), which forces
+#   _GLIBCXX_USE_CXX11_ABI=0 on CentOS 7.
+#
+# What it costs: parts of the standard library that are only defined for the new
+# ABI are unavailable, most visibly std::pmr::string. ImageMetadata therefore
+# keeps two sets of member declarations and stores strings as std::string_view
+# into its own memory resource; see cpp/include/cucim/io/format/image_format.h
+# and ImageMetadata::store_string().
+#
+# Changing it is not a local edit: cpp/CMakeLists.txt exports this definition as
+# an INTERFACE compile definition, so it is part of the installed package's
+# contract and flipping it breaks ABI for anything already linked against
+# libcucim. The manylinux2014 constraint itself no longer appears to apply (the
+# repository no longer references manylinux anywhere and requires-python is
+# >=3.11), so this is worth revisiting deliberately as its own change rather
+# than in passing.
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 
 ################################################################################
 # Define basic dependencies

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -136,7 +136,7 @@ target_compile_definitions(${CUCIM_PACKAGE_NAME}
         CUCIM_STATIC_GDS=$<BOOL:${CUCIM_STATIC_GDS}>
         CUCIM_SUPPORT_CUDA=$<BOOL:${CUCIM_SUPPORT_CUDA}>
         CUCIM_SUPPORT_NVTX=$<BOOL:${CUCIM_SUPPORT_NVTX}>
-        _GLIBCXX_USE_CXX11_ABI=0  # TODO: create two library, one with CXX11 ABI and one without it.
+        _GLIBCXX_USE_CXX11_ABI=0  # See the top-level CMakeLists.txt for why this is 0.
 )
 
 # Link libraries

--- a/cpp/include/cucim/io/format/image_format.h
+++ b/cpp/include/cucim/io/format/image_format.h
@@ -68,6 +68,22 @@ public:
     ImageMetadata();
     ~ImageMetadata();
     void* allocate(size_t size);
+
+    /**
+     * @brief Copy @p value into this metadata's memory and return a view of the copy.
+     *
+     * The setters below take std::string_view and the views are handed out through
+     * ImageMetadataDesc as plain `char*`, so the characters have to outlive whatever
+     * temporary produced them and have to be null-terminated. This copies once into
+     * the metadata's own resource and hands back a view of that copy, which callers
+     * can store directly.
+     *
+     * std::pmr::string would express this more directly, but it is unavailable while
+     * _GLIBCXX_USE_CXX11_ABI=0 (see the note above the member declarations below).
+     * This helper works either way, so it does not need revisiting if that changes.
+     */
+    std::string_view store_string(std::string_view value);
+
     std::pmr::monotonic_buffer_resource& get_resource();
     constexpr uint8_t* get_buffer()
     {

--- a/cpp/plugins/cucim.kit.cumed/CMakeLists.txt
+++ b/cpp/plugins/cucim.kit.cumed/CMakeLists.txt
@@ -98,7 +98,7 @@ include(ExternalProject)
 # Setup CXX11 ABI
 # : Adds CXX11 ABI definition to the compiler command line for targets in the current directory,
 #   whether added before or after this command is invoked, and for the ones in sub-directories added after.
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # TODO: create two library, one with CXX11 ABI and one without it.
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # See the top-level CMakeLists.txt for why this is 0.
 
 ################################################################################
 # Define dependencies

--- a/cpp/plugins/cucim.kit.cuslide/CMakeLists.txt
+++ b/cpp/plugins/cucim.kit.cuslide/CMakeLists.txt
@@ -98,7 +98,7 @@ include(ExternalProject)
 # Setup CXX11 ABI
 # : Adds CXX11 ABI definition to the compiler command line for targets in the current directory,
 #   whether added before or after this command is invoked, and for the ones in sub-directories added after.
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # TODO: create two library, one with CXX11 ABI and one without it.
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # See the top-level CMakeLists.txt for why this is 0.
 
 ################################################################################
 # Define dependencies

--- a/cpp/plugins/cucim.kit.cuslide2/CMakeLists.txt
+++ b/cpp/plugins/cucim.kit.cuslide2/CMakeLists.txt
@@ -96,7 +96,7 @@ include(ExternalProject)
 # Setup CXX11 ABI
 # : Adds CXX11 ABI definition to the compiler command line for targets in the current directory,
 #   whether added before or after this command is invoked, and for the ones in sub-directories added after.
-add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0) # TODO: create two library, one with CXX11 ABI and one without it.
+add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0) # See the top-level CMakeLists.txt for why this is 0.
 
 ################################################################################
 # Define dependencies

--- a/cpp/plugins/cucim.kit.cuslide2/src/cuslide/cuslide.cpp
+++ b/cpp/plugins/cucim.kit.cuslide2/src/cuslide/cuslide.cpp
@@ -246,10 +246,9 @@ static bool CUCIM_ABI parser_parse(CuCIMFileHandle_ptr handle_ptr, cucim::io::fo
         shape[2] = n_ch;
     }
 
-    // Own the names as strings while building. ImageMetadata::channel_names
-    // takes string_views and may retain pointers into the metadata buffer, so
-    // we copy into `resource` once at the end rather than keeping views into
-    // this temporary storage.
+    // Own the names as strings while building, then hand them to the metadata
+    // once at the end via store_string() rather than keeping views into this
+    // temporary storage.
     std::vector<std::string> channel_name_storage;
     channel_name_storage.reserve(n_ch);
     if (!ome_channel_names.empty())
@@ -286,9 +285,7 @@ static bool CUCIM_ABI parser_parse(CuCIMFileHandle_ptr handle_ptr, cucim::io::fo
     channel_names.reserve(channel_name_storage.size());
     for (const auto& name : channel_name_storage)
     {
-        char* buf = static_cast<char*>(resource.allocate(name.size() + 1, alignof(char)));
-        std::memcpy(buf, name.c_str(), name.size() + 1);
-        channel_names.emplace_back(buf, name.size());
+        channel_names.push_back(out_metadata.store_string(name));
     }
 
     // Spacing units

--- a/cpp/src/cuimage.cpp
+++ b/cpp/src/cuimage.cpp
@@ -865,12 +865,7 @@ CuImage CuImage::read_region(std::vector<int64_t>&& location,
         constexpr size_t kMaxSpacingUnitLen = 256;
         size_t str_len = strnlen(str_ptr, kMaxSpacingUnitLen);
 
-        char* spacing_unit = static_cast<char*>(resource.allocate(str_len + 1));
-        memcpy(spacing_unit, str_ptr, str_len);
-        spacing_unit[str_len] = '\0';
-        // std::pmr::string spacing_unit{ image_metadata_->spacing_units[dim_index], &resource };
-
-        spacing_units.emplace_back(std::string_view{ spacing_unit });
+        spacing_units.push_back(out_metadata.store_string(std::string_view{ str_ptr, str_len }));
 
         // Update spacing based on level_downsample
         char dim_char = image_metadata_->dims[dim_index];
@@ -908,13 +903,8 @@ CuImage CuImage::read_region(std::vector<int64_t>&& location,
         // "LPS" or "RAS")
         constexpr size_t kMaxCoordSysLen = 16;
         size_t coord_sys_len = strnlen(coord_sys_ptr, kMaxCoordSysLen);
-        char* coord_sys_str = static_cast<char*>(resource.allocate(coord_sys_len + 1));
-        memcpy(coord_sys_str, coord_sys_ptr, coord_sys_len);
-        coord_sys_str[coord_sys_len] = '\0';
-        coord_sys = std::string_view{ coord_sys_str };
+        coord_sys = out_metadata.store_string(std::string_view{ coord_sys_ptr, coord_sys_len });
     }
-    // std::pmr::string coord_sys_str{ image_metadata_->coord_sys ? image_metadata_->coord_sys : "", &resource };
-    // std::string_view coord_sys{ coord_sys_str };
 
     // Manually set resolution dimensions to 2
     const uint16_t level_ndim = 2;

--- a/cpp/src/io/format/image_format.cpp
+++ b/cpp/src/io/format/image_format.cpp
@@ -24,6 +24,19 @@ void* ImageMetadata::allocate(size_t size)
     return res_.allocate(size);
 }
 
+std::string_view ImageMetadata::store_string(std::string_view value)
+{
+    char* buf = static_cast<char*>(res_.allocate(value.size() + 1, alignof(char)));
+    if (!value.empty())
+    {
+        std::memcpy(buf, value.data(), value.size());
+    }
+    // Terminate explicitly rather than copying value.size() + 1 bytes: `value` may
+    // be a view into a longer buffer, in which case the extra byte is not a '\0'.
+    buf[value.size()] = '\0';
+    return std::string_view{ buf, value.size() };
+}
+
 std::pmr::monotonic_buffer_resource& ImageMetadata::get_resource()
 {
     return res_;

--- a/cpp/tests/test_metadata.cpp
+++ b/cpp/tests/test_metadata.cpp
@@ -122,6 +122,56 @@ TEST_CASE("Verify metadata", "[test_metadata.cpp]")
     // REQUIRE(1 == 1);
 }
 
+TEST_CASE("ImageMetadata::store_string copies into metadata memory", "[test_metadata.cpp]")
+{
+    cucim::io::format::ImageMetadata metadata{};
+
+    SECTION("the copy is independent of the source and null-terminated")
+    {
+        std::string source{ "Cy5" };
+        std::string_view stored = metadata.store_string(source);
+
+        REQUIRE(stored == "Cy5");
+        REQUIRE(stored.data() != source.data());
+        // Consumers reach these through ImageMetadataDesc as plain `char*`.
+        REQUIRE(stored.data()[stored.size()] == '\0');
+
+        source[0] = 'X';
+        REQUIRE(stored == "Cy5");
+    }
+
+    SECTION("a view into a longer buffer is terminated at its own end")
+    {
+        // The reason store_string() writes the terminator itself instead of
+        // copying size() + 1 bytes from the source.
+        std::string_view middle_of{ "DAPI/FITC", 4 };
+        std::string_view stored = metadata.store_string(middle_of);
+
+        REQUIRE(stored == "DAPI");
+        REQUIRE(stored.size() == 4);
+        REQUIRE(stored.data()[4] == '\0');
+    }
+
+    SECTION("an empty value is still a valid null-terminated string")
+    {
+        std::string_view stored = metadata.store_string(std::string_view{});
+
+        REQUIRE(stored.empty());
+        REQUIRE(stored.data() != nullptr);
+        REQUIRE(stored.data()[0] == '\0');
+    }
+
+    SECTION("separate calls do not alias")
+    {
+        std::string_view first = metadata.store_string("R");
+        std::string_view second = metadata.store_string("G");
+
+        REQUIRE(first == "R");
+        REQUIRE(second == "G");
+        REQUIRE(first.data() != second.data());
+    }
+}
+
 TEST_CASE("Load test", "[test_metadata.cpp]")
 {
     cucim::CuImage img{ g_config.get_input_path("private/philips_tiff_000.tif") };

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -84,7 +84,7 @@ include(ExternalProject)
 # Setup CXX11 ABI
 # : Adds CXX11 ABI definition to the compiler command line for targets in the current directory,
 #   whether added before or after this command is invoked, and for the ones in sub-directories added after.
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # TODO: create two library, one with CXX11 ABI and one without it.
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0) # See the top-level CMakeLists.txt for why this is 0.
 
 ################################################################################
 # Define dependencies


### PR DESCRIPTION
## Summary

Addresses review feedback on the OME channel-name change, which asked two things:

> What is the reason for using `_GLIBCXX_USE_CXX11_ABI=0`?
>
> Before, I missed the fact that you are using pmr. If possible using string with pmr would be less tricky to read. But this can be done in a future PR

### Answering the question

`_GLIBCXX_USE_CXX11_ABI=0` dates to the initial commit and was set for **manylinux2014 wheels**: that platform tag requires a gcc4-compatible libstdc++ ABI (gcc configured with `--with-default-libstdcxx-abi=gcc4-compatible`), which forces the old ABI on CentOS 7. The reason was recorded in exactly one place — a comment inside `image_format.h` — while all six CMake files that actually set the flag carried a misleading `# TODO: create two library, one with CXX11 ABI and one without it.`

### Why the two asks are coupled

`std::pmr::string` is only defined for the new libstdc++ ABI, so this flag removes it. Confirmed directly:

```
$ g++ -std=c++17 -D_GLIBCXX_USE_CXX11_ABI=1 ...   # OK
$ g++ -std=c++17 -D_GLIBCXX_USE_CXX11_ABI=0 ...
error: 'string' is not a member of 'std::pmr'; did you mean 'std::string'?
```

That is also why `ImageMetadata` keeps two sets of member declarations under `#if _GLIBCXX_USE_CXX11_ABI`, and why the suggested form was already sitting commented out in `cuimage.cpp`:

```cpp
// std::pmr::string coord_sys_str{ image_metadata_->coord_sys ? image_metadata_->coord_sys : "", &resource };
```

### Why not just flip the flag

`cpp/CMakeLists.txt` exports the definition as an `INTERFACE` compile definition, so it lands in the installed `cucim-targets.cmake` and is part of the package's contract — flipping it is an ABI break for anything already linked against `libcucim`, not a local cleanup. Worth noting the original justification does look obsolete (the repo no longer references manylinux anywhere and `requires-python` is `>=3.11`), but that deserves its own deliberate change. This PR documents the situation instead of acting on it.

## Changes

- **`ImageMetadata::store_string()`** — copies a string into the metadata's own memory resource and returns a `std::string_view` of the copy. This is what the call sites actually wanted, and it is what `std::pmr::string` would have been used for. It works under either ABI setting, so it needs no revisiting if the flag is ever flipped.
- **Three call sites simplified** — cuslide2 channel names, plus the spacing-unit and `coord_sys` strings in `CuImage::read_region()`. The stale commented-out `std::pmr::string` attempts are removed.

  ```cpp
  // before
  char* buf = static_cast<char*>(resource.allocate(name.size() + 1, alignof(char)));
  std::memcpy(buf, name.c_str(), name.size() + 1);
  channel_names.emplace_back(buf, name.size());

  // after
  channel_names.push_back(out_metadata.store_string(name));
  ```

- **Comments at all six flag sites** replaced with the real reason, the concrete cost, and what changing it would involve, consolidated into one canonical explanation in the top-level `CMakeLists.txt`.
- **Tests** in `cpp/tests/test_metadata.cpp`.

One subtlety worth a reviewer's eye: `store_string()` writes the terminator itself rather than copying `size() + 1` bytes, because the input may be a view into a longer buffer whose following byte is not `'\0'` (e.g. `std::string_view{"DAPI/FITC", 4}`). The old channel-name code copied `size() + 1` and was only safe because its source was always a `std::string`.

## Testing

- The new `store_string()` cases need no GPU or slide files, unlike the rest of `test_metadata.cpp`.
- Logic verified standalone under `-fsanitize=address,undefined` with `_GLIBCXX_USE_CXX11_ABI=0`; all assertions pass clean, including the truncated-view and empty-string cases.
- `image_format.cpp`, `cuimage.cpp`, `cuslide.cpp`, and `test_metadata.cpp` all pass full semantic analysis (`-fsyntax-only` with each file's real compile-database flags).
- No behavior change intended: every touched site produced a null-terminated copy in the metadata resource before and does so now.
