### PR TITLE
Backport "Fix stain covariance centering with CuPy CUB" (#1142)

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
+++ b/python/cucim/src/cucim/core/operations/color/stain_normalizer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -196,6 +196,11 @@ def _covariance(a):
     if fact <= 0:
         raise RuntimeError("Degrees of freedom <= 0")
 
+    # Shift before computing the mean to improve the accuracy of centering.
+    # In particular, this ensures that constant rows center to exact zeros
+    # regardless of the floating-point reduction order used by the backend.
+    offset = X[:, :1].copy()
+    X -= offset
     X -= X.mean(axis=1, keepdims=True)
     if not X.flags.f_contiguous:
         # TODO: Empirically, it is faster to use F order for .dot() call below.

--- a/python/cucim/tests/unit/core/test_stain_normalizer.py
+++ b/python/cucim/tests/unit/core/test_stain_normalizer.py
@@ -4,15 +4,21 @@
 
 import cupy as cp
 import pytest
-from packaging.version import parse
 
 from cucim.core.operations.color import (
     normalize_colors_pca,
     stain_extraction_pca,
 )
+from cucim.core.operations.color.stain_normalizer import _covariance
 
-# check CuPy instead of SciPy
-CUPY_GT_14_2 = parse(cp.__version__) >= parse("14.2.0a0")
+
+def test_covariance_constant_rows_are_exactly_zero():
+    value = cp.float32(5.4806389808654785)
+    image = cp.full((3, 8), value, dtype=cp.float32)
+
+    cp.testing.assert_array_equal(
+        _covariance(image), cp.zeros((3, 3), dtype=cp.float32)
+    )
 
 
 class TestStainExtractorMacenko:
@@ -63,10 +69,6 @@ class TestStainExtractorMacenko:
             result = stain_extraction_pca(image)
             cp.testing.assert_array_equal(result[:, 0], result[:, 1])
 
-    @pytest.mark.xfail(
-        CUPY_GT_14_2,
-        reason="Fails on CuPy 14.2.0+, see tracking issue: https://github.com/rapidsai/cucim/issues/1137",
-    )
     @pytest.mark.parametrize(
         "image, expected",
         [


### PR DESCRIPTION
This was originally submitted as a bug fix for a test fix in cuCIM 26.10 with PR #1142 . However it wound up being merged after `main` was updated to 26.12. To ensure this fix is properly included in 26.10 as intended, this backports the fix to the `release/26.10` branch. Have done this by cherry-picking the merged change f849ce31647ecdf9aa3e5cff46ba305ef3b538b5 from `main`.

Original PR body text:

> resolves #1137 by making stain normalization robust to a small change in numerical accuracy of some axis-specific `cupy.mean` operations when CUB is enabled in CuPy 14.2.
> 
> The root cause and two possible fixes are explained in this comment in that issue: https://github.com/rapidsai/cucim/issues/1137#issuecomment-5495378665
> 
> The second option of shifting each row to make the computation numerically robust while preserving the performance of float32 reduction was kept.
