### PR TITLE
Build cuCIM ABI3 packages once per CUDA and architecture

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,6 +110,7 @@ jobs:
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
@@ -143,6 +144,7 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
+      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       script: ci/build_wheel.sh
       package-name: cucim
       package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -212,6 +212,7 @@ jobs:
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
+      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       script: ci/build_python.sh
   conda-python-tests:
     needs: [conda-python-build, changed-files]
@@ -277,6 +278,7 @@ jobs:
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
+      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
       script: ci/build_wheel.sh
       package-name: cucim
       package-type: python

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -41,5 +41,5 @@ RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
 
 sccache --show-adv-stats
 
-RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python cucim cucim --py "$RAPIDS_PY_VERSION" --cuda "$RAPIDS_CUDA_VERSION")"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python cucim cucim --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -83,5 +83,5 @@ ls -1 "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" | grep -vqz 'none'
 
 ../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python cucim cucim --py "$RAPIDS_PY_VERSION" --cuda "$RAPIDS_CUDA_VERSION")"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python cucim cucim --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Common setup steps shared by Python test jobs
@@ -13,7 +13,7 @@ conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libcucim cucim --cuda "$RAPIDS_CUDA_VERSION")")
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python cucim cucim --py "$RAPIDS_PY_VERSION" --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python cucim cucim --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
 
 source rapids-init-pip
 
-PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python cucim cucim --py "$RAPIDS_PY_VERSION" --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python cucim cucim --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"


### PR DESCRIPTION
**Posted by codex GPT-5.6-sol on Michael Sarahan's behalf. Readers should treat this PR description as LLM-generated.**

## Stack

- Depends on #1152, which supplies and validates the Cython cp311 ABI3 packages.
- Implements the build-matrix reduction phase of #1151.

The base branch is intentionally `codex/cython-abi3` so reviewers can evaluate this small policy change separately from the binding migration. After #1152 merges, this PR should be retargeted to `main`.

## Why

Once cuCIM produces Python 3.11 limited-ABI packages, rebuilding those native packages under every supported Python interpreter is redundant. Selecting one build per CUDA/architecture combination removes that repeated work and is the cuCIM-side prerequisite for reducing the Python variants maintained by `rapidsai/ci-imgs`.

The test matrices stay intact. Each supported Python version downloads the same stable ABI3 artifact, so the matrix continues to prove cross-version compatibility instead of rebuilding identical native packages.

## Implementation mapped to the plan

- The [branch/release Conda and wheel build filters](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/.github/workflows/build.yaml#L100-L150) and [pull-request build filters](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/.github/workflows/pr.yaml#L204-L284) implement [plan section 6](https://github.com/rapidsai/cucim/issues/1151#6-reduce-the-build-matrix-and-update-ci-imgs). They retain the minimum Python version in each exact CUDA/architecture group, which is Python 3.11 for the current support matrix.
- The Conda [producer](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/ci/build_python.sh#L37-L45) and [consumer](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/ci/test_python.sh#L14-L23) use one stable artifact name per CUDA/architecture. This connects the reduced build matrix to every Python-version test job and completes the artifact-naming part of [plan section 4](https://github.com/rapidsai/cucim/issues/1151#4-make-wheel-and-conda-outputs-abi3version-independent).
- The wheel [producer](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/ci/build_wheel.sh#L79-L87) and [consumer](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/ci/test_wheel.sh#L5-L12) use the equivalent stable name.
- The unfiltered [Conda](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/.github/workflows/pr.yaml#L217-L230) and [wheel](https://github.com/rapidsai/cucim/blob/cbed1bf167b8e3cc8ff3bc16008f767136ebb94e/.github/workflows/pr.yaml#L285-L300) test jobs preserve the cross-version validation required by [plan section 5](https://github.com/rapidsai/cucim/issues/1151#5-validate-artifacts-before-reducing-the-matrix).

The eventual `ci-imgs` cleanup is a separate-repository follow-up after these package and test jobs establish that cuCIM no longer needs Python-specific build images.

## Validation

- The complete pre-commit suite passes, including ruff, Bandit, flake8-bugbear, shellcheck, dependency-file generation, and workflow security checks.
- The producer and consumer artifact names are paired for both Conda and wheels.
- The workflow filters use the established RAPIDS ABI3 pattern already present in cuDF and cuVS.

## Current CI baseline

As of 2026-09-08, #1150 has updated `main` to `VERSION=26.12.00`, while the newest repository tag is still `v26.10.00a`. The shared version-versus-tag check therefore reports `Expected latest tag to be '26.12.00', got '26.10.00'` and skips the dependent package jobs. Neither PR in this stack changes `VERSION`; the version guard remains enabled and should be rerun after the expected 26.12 alpha tag is created. The Branch Checker failure on this PR is expected while its base is the feature branch for #1152.
