### PR TITLE
Fix missing comma in `cucim.core.operations.color.__all__`

### DIFF
--- a/python/cucim/src/cucim/core/operations/color/__init__.py
+++ b/python/cucim/src/cucim/core/operations/color/__init__.py
@@ -11,7 +11,8 @@ from .stain_normalizer import (
 
 __all__ = [
     "color_jitter",
-    "rand_color_jitter" "absorbance_to_image",
+    "rand_color_jitter",
+    "absorbance_to_image",
     "image_to_absorbance",
     "stain_extraction_pca",
     "normalize_colors_pca",


### PR DESCRIPTION
## Description

`cucim.core.operations.color.__all__` is missing a comma between two entries:

```python
__all__ = [
    "color_jitter",
    "rand_color_jitter" "absorbance_to_image",   # implicit string concatenation
    ...
]
```

Python concatenates the adjacent literals into the single name `"rand_color_jitterabsorbance_to_image"`, which does not exist in the module. As a result:

- `from cucim.core.operations.color import *` raises
  `AttributeError: module 'cucim.core.operations.color' has no attribute 'rand_color_jitterabsorbance_to_image'`
- neither `rand_color_jitter` nor `absorbance_to_image` is part of the advertised public API (docs / `help()` / tooling reading `__all__`).

Explicit imports (`from cucim.core.operations.color import rand_color_jitter`) are unaffected, which is why this has gone unnoticed.

This PR splits the entry back into the two intended names. No other changes.

### Verification

I don't have a CUDA build of cuCIM set up here, so I verified the package with `cupy`/`numpy` stubbed out (only the module-level import machinery matters for this bug):

- before: `from <color pkg> import *` → `AttributeError ... 'rand_color_jitterabsorbance_to_image'`
- after: star-import succeeds and exports `absorbance_to_image, color_jitter, image_to_absorbance, normalize_colors_pca, rand_color_jitter, stain_extraction_pca`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cucim/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes. (one-line `__all__` fix; happy to add a star-import smoke test if you'd like)
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
